### PR TITLE
fix: add datadog service name during initialization

### DIFF
--- a/datadog-opentelemetry/examples/propagator/src/server.rs
+++ b/datadog-opentelemetry/examples/propagator/src/server.rs
@@ -215,6 +215,7 @@ fn init_tracer() -> SdkTracerProvider {
         SdkTracerProvider::builder()
             .with_span_processor(EnrichWithBaggageSpanProcessor)
             .with_simple_exporter(SpanExporter::default()),
+        None,
     )
 }
 

--- a/datadog-opentelemetry/examples/simple_tracing.rs
+++ b/datadog-opentelemetry/examples/simple_tracing.rs
@@ -19,6 +19,7 @@ fn main() {
     let tracer_provider = datadog_opentelemetry::init_datadog(
         dd_trace::Config::default(),
         SdkTracerProvider::builder(),
+        None,
     );
 
     foo();

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -10,7 +10,9 @@ mod trace_id;
 
 use std::sync::{Arc, RwLock};
 
+use opentelemetry::{Key, KeyValue};
 use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use sampler::Sampler;
 use span_processor::{DatadogSpanProcessor, TraceRegistry};
 use text_map_propagator::DatadogPropagator;
@@ -30,7 +32,8 @@ use text_map_propagator::DatadogPropagator;
 /// datadog_opentelemetry::init_datadog(
 ///     datadog_config,
 ///     TracerProviderBuilder::default(), // Pass any opentelemetry specific configuration here
-///                                       // .with_max_attributes_per_span(max_attributes)
+///     // .with_max_attributes_per_span(max_attributes)
+///     None,
 /// );
 /// ```
 pub fn init_datadog(
@@ -41,8 +44,9 @@ pub fn init_datadog(
     // Or maybe we need a builder API called DatadogDistribution that takes
     // all parameters and has an install method?
     tracer_provider_builder: opentelemetry_sdk::trace::TracerProviderBuilder,
+    resource: Option<Resource>,
 ) -> SdkTracerProvider {
-    let (tracer_provider, propagator) = make_tracer(config, tracer_provider_builder, None);
+    let (tracer_provider, propagator) = make_tracer(config, tracer_provider_builder, resource);
 
     opentelemetry::global::set_text_map_propagator(propagator);
     opentelemetry::global::set_tracer_provider(tracer_provider.clone());
@@ -59,10 +63,11 @@ fn make_tracer(
     let resource_slot = Arc::new(RwLock::new(Resource::builder_empty().build()));
     let sampler = Sampler::new(&config, resource_slot.clone(), registry.clone());
 
-    if let Some(resource) = resource {
-        tracer_provider_builder = tracer_provider_builder.with_resource(resource)
-    }
-
+    let dd_resource = create_dd_resource(
+        resource.unwrap_or(Resource::builder().build()),
+        config.service(),
+    );
+    tracer_provider_builder = tracer_provider_builder.with_resource(dd_resource);
     let propagator = DatadogPropagator::new(&config, registry.clone());
 
     let span_processor = DatadogSpanProcessor::new(config, registry.clone(), resource_slot.clone());
@@ -75,16 +80,37 @@ fn make_tracer(
     (tracer_provider, propagator)
 }
 
+fn create_dd_resource(resource: Resource, service_name: &str) -> Resource {
+    let otel_service_name = resource.get(&Key::from_static_str(SERVICE_NAME));
+    if !service_name.is_empty()
+        && (otel_service_name.is_none() || otel_service_name.unwrap().as_str() == "unknown_service")
+    {
+        let mut builder = opentelemetry_sdk::Resource::builder_empty();
+        if let Some(schema_url) = resource.schema_url() {
+            builder = builder.with_schema_url(
+                resource
+                    .iter()
+                    .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+                schema_url.to_string(),
+            );
+        } else {
+            builder = builder.with_attributes(
+                resource
+                    .iter()
+                    .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+            );
+        }
+
+        builder.with_service_name(service_name.to_string()).build()
+    } else {
+        resource
+    }
+}
+
 #[cfg(feature = "test-utils")]
 pub fn make_test_tracer(
     config: dd_trace::Config,
     tracer_provider_builder: opentelemetry_sdk::trace::TracerProviderBuilder,
 ) -> (SdkTracerProvider, DatadogPropagator) {
-    let resource = Resource::builder()
-        .with_attribute(opentelemetry::KeyValue::new(
-            "service.name",
-            config.service().to_string(),
-        ))
-        .build();
-    make_tracer(config, tracer_provider_builder, Some(resource))
+    make_tracer(config, tracer_provider_builder, None)
 }


### PR DESCRIPTION
I thought a bit about this, and maybe it would be best to have the `Resource` as a parameter to the function setting up the `TracerProvider`. That way all the spans will have the _correct_ service name at the time of sampling.