### PR TITLE
feat(propagator): datadog and tracecontext injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,28 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "assert_unordered"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74323b7881323eb351134e08ee5331594826789557afef8e309baf481b2264"
+dependencies = [
+ "ansi_term",
+]
 
 [[package]]
 name = "async-trait"
@@ -55,8 +73,10 @@ dependencies = [
 name = "dd-trace-propagation"
 version = "0.0.1"
 dependencies = [
+ "assert_unordered",
  "dd-trace",
  "lazy_static",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_json",
@@ -70,6 +90,12 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "futures-channel"
@@ -268,6 +294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -551,6 +587,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +616,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/dd-trace-propagation/Cargo.toml
+++ b/dd-trace-propagation/Cargo.toml
@@ -19,6 +19,10 @@ regex = { version = "1.10", default-features = false, features = ["unicode-case"
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
 
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+assert_unordered = "0.3"
+
 [features]
 default = []
 serde_config = ["serde", "serde_json"]

--- a/dd-trace-propagation/src/config.rs
+++ b/dd-trace-propagation/src/config.rs
@@ -1,6 +1,8 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use lazy_static::lazy_static;
+
 use crate::trace_propagation_style::TracePropagationStyle;
 
 #[cfg(feature = "serde_config")]
@@ -9,26 +11,43 @@ use crate::trace_propagation_style::deserialize_trace_propagation_style;
 #[cfg(feature = "serde_config")]
 use serde::Deserialize;
 
+lazy_static! {
+    pub static ref DEFAULT_PROPAGATION_STYLES: Vec<TracePropagationStyle> = vec![
+        TracePropagationStyle::Datadog,
+        TracePropagationStyle::TraceContext,
+    ];
+}
+
 #[cfg(not(feature = "serde_config"))]
 #[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::struct_excessive_bools)]
+#[derive(Default)]
 pub struct Config {
     // Trace Propagation
-    pub trace_propagation_style: Vec<TracePropagationStyle>,
-    pub trace_propagation_style_extract: Vec<TracePropagationStyle>,
+    pub trace_propagation_style: Option<Vec<TracePropagationStyle>>,
+    pub trace_propagation_style_extract: Option<Vec<TracePropagationStyle>>,
+    pub trace_propagation_style_inject: Option<Vec<TracePropagationStyle>>,
     pub trace_propagation_extract_first: bool,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            // Trace Propagation
-            trace_propagation_style: vec![
-                TracePropagationStyle::Datadog,
-                TracePropagationStyle::TraceContext,
-            ],
-            trace_propagation_style_extract: vec![],
-            trace_propagation_extract_first: false,
+impl Config {
+    pub fn get_extractors(&self) -> &Vec<TracePropagationStyle> {
+        if let Some(extractors) = &self.trace_propagation_style_extract {
+            extractors
+        } else if let Some(styles) = &self.trace_propagation_style {
+            styles
+        } else {
+            &DEFAULT_PROPAGATION_STYLES
+        }
+    }
+
+    pub fn get_injectors(&self) -> &Vec<TracePropagationStyle> {
+        if let Some(injectors) = &self.trace_propagation_style_inject {
+            injectors
+        } else if let Some(styles) = &self.trace_propagation_style {
+            styles
+        } else {
+            &DEFAULT_PROPAGATION_STYLES
         }
     }
 }
@@ -37,11 +56,14 @@ impl Default for Config {
 #[derive(Debug, PartialEq, Deserialize, Clone)]
 #[serde(default)]
 #[allow(clippy::struct_excessive_bools)]
+#[derive(Default)]
 pub struct Config {
     // Trace Propagation
     #[serde(deserialize_with = "deserialize_trace_propagation_style")]
-    pub trace_propagation_style: Vec<TracePropagationStyle>,
+    pub trace_propagation_style: Option<Vec<TracePropagationStyle>>,
     #[serde(deserialize_with = "deserialize_trace_propagation_style")]
-    pub trace_propagation_style_extract: Vec<TracePropagationStyle>,
+    pub trace_propagation_style_extract: Option<Vec<TracePropagationStyle>>,
+    #[serde(deserialize_with = "deserialize_trace_propagation_style")]
+    pub trace_propagation_style_inject: Option<Vec<TracePropagationStyle>>,
     pub trace_propagation_extract_first: bool,
 }

--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -1,14 +1,125 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::{borrow::Cow, collections::HashMap, fmt::Display, str::FromStr, vec};
+
+use dd_trace::dd_debug;
 
 use crate::{trace_propagation_style::TracePropagationStyle, tracecontext::TRACESTATE_KEY};
 
+lazy_static! {
+    static ref INVALID_ASCII_CHARACTERS_REGEX: Regex =
+        Regex::new(r"[^\x20-\x7E]+").expect("failed creating regex");
+}
+
+pub const DATADOG_PROPAGATION_TAG_PREFIX: &str = "_dd.p.";
+pub const DATADOG_SAMPLING_DECISION_KEY: &str = "_dd.p.dm";
+
 #[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct Sampling {
-    pub priority: Option<i8>,
-    pub mechanism: Option<u8>,
+    pub priority: Option<SamplingPriority>,
+    pub mechanism: Option<SamplingMechanism>,
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
+pub enum SamplingMechanism {
+    #[default]
+    Default = 0,
+    Agent = 1,
+    Rule = 3,
+    Manual = 4,
+    Appsec = 5,
+    Span = 8,
+    User = 11,
+    Dynamic = 12,
+}
+
+impl Display for SamplingMechanism {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prio = match self {
+            Self::Default => "-0",
+            Self::Agent => "-1",
+            Self::Rule => "-3",
+            Self::Manual => "-4",
+            Self::Appsec => "-5",
+            Self::Span => "-8",
+            Self::User => "-11",
+            Self::Dynamic => "-12",
+        };
+        write!(f, "{prio}")
+    }
+}
+
+impl FromStr for SamplingMechanism {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "-0" => Ok(Self::Default),
+            "-1" => Ok(Self::Agent),
+            "-3" => Ok(Self::Rule),
+            "-4" => Ok(Self::Manual),
+            "-5" => Ok(Self::Appsec),
+            "-8" => Ok(Self::Span),
+            "-11" => Ok(Self::User),
+            "-12" => Ok(Self::Dynamic),
+            _ => Err(format!("Unknown Sampling mechanism: {s}")),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
+pub enum SamplingPriority {
+    UserReject = -1,
+    AutoReject = 0,
+
+    #[default]
+    AutoKeep = 1,
+    UserKeep = 2,
+}
+
+impl SamplingPriority {
+    pub fn is_keep(&self) -> bool {
+        *self == Self::AutoKeep || *self == Self::UserKeep
+    }
+
+    pub fn from_flag(flag: i8) -> Self {
+        match flag {
+            -1 => Self::UserReject,
+            0 => Self::AutoReject,
+            1 => Self::AutoKeep,
+            2 => Self::UserKeep,
+            _ => Self::default(),
+        }
+    }
+}
+
+impl Display for SamplingPriority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prio = match self {
+            Self::UserReject => "-1",
+            Self::AutoReject => "0",
+            Self::AutoKeep => "1",
+            Self::UserKeep => "2",
+        };
+        write!(f, "{prio}")
+    }
+}
+
+impl FromStr for SamplingPriority {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "-1" => Ok(Self::UserReject),
+            "0" => Ok(Self::AutoReject),
+            "1" => Ok(Self::AutoKeep),
+            "2" => Ok(Self::UserKeep),
+            _ => Err(format!("Unknown Sampling priority: {s}")),
+        }
+    }
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
@@ -26,7 +137,7 @@ impl SpanLink {
         let flags = context
             .sampling
             .and_then(|sampling| sampling.priority)
-            .map(|priority| u32::from(priority > 0));
+            .map(|priority| u32::from(priority.is_keep()));
 
         let tracestate: Option<String> = match style {
             TracePropagationStyle::TraceContext => context.tags.get(TRACESTATE_KEY).cloned(),
@@ -58,6 +169,116 @@ pub struct SpanContext {
     pub origin: Option<String>,
     pub tags: HashMap<String, String>,
     pub links: Vec<SpanLink>,
+    pub is_remote: bool,
+    pub tracestate: Option<Tracestate>,
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct Traceparent {
+    pub sampling_priority: SamplingPriority,
+    pub trace_id: u128,
+    pub span_id: u64,
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct Tracestate {
+    pub sampling: Option<Sampling>,
+    pub origin: Option<String>,
+    pub lower_order_trace_id: Option<String>,
+    pub propagation_tags: Option<HashMap<String, String>>,
+    pub additional_values: Option<Vec<String>>,
+}
+
+impl FromStr for Tracestate {
+    type Err = String;
+    fn from_str(tracestate: &str) -> Result<Self, Self::Err> {
+        let ts_v = tracestate.split(',').map(str::trim);
+        let ts = ts_v.clone().collect::<Vec<&str>>().join(",");
+
+        if INVALID_ASCII_CHARACTERS_REGEX.is_match(&ts) {
+            dd_debug!("Received invalid tracestate header {tracestate}");
+            return Err(String::from("Invalid tracestate"));
+        }
+
+        let mut dd: Option<HashMap<String, String>> = None;
+        let mut additional_values = vec![];
+        for v in ts_v {
+            if let Some(stripped) = v.strip_prefix("dd=") {
+                dd = Some(
+                    stripped
+                        .split(';')
+                        .filter_map(|item| {
+                            let mut parts = item.splitn(2, ':');
+                            Some((parts.next()?.to_string(), decode_tag_value(parts.next()?)))
+                        })
+                        .collect(),
+                );
+            } else if !v.is_empty() {
+                additional_values.push(v.to_string());
+            }
+        }
+
+        let mut tracestate = Tracestate {
+            sampling: None,
+            origin: None,
+            lower_order_trace_id: None,
+            propagation_tags: None,
+            additional_values: None,
+        };
+
+        // the original order must be maintained
+        if !additional_values.is_empty() {
+            tracestate.additional_values = Some(additional_values);
+        }
+
+        let propagation_tags = if let Some(dd) = dd {
+            let mut tags = HashMap::new();
+            let mut priority = None;
+            let mut mechanism = None;
+
+            for (k, v) in dd {
+                match k.as_str() {
+                    "s" => {
+                        if let Ok(p_sp) = SamplingPriority::from_str(&v) {
+                            priority = Some(p_sp);
+                        }
+                    }
+                    "o" => tracestate.origin = Some(decode_tag_value(&v)),
+                    "p" => tracestate.lower_order_trace_id = Some(v.to_string()),
+                    "t.dm" => {
+                        if let Ok(p_sm) = SamplingMechanism::from_str(&v) {
+                            mechanism = Some(p_sm);
+                        }
+                        tags.insert(k, v);
+                    }
+                    _ => {
+                        tags.insert(k, v);
+                    }
+                }
+            }
+
+            tracestate.sampling = Some(Sampling {
+                priority,
+                mechanism,
+            });
+
+            Some(tags)
+        } else {
+            None
+        };
+
+        tracestate.propagation_tags = propagation_tags;
+
+        Ok(tracestate)
+    }
+}
+
+fn decode_tag_value(value: &str) -> String {
+    value.replace('~', "=")
+}
+
+pub fn encode_tag_value(value: Cow<'_, str>) -> String {
+    value.replace('=', "~")
 }
 
 pub fn split_trace_id(trace_id: u128) -> (Option<u64>, u64) {

--- a/dd-trace-propagation/src/error.rs
+++ b/dd-trace-propagation/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[derive(Error, Debug, Copy, Clone)]
 #[error("Cannot {} from {}, {}", operation, message, propagator_name)]
 pub struct Error {
-    message: &'static str,
+    pub message: &'static str,
     // which propagator this error comes from
     propagator_name: &'static str,
     // what operation was attempted
@@ -26,7 +26,6 @@ impl Error {
 
     /// Error when injecting a value into a carrier
     #[allow(clippy::must_use_candidate)]
-    #[allow(dead_code)]
     pub fn inject(message: &'static str, propagator_name: &'static str) -> Self {
         Self {
             message,


### PR DESCRIPTION
# What does this PR do?

- Adds the injection capability to `datadog` and `tracecontext` propagation styles.
- Modifies `tracecontext` extraction to store the parsed `tracestate` in `SpanContext` to use it in the injection phase.
- Changes some plain literals to enums: `SamplingPriority` and `SamplingMechanism`
- Includes two new `SpanContext` fields:
  - `is_remote`: used to determine the `p` (aka  `_dd.parent_id`) `tracestate` part
  - `tracestate`: contains the parsed Tracestate extracted from the headers if any

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

[APMSP-1833]

[APMSP-1833]: https://datadoghq.atlassian.net/browse/APMSP-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ