### PR TITLE
fix: do not register not recording or invalid spans

### DIFF
--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -320,6 +320,10 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
         span: &mut opentelemetry_sdk::trace::Span,
         parent_ctx: &opentelemetry::Context,
     ) {
+        if !span.is_recording() || !span.span_context().is_valid() {
+            return;
+        }
+
         let trace_id = span.span_context().trace_id().to_bytes();
         let span_id = span.span_context().span_id().to_bytes();
 


### PR DESCRIPTION
# What does this PR do?

Add a check in `DatadogSpanProcessor` to skip spans that are not recording or invalid.

# Motivation

If not recording spans are registered into `TraceRegistry` there is no way to unregister them as `DatadogSpanProcessor::on_end` is never called for them.

