### PR TITLE
fix(ci): make all checks action not wait for merge queue

### DIFF
--- a/.github/workflows/all-checks.yaml
+++ b/.github/workflows/all-checks.yaml
@@ -23,4 +23,5 @@ jobs:
           max-retries: 30
           polling-interval-seconds: 30
           ignored-name-patterns: |
+            devflow/merge
             parametric.*


### PR DESCRIPTION
# What does this PR do?

Makes the all checks action not wait for the merge queue action, that waits for the all checks action, ad infinitum.

# Motivation

https://github.com/DataDog/libdatadog/pull/1102

# Additional Notes

None
