### PR TITLE
fix(propagation): add missing extracted tags

### DIFF
--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -233,7 +233,7 @@ impl DatadogSpanProcessor {
 
         if let Some(DatadogExtractData {
             links,
-            propagation_tags,
+            internal_tags,
             origin,
             sampling,
         }) = parent_ctx.get::<DatadogExtractData>().cloned()
@@ -268,7 +268,7 @@ impl DatadogSpanProcessor {
             return TracePropagationData {
                 origin,
                 sampling_decision,
-                tags: Some(propagation_tags),
+                tags: Some(internal_tags),
             };
         }
 

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -22,7 +22,7 @@ const TRACE_FLAG_DEFERRED: opentelemetry::TraceFlags = opentelemetry::TraceFlags
 pub struct DatadogExtractData {
     pub links: Vec<SpanLink>,
     pub origin: Option<String>,
-    pub propagation_tags: HashMap<String, String>,
+    pub internal_tags: HashMap<String, String>,
     pub sampling: Option<Sampling>,
 }
 
@@ -36,7 +36,7 @@ impl DatadogExtractData {
             ..
         }: SpanContext,
     ) -> Self {
-        let propagation_tags = tags
+        let internal_tags = tags
             .iter()
             .filter_map(|tag| {
                 if tag.0.starts_with("_dd.") {
@@ -50,7 +50,7 @@ impl DatadogExtractData {
         DatadogExtractData {
             links,
             origin,
-            propagation_tags,
+            internal_tags,
             sampling,
         }
     }
@@ -484,9 +484,9 @@ pub mod tests {
 
         let extract_data = context.get::<DatadogExtractData>().unwrap();
 
-        assert!(extract_data.propagation_tags.contains_key("_dd.parent_id"));
-        assert!(extract_data.propagation_tags.contains_key("_dd.p.dm"));
-        assert!(!extract_data.propagation_tags.contains_key("tracestate"));
+        assert!(extract_data.internal_tags.contains_key("_dd.parent_id"));
+        assert!(extract_data.internal_tags.contains_key("_dd.p.dm"));
+        assert!(!extract_data.internal_tags.contains_key("tracestate"));
     }
 
     #[test]

--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -367,7 +367,7 @@ mod test {
             Some(SamplingPriority::AutoKeep)
         );
         assert_eq!(context.origin, Some("synthetics".to_string()));
-        println!("{:?}", context.tags);
+
         assert_eq!(context.tags.get("_dd.p.test").unwrap(), "value");
         assert_eq!(context.tags.get("_dd.p.tid").unwrap(), "0000000000004321");
         assert_eq!(context.tags.get("_dd.p.dm").unwrap(), "-3");


### PR DESCRIPTION
# What does this PR do?

Add to the root span some tags received or generated during extraction that were lost, as in the case of `_dd.parent_id` or `_dd.propagation_error` tags.

# Additional Notes
The fix is needed to make pass some system tests like
`Test_Headers_Tracecontext::test_tracestate_w3c_p_extract`
`Test_Headers_Tracecontext::test_tracestate_w3c_p_inject`
`Test_Headers_Tracecontext::test_tracestate_w3c_p_extract_datadog_w3c`
`Test_Headers_Tracecontext::test_tracestate_w3c_p_phase_3_extract_first`

(this fix won't make them green since there is another problem with exported span name)
