### PR TITLE
feat(sampler): propagate the agent response back to the sampler to sample by agent rates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ["1.81.0", "stable", "nightly-2024-12-16"]
+        rust_version: ["1.84.1", "stable", "nightly-2024-12-16"]
         platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           # shellcheck disable=SC2046
-          cargo clippy --locked --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.81.0 ] || [ ${{ matrix.rust_version }} = stable ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
+          cargo clippy --locked --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.84.1 ] || [ ${{ matrix.rust_version }} = stable ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
   licensecheck:
     runs-on: ubuntu-latest
     name: "Presence of licence headers"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ permissions:
 on: [push]
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.81.0
+  RUST_VERSION: 1.84.1
 
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,8 +714,8 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-pipeline"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -731,20 +731,20 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "log",
  "rmp-serde",
  "serde",
  "serde_json",
  "tinybytes",
  "tokio",
  "tokio-util",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "datadog-ddsketch"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "prost",
 ]
@@ -784,8 +784,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -793,8 +793,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "prost",
  "serde",
@@ -803,8 +803,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "bytes",
@@ -817,7 +817,6 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "hyper 1.6.0",
- "log",
  "prost",
  "rand 0.8.5",
  "rmp",
@@ -828,6 +827,7 @@ dependencies = [
  "testcontainers",
  "tinybytes",
  "tokio",
+ "tracing",
  "urlencoding",
 ]
 
@@ -867,12 +867,14 @@ dependencies = [
  "opentelemetry-semantic-conventions 0.15.0",
  "opentelemetry_sdk",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "ddcommon"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "cc",
@@ -888,18 +890,14 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
- "log",
- "memfd",
  "nix",
  "pin-project",
- "rand 0.8.5",
  "regex",
- "rmp",
- "rmp-serde",
  "rustls",
  "rustls-native-certs 0.8.1",
  "serde",
  "static_assertions",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -908,8 +906,8 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1012,8 +1010,8 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "anyhow",
  "cadence",
@@ -2041,15 +2039,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memfd"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
-dependencies = [
- "rustix",
-]
 
 [[package]]
 name = "mime"
@@ -3379,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "17.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=540ea1e63ab403774325ffadb76f870747f11f6c#540ea1e63ab403774325ffadb76f870747f11f6c"
+version = "19.0.1"
+source = "git+https://github.com/Datadog/libdatadog?rev=2a14f037b05115ddbf1376ae42b81261c10ace69#2a14f037b05115ddbf1376ae42b81261c10ace69"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.81.0"
+rust-version = "1.84.1"
 edition = "2021"
 version = "0.0.1"
 license = "Apache-2.0"
@@ -26,9 +26,9 @@ description = "Reserved future DataDog package, contact info@datadoghq.com if yo
 
 [workspace.dependencies]
 # Libdatadog dependencies - change to a stable version once we release
-data-pipeline = { git = "https://github.com/Datadog/libdatadog", rev = "540ea1e63ab403774325ffadb76f870747f11f6c" }
-datadog-trace-utils = { git = "https://github.com/Datadog/libdatadog", rev = "540ea1e63ab403774325ffadb76f870747f11f6c" }
-tinybytes = { git = "https://github.com/Datadog/libdatadog", rev = "540ea1e63ab403774325ffadb76f870747f11f6c" }
+data-pipeline = { git = "https://github.com/Datadog/libdatadog", rev = "2a14f037b05115ddbf1376ae42b81261c10ace69" }
+datadog-trace-utils = { git = "https://github.com/Datadog/libdatadog", rev = "2a14f037b05115ddbf1376ae42b81261c10ace69" }
+tinybytes = { git = "https://github.com/Datadog/libdatadog", rev = "2a14f037b05115ddbf1376ae42b81261c10ace69" }
 
 futures = "0.3.31"
 opentelemetry_sdk = { version = "0.28.0", features = [
@@ -40,6 +40,9 @@ opentelemetry = { version = "0.28.0", features = [
 opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"] }
 tokio = { version = "1.44.1" }
 rand = { version = "0.8" }
+
+serde = { version = "1.0.194" }
+serde_json = { version = "1.0.140" }
 
 [profile.dev]
 debug = 2 # full debug info

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -163,7 +163,6 @@ lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotm
 lru-cache,https://github.com/contain-rs/lru-cache,MIT OR Apache-2.0,Stepan Koltsov <stepan.koltsov@gmail.com>
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
-memfd,https://github.com/lucab/memfd-rs,MIT OR Apache-2.0,"Luca Bruno <lucab@lucabruno.net>, Simonas Kazlauskas <memfd@kazlauskas.me>"
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"

--- a/LICENSE-3rdparty.yml
+++ b/LICENSE-3rdparty.yml
@@ -4267,7 +4267,7 @@ third_party_libraries:
       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
       SOFTWARE.
 - package_name: data-pipeline
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -4476,7 +4476,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: datadog-ddsketch
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -4685,7 +4685,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: datadog-trace-normalization
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -4894,7 +4894,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: datadog-trace-protobuf
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -5103,7 +5103,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: datadog-trace-utils
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -5312,7 +5312,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: ddcommon
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -5521,7 +5521,7 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 - package_name: ddtelemetry
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -6606,7 +6606,7 @@ third_party_libraries:
 
       END OF TERMS AND CONDITIONS
 - package_name: dogstatsd-client
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:
@@ -12457,232 +12457,6 @@ third_party_libraries:
       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
       THE SOFTWARE.
-- package_name: memfd
-  package_version: 0.6.4
-  repository: https://github.com/lucab/memfd-rs
-  license: MIT OR Apache-2.0
-  licenses:
-  - license: MIT
-    text: |
-      Copyright <YEAR> <COPYRIGHT HOLDER>
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-      associated documentation files (the "Software"), to deal in the Software without restriction,
-      including without limitation the rights to use, copy, modify, merge, publish, distribute,
-      sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-      furnished to do so, subject to the following conditions:
-
-      The above copyright notice and this permission notice shall be included in all copies or
-      substantial portions of the Software.
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-      NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-      NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-      DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
-      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  - license: Apache-2.0
-    text: |2
-                                       Apache License
-                                 Version 2.0, January 2004
-                              http://www.apache.org/licenses/
-
-         TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-         1. Definitions.
-
-            "License" shall mean the terms and conditions for use, reproduction,
-            and distribution as defined by Sections 1 through 9 of this document.
-
-            "Licensor" shall mean the copyright owner or entity authorized by
-            the copyright owner that is granting the License.
-
-            "Legal Entity" shall mean the union of the acting entity and all
-            other entities that control, are controlled by, or are under common
-            control with that entity. For the purposes of this definition,
-            "control" means (i) the power, direct or indirect, to cause the
-            direction or management of such entity, whether by contract or
-            otherwise, or (ii) ownership of fifty percent (50%) or more of the
-            outstanding shares, or (iii) beneficial ownership of such entity.
-
-            "You" (or "Your") shall mean an individual or Legal Entity
-            exercising permissions granted by this License.
-
-            "Source" form shall mean the preferred form for making modifications,
-            including but not limited to software source code, documentation
-            source, and configuration files.
-
-            "Object" form shall mean any form resulting from mechanical
-            transformation or translation of a Source form, including but
-            not limited to compiled object code, generated documentation,
-            and conversions to other media types.
-
-            "Work" shall mean the work of authorship, whether in Source or
-            Object form, made available under the License, as indicated by a
-            copyright notice that is included in or attached to the work
-            (an example is provided in the Appendix below).
-
-            "Derivative Works" shall mean any work, whether in Source or Object
-            form, that is based on (or derived from) the Work and for which the
-            editorial revisions, annotations, elaborations, or other modifications
-            represent, as a whole, an original work of authorship. For the purposes
-            of this License, Derivative Works shall not include works that remain
-            separable from, or merely link (or bind by name) to the interfaces of,
-            the Work and Derivative Works thereof.
-
-            "Contribution" shall mean any work of authorship, including
-            the original version of the Work and any modifications or additions
-            to that Work or Derivative Works thereof, that is intentionally
-            submitted to Licensor for inclusion in the Work by the copyright owner
-            or by an individual or Legal Entity authorized to submit on behalf of
-            the copyright owner. For the purposes of this definition, "submitted"
-            means any form of electronic, verbal, or written communication sent
-            to the Licensor or its representatives, including but not limited to
-            communication on electronic mailing lists, source code control systems,
-            and issue tracking systems that are managed by, or on behalf of, the
-            Licensor for the purpose of discussing and improving the Work, but
-            excluding communication that is conspicuously marked or otherwise
-            designated in writing by the copyright owner as "Not a Contribution."
-
-            "Contributor" shall mean Licensor and any individual or Legal Entity
-            on behalf of whom a Contribution has been received by Licensor and
-            subsequently incorporated within the Work.
-
-         2. Grant of Copyright License. Subject to the terms and conditions of
-            this License, each Contributor hereby grants to You a perpetual,
-            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-            copyright license to reproduce, prepare Derivative Works of,
-            publicly display, publicly perform, sublicense, and distribute the
-            Work and such Derivative Works in Source or Object form.
-
-         3. Grant of Patent License. Subject to the terms and conditions of
-            this License, each Contributor hereby grants to You a perpetual,
-            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-            (except as stated in this section) patent license to make, have made,
-            use, offer to sell, sell, import, and otherwise transfer the Work,
-            where such license applies only to those patent claims licensable
-            by such Contributor that are necessarily infringed by their
-            Contribution(s) alone or by combination of their Contribution(s)
-            with the Work to which such Contribution(s) was submitted. If You
-            institute patent litigation against any entity (including a
-            cross-claim or counterclaim in a lawsuit) alleging that the Work
-            or a Contribution incorporated within the Work constitutes direct
-            or contributory patent infringement, then any patent licenses
-            granted to You under this License for that Work shall terminate
-            as of the date such litigation is filed.
-
-         4. Redistribution. You may reproduce and distribute copies of the
-            Work or Derivative Works thereof in any medium, with or without
-            modifications, and in Source or Object form, provided that You
-            meet the following conditions:
-
-            (a) You must give any other recipients of the Work or
-                Derivative Works a copy of this License; and
-
-            (b) You must cause any modified files to carry prominent notices
-                stating that You changed the files; and
-
-            (c) You must retain, in the Source form of any Derivative Works
-                that You distribute, all copyright, patent, trademark, and
-                attribution notices from the Source form of the Work,
-                excluding those notices that do not pertain to any part of
-                the Derivative Works; and
-
-            (d) If the Work includes a "NOTICE" text file as part of its
-                distribution, then any Derivative Works that You distribute must
-                include a readable copy of the attribution notices contained
-                within such NOTICE file, excluding those notices that do not
-                pertain to any part of the Derivative Works, in at least one
-                of the following places: within a NOTICE text file distributed
-                as part of the Derivative Works; within the Source form or
-                documentation, if provided along with the Derivative Works; or,
-                within a display generated by the Derivative Works, if and
-                wherever such third-party notices normally appear. The contents
-                of the NOTICE file are for informational purposes only and
-                do not modify the License. You may add Your own attribution
-                notices within Derivative Works that You distribute, alongside
-                or as an addendum to the NOTICE text from the Work, provided
-                that such additional attribution notices cannot be construed
-                as modifying the License.
-
-            You may add Your own copyright statement to Your modifications and
-            may provide additional or different license terms and conditions
-            for use, reproduction, or distribution of Your modifications, or
-            for any such Derivative Works as a whole, provided Your use,
-            reproduction, and distribution of the Work otherwise complies with
-            the conditions stated in this License.
-
-         5. Submission of Contributions. Unless You explicitly state otherwise,
-            any Contribution intentionally submitted for inclusion in the Work
-            by You to the Licensor shall be under the terms and conditions of
-            this License, without any additional terms or conditions.
-            Notwithstanding the above, nothing herein shall supersede or modify
-            the terms of any separate license agreement you may have executed
-            with Licensor regarding such Contributions.
-
-         6. Trademarks. This License does not grant permission to use the trade
-            names, trademarks, service marks, or product names of the Licensor,
-            except as required for reasonable and customary use in describing the
-            origin of the Work and reproducing the content of the NOTICE file.
-
-         7. Disclaimer of Warranty. Unless required by applicable law or
-            agreed to in writing, Licensor provides the Work (and each
-            Contributor provides its Contributions) on an "AS IS" BASIS,
-            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-            implied, including, without limitation, any warranties or conditions
-            of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-            PARTICULAR PURPOSE. You are solely responsible for determining the
-            appropriateness of using or redistributing the Work and assume any
-            risks associated with Your exercise of permissions under this License.
-
-         8. Limitation of Liability. In no event and under no legal theory,
-            whether in tort (including negligence), contract, or otherwise,
-            unless required by applicable law (such as deliberate and grossly
-            negligent acts) or agreed to in writing, shall any Contributor be
-            liable to You for damages, including any direct, indirect, special,
-            incidental, or consequential damages of any character arising as a
-            result of this License or out of the use or inability to use the
-            Work (including but not limited to damages for loss of goodwill,
-            work stoppage, computer failure or malfunction, or any and all
-            other commercial damages or losses), even if such Contributor
-            has been advised of the possibility of such damages.
-
-         9. Accepting Warranty or Additional Liability. While redistributing
-            the Work or Derivative Works thereof, You may choose to offer,
-            and charge a fee for, acceptance of support, warranty, indemnity,
-            or other liability obligations and/or rights consistent with this
-            License. However, in accepting such obligations, You may act only
-            on Your own behalf and on Your sole responsibility, not on behalf
-            of any other Contributor, and only if You agree to indemnify,
-            defend, and hold each Contributor harmless for any liability
-            incurred by, or claims asserted against, such Contributor by reason
-            of your accepting any such warranty or additional liability.
-
-         END OF TERMS AND CONDITIONS
-
-         APPENDIX: How to apply the Apache License to your work.
-
-            To apply the Apache License to your work, attach the following
-            boilerplate notice, with the fields enclosed by brackets "[]"
-            replaced with your own identifying information. (Don't include
-            the brackets!)  The text should be enclosed in the appropriate
-            comment syntax for the file format. We also recommend that a
-            file or class name and description of purpose be included on the
-            same "printed page" as the copyright notice for easier
-            identification within third-party archives.
-
-         Copyright [yyyy] [name of copyright owner]
-
-         Licensed under the Apache License, Version 2.0 (the "License");
-         you may not use this file except in compliance with the License.
-         You may obtain a copy of the License at
-
-             http://www.apache.org/licenses/LICENSE-2.0
-
-         Unless required by applicable law or agreed to in writing, software
-         distributed under the License is distributed on an "AS IS" BASIS,
-         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-         See the License for the specific language governing permissions and
-         limitations under the License.
 - package_name: mime
   package_version: 0.3.17
   repository: https://github.com/hyperium/mime
@@ -24983,7 +24757,7 @@ third_party_libraries:
 
          END OF TERMS AND CONDITIONS
 - package_name: tinybytes
-  package_version: 17.0.0
+  package_version: 19.0.1
   repository: ''
   license: Apache-2.0
   licenses:

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -63,11 +63,18 @@ fn make_tracer(
     let resource_slot = Arc::new(RwLock::new(Resource::builder_empty().build()));
     let sampler = Sampler::new(&config, resource_slot.clone(), registry.clone());
 
+    let agent_response_handler = sampler.on_agent_response();
+
     let dd_resource = create_dd_resource(resource.unwrap_or(Resource::builder().build()), &config);
     tracer_provider_builder = tracer_provider_builder.with_resource(dd_resource);
     let propagator = DatadogPropagator::new(&config, registry.clone());
 
-    let span_processor = DatadogSpanProcessor::new(config, registry.clone(), resource_slot.clone());
+    let span_processor = DatadogSpanProcessor::new(
+        config,
+        registry.clone(),
+        resource_slot.clone(),
+        Some(agent_response_handler),
+    );
     let tracer_provider = tracer_provider_builder
         .with_span_processor(span_processor)
         .with_sampler(sampler) // Use the sampler created above

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -45,6 +45,10 @@ impl Sampler {
             trace_registry,
         }
     }
+
+    pub fn on_agent_response(&self) -> Box<dyn for<'a> Fn(&'a str) + Send + Sync> {
+        self.sampler.on_agent_response()
+    }
 }
 
 impl ShouldSample for Sampler {

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use data_pipeline::trace_exporter::{
-    error::TraceExporterError, TraceExporter, TraceExporterBuilder, TraceExporterOutputFormat,
+    agent_response::AgentResponse, error::TraceExporterError, TraceExporter, TraceExporterBuilder,
+    TraceExporterOutputFormat,
 };
 use opentelemetry_sdk::{
     error::{OTelSdkError, OTelSdkResult},
@@ -19,7 +20,7 @@ use opentelemetry_sdk::{
 
 use crate::ddtrace_transform;
 
-/// A reasonnable amount of time that shouldn't impact the app while allowing
+/// A reasonable amount of time that shouldn't impact the app while allowing
 /// the leftover data to be almost always flushed
 const SPAN_EXPORTER_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
@@ -128,7 +129,11 @@ pub struct DatadogExporter {
 }
 
 impl DatadogExporter {
-    pub fn new(config: dd_trace::Config) -> Self {
+    #[allow(clippy::type_complexity)]
+    pub fn new(
+        config: dd_trace::Config,
+        agent_response_handler: Option<Box<dyn for<'a> Fn(&'a str) + Send + Sync>>,
+    ) -> Self {
         let (tx, rx) = channel(SPAN_FLUSH_THRESHOLD, MAX_BUFFERED_SPANS);
         let trace_exporter = {
             let mut builder = TraceExporterBuilder::default();
@@ -140,7 +145,9 @@ impl DatadogExporter {
                 .set_language_version(config.language_version())
                 .set_service(config.service())
                 .set_output_format(TraceExporterOutputFormat::V04)
-                .set_client_computed_top_level();
+                .set_client_computed_top_level()
+                .enable_agent_rates_payload_version();
+
             if config.trace_stats_computation_enabled() {
                 builder.enable_stats(Duration::from_secs(10));
             }
@@ -150,7 +157,13 @@ impl DatadogExporter {
             if let Some(version) = config.version() {
                 builder.set_app_version(version);
             }
-            TraceExporterWorker::spawn(config, builder, rx, Resource::builder_empty().build())
+            TraceExporterWorker::spawn(
+                config,
+                builder,
+                rx,
+                Resource::builder_empty().build(),
+                agent_response_handler,
+            )
         };
         Self { trace_exporter, tx }
     }
@@ -435,7 +448,9 @@ struct TraceExporterWorker {
     cfg: dd_trace::Config,
     trace_exporter: TraceExporter,
     rx: Receiver,
-    otel_resoure: opentelemetry_sdk::Resource,
+    otel_resource: opentelemetry_sdk::Resource,
+    #[allow(clippy::type_complexity)]
+    agent_response_handler: Option<Box<dyn for<'a> Fn(&'a str) + Send + Sync>>,
 }
 
 impl TraceExporterWorker {
@@ -445,11 +460,14 @@ impl TraceExporterWorker {
     /// * The handle is dropped
     /// * A shutdown flag is set
     /// * The thread panics
+    #[allow(clippy::type_complexity)]
     fn spawn(
         cfg: dd_trace::Config,
         builder: TraceExporterBuilder,
         rx: Receiver,
-        otel_resoure: opentelemetry_sdk::Resource,
+        otel_resource: opentelemetry_sdk::Resource,
+
+        agent_response_handler: Option<Box<dyn for<'a> Fn(&'a str) + Send + Sync>>,
     ) -> TraceExporterHandle {
         let handle = thread::spawn({
             move || {
@@ -463,7 +481,8 @@ impl TraceExporterWorker {
                     trace_exporter,
                     cfg,
                     rx,
-                    otel_resoure,
+                    otel_resource,
+                    agent_response_handler,
                 };
                 task.run()
             }
@@ -496,7 +515,7 @@ impl TraceExporterWorker {
                 TraceExporterMessage::FlushTraceChunks
                 | TraceExporterMessage::FlushTraceChunksWithTimeout => {}
                 TraceExporterMessage::SetResource { resource } => {
-                    self.otel_resoure = resource;
+                    self.otel_resource = resource;
                 }
             }
         }
@@ -511,21 +530,28 @@ impl TraceExporterWorker {
                 ddtrace_transform::otel_trace_chunk_to_dd_trace_chunk(
                     &self.cfg,
                     chunk,
-                    &self.otel_resoure,
+                    &self.otel_resource,
                 )
             })
             .collect();
         match self.trace_exporter.send_trace_chunks(trace_chunks) {
             Ok(agent_response) => {
-                self.handle_agent_reponse(agent_response);
+                self.handle_agent_response(agent_response);
                 Ok(())
             }
             Err(e) => Err(OTelSdkError::InternalFailure(e.to_string())),
         }
     }
 
-    fn handle_agent_reponse(&self, _agent_response: String) {
-        // TODO: handle agent response
+    fn handle_agent_response(&self, agent_response: AgentResponse) {
+        match agent_response {
+            AgentResponse::Unchanged => {}
+            AgentResponse::Changed { body } => {
+                if let Some(ref handler) = self.agent_response_handler {
+                    (handler)(&body);
+                }
+            }
+        }
     }
 }
 

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -302,14 +302,16 @@ impl std::fmt::Debug for DatadogSpanProcessor {
 }
 
 impl DatadogSpanProcessor {
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new(
         config: dd_trace::Config,
         registry: Arc<TraceRegistry>,
         resource: Arc<RwLock<Resource>>,
+        agent_response_handler: Option<Box<dyn for<'a> Fn(&'a str) + Send + Sync>>,
     ) -> Self {
         Self {
             registry,
-            span_exporter: DatadogExporter::new(config.clone()),
+            span_exporter: DatadogExporter::new(config.clone(), agent_response_handler),
             resource,
             config,
         }
@@ -486,7 +488,7 @@ mod tests {
         let registry = Arc::new(TraceRegistry::new());
         let resource = Arc::new(RwLock::new(Resource::builder_empty().build()));
 
-        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone());
+        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone(), None);
 
         let otel_resource = Resource::builder()
             // .with_service_name("otel-service")
@@ -515,7 +517,7 @@ mod tests {
         let registry = Arc::new(TraceRegistry::new());
         let resource = Arc::new(RwLock::new(Resource::builder_empty().build()));
 
-        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone());
+        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone(), None);
 
         let attributes = [KeyValue::new("key_schema", "value_schema")];
 
@@ -553,7 +555,7 @@ mod tests {
         let registry = Arc::new(TraceRegistry::new());
         let resource = Arc::new(RwLock::new(Resource::builder_empty().build()));
 
-        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone());
+        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone(), None);
 
         let otel_resource = Resource::builder_empty()
             .with_attribute(KeyValue::new("key1", "value1"))
@@ -581,7 +583,7 @@ mod tests {
         let registry = Arc::new(TraceRegistry::new());
         let resource = Arc::new(RwLock::new(Resource::builder_empty().build()));
 
-        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone());
+        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone(), None);
 
         let otel_resource = Resource::builder()
             .with_service_name("otel-service")
@@ -603,7 +605,7 @@ mod tests {
         let registry = Arc::new(TraceRegistry::new());
         let resource = Arc::new(RwLock::new(Resource::builder_empty().build()));
 
-        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone());
+        let mut processor = DatadogSpanProcessor::new(config, registry, resource.clone(), None);
 
         let otel_resource = Resource::builder()
             .with_service_name("otel-service")

--- a/dd-trace-propagation/Cargo.toml
+++ b/dd-trace-propagation/Cargo.toml
@@ -14,10 +14,16 @@ crate-type = ["lib"]
 [dependencies]
 dd-trace = { path = "../dd-trace" }
 lazy_static = { version = "1.5", default-features = false }
-regex = { version = "1.10", default-features = false, features = ["unicode-case"] }
-serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
-thiserror = { version = "1.0", default-features = false}
+regex = { version = "1.10", default-features = false, features = [
+    "unicode-case",
+] }
+serde = { workspace = true, default-features = false, optional = true, features = [
+    "derive",
+] }
+serde_json = { workspace = true, default-features = false, optional = true, features = [
+    "alloc",
+] }
+thiserror = { version = "1.0", default-features = false }
 
 opentelemetry = { workspace = true, optional = true }
 

--- a/dd-trace-sampling/Cargo.toml
+++ b/dd-trace-sampling/Cargo.toml
@@ -15,6 +15,8 @@ description.workspace = true
 opentelemetry = { workspace = true, features = ["trace"] }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 opentelemetry-semantic-conventions = { version = "0.15.0" }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 lru = "0.10.1"
 regex = "1.10.3"

--- a/dd-trace-sampling/src/agent_service_sampler.rs
+++ b/dd-trace-sampling/src/agent_service_sampler.rs
@@ -1,0 +1,51 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use crate::rate_sampler::RateSampler;
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct AgentRates<'a> {
+    #[serde(borrow)]
+    pub rates_by_service: Option<HashMap<&'a str, f64>>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ServicesSampler {
+    inner: Arc<RwLock<HashMap<String, RateSampler>>>,
+}
+
+impl ServicesSampler {
+    pub fn get(&self, service: &str) -> Option<RateSampler> {
+        self.inner.read().unwrap().get(service).cloned()
+    }
+
+    pub fn update_rates<I: IntoIterator<Item = (String, f64)>>(&self, rates: I) {
+        let new_rates: HashMap<_, _> = rates
+            .into_iter()
+            .map(|(s, r)| (s, RateSampler::new(r)))
+            .collect();
+        *self.inner.write().unwrap() = new_rates;
+    }
+
+    // used for testing purposes
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.read().unwrap().is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.inner.read().unwrap().len()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn contains_key(&self, service: &str) -> bool {
+        self.inner.read().unwrap().contains_key(service)
+    }
+}

--- a/dd-trace-sampling/src/lib.rs
+++ b/dd-trace-sampling/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod agent_service_sampler;
 pub(crate) mod constants;
 pub(crate) mod datadog_sampler;
 pub(crate) mod glob_matcher;

--- a/dd-trace/Cargo.toml
+++ b/dd-trace/Cargo.toml
@@ -14,12 +14,8 @@ description.workspace = true
 [dependencies]
 uuid = { version = "1.11.0", features = ["v4"] }
 anyhow = "1.0.97"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-
-[dev-dependencies]
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 [features]
 test-utils = []

--- a/dd-trace/src/configuration/configuration.rs
+++ b/dd-trace/src/configuration/configuration.rs
@@ -387,7 +387,7 @@ fn default_config() -> Config {
     Config {
         runtime_id: Config::process_runtime_id(),
         env: None,
-        // TODO(paulgdc): Default service naming detection, probably from arg0
+        // TODO(paullgdc): Default service naming detection, probably from arg0
         service: ServiceName::Default,
         version: None,
         global_tags: Vec::new(),


### PR DESCRIPTION
# What does this PR do?

This PR exposes a callback from the trace exporter into the sampler to return agent rates.

The agent rates is in a RwLock because it need to be periodically sampled.

This PR also depends on an unmerged branch of the trace exporter which needs to be updated once the linked PR is merged.
https://github.com/DataDog/libdatadog/pull/1104

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
