### PR TITLE
feat(datadog_opentelemetry): cleanup apis

### DIFF
--- a/datadog-opentelemetry/examples/propagator/src/server.rs
+++ b/datadog-opentelemetry/examples/propagator/src/server.rs
@@ -214,13 +214,13 @@ impl SpanProcessor for EnrichWithBaggageSpanProcessor {
 }
 
 fn init_tracer() -> SdkTracerProvider {
-    datadog_opentelemetry::init_datadog(
-        dd_trace::Config::builder().build(),
-        SdkTracerProvider::builder()
-            .with_span_processor(EnrichWithBaggageSpanProcessor)
-            .with_simple_exporter(SpanExporter::default()),
-        None,
-    )
+    datadog_opentelemetry::tracing()
+        .with_config(dd_trace::Config::builder().build())
+        .with_span_processor(EnrichWithBaggageSpanProcessor)
+        .with_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
+            SpanExporter::default(),
+        ))
+        .init()
 }
 
 fn init_logs() -> SdkLoggerProvider {

--- a/datadog-opentelemetry/examples/simple_tracing/src/main.rs
+++ b/datadog-opentelemetry/examples/simple_tracing/src/main.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use opentelemetry::trace::Tracer;
-use opentelemetry_sdk::trace::SdkTracerProvider;
 
 fn foo() {
     opentelemetry::global::tracer("foo").in_span("foo", |_cx| {
@@ -16,13 +15,13 @@ fn bar() {
 }
 
 fn main() {
-    let tracer_provider = datadog_opentelemetry::init_datadog(
-        dd_trace::Config::builder()
-            .set_service("simple_tracing".to_string())
-            .build(),
-        SdkTracerProvider::builder(),
-        None,
-    );
+    let tracer_provider = datadog_opentelemetry::tracing()
+        .with_config(
+            dd_trace::Config::builder()
+                .set_service("simple_tracing".to_string())
+                .build(),
+        )
+        .init();
 
     foo();
 

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -1,6 +1,58 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+//! # Datadog Opentelemetry
+//!
+//! A datadog layer of compatibility for the opentelemetry SDK
+//! 
+//! ## Usage
+//! 
+//! This is the minimal example to initialize the SDK.
+//! 
+//! This will read datadog and opentelemetry configuration from environment variables and other 
+//! available sources.
+//! And initialize and set up the tracer provider and the text map propagator globally.
+//!
+//! ```rust
+//! # fn main() {
+//! datadog_opentelemetry::tracing()
+//!    .init();
+//! # }
+//! ```
+//! 
+//! It is also possible to customize the datadog configuration passed to the tracer provider.
+//!
+//! ```rust
+//! // Custom datadog configuration
+//! datadog_opentelemetry::tracing()
+//!     .with_config(dd_trace::Config::builder()
+//!         .set_service("my_service".to_string())
+//!         .set_env("my_env".to_string())
+//!         .set_version("1.0.0".to_string())
+//!         .build()
+//!     )
+//!     .init();
+//! ```
+//!
+//! Or to pass options to the OpenTelemetry SDK TracerProviderBuilder
+//! ```rust
+//! #[derive(Debug)]
+//! struct MySpanProcessor;
+//!
+//! impl opentelemetry_sdk::trace::SpanProcessor for MySpanProcessor {
+//!     fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, cx: &opentelemetry::Context) {}
+//!     fn on_end(&self, span: opentelemetry_sdk::trace::SpanData) {}
+//!     fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult { Ok(()) }
+//!     fn shutdown_with_timeout(&self, timeout: std::time::Duration) -> opentelemetry_sdk::error::OTelSdkResult { Ok(()) }
+//!     fn set_resource(&mut self, _resource: &opentelemetry_sdk::Resource) {}
+//! }
+//!
+//! datadog_opentelemetry::tracing()
+//!     .with_max_attributes_per_span(64)
+//!     .with_span_processor(MySpanProcessor)
+//!     .init();
+//! ```
+
 mod ddtrace_transform;
 mod sampler;
 mod span_exporter;
@@ -17,40 +69,138 @@ use sampler::Sampler;
 use span_processor::{DatadogSpanProcessor, TraceRegistry};
 use text_map_propagator::DatadogPropagator;
 
-/// Initialize the Datadog OpenTelemetry exporter.
-///
-/// This function sets up the global OpenTelemetry SDK provider for compatibility with datadog.
+pub struct DatadogTracingBuilder {
+    config: Option<dd_trace::Config>,
+    resource: Option<opentelemetry_sdk::Resource>,
+    tracer_provider: opentelemetry_sdk::trace::TracerProviderBuilder,
+}
+
+impl DatadogTracingBuilder {
+    pub fn with_config(mut self, config: dd_trace::Config) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    pub fn with_resource(mut self, resource: opentelemetry_sdk::Resource) -> Self {
+        self.resource = Some(resource);
+        self
+    }
+
+    pub fn init(self) -> SdkTracerProvider {
+        let config = self
+            .config
+            .unwrap_or_else(|| dd_trace::Config::builder().build());
+        let (tracer_provider, propagator) =
+            make_tracer(config, self.tracer_provider, self.resource);
+
+        opentelemetry::global::set_text_map_propagator(propagator);
+        opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+        tracer_provider
+    }
+}
+
+impl DatadogTracingBuilder {
+    // Methods forwarded to the otel tracer provider builder
+
+    pub fn with_span_processor<T: opentelemetry_sdk::trace::SpanProcessor + 'static>(
+        mut self,
+        processor: T,
+    ) -> Self {
+        self.tracer_provider = self.tracer_provider.with_span_processor(processor);
+        self
+    }
+
+    /// Specify the number of events to be recorded per span.
+    pub fn with_max_events_per_span(mut self, max_events: u32) -> Self {
+        self.tracer_provider = self.tracer_provider.with_max_events_per_span(max_events);
+        self
+    }
+
+    /// Specify the number of attributes to be recorded per span.
+    pub fn with_max_attributes_per_span(mut self, max_attributes: u32) -> Self {
+        self.tracer_provider = self
+            .tracer_provider
+            .with_max_attributes_per_span(max_attributes);
+        self
+    }
+
+    /// Specify the number of events to be recorded per span.
+    pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
+        self.tracer_provider = self.tracer_provider.with_max_links_per_span(max_links);
+        self
+    }
+
+    /// Specify the number of attributes one event can have.
+    pub fn with_max_attributes_per_event(mut self, max_attributes: u32) -> Self {
+        self.tracer_provider = self
+            .tracer_provider
+            .with_max_attributes_per_event(max_attributes);
+        self
+    }
+
+    /// Specify the number of attributes one link can have.
+    pub fn with_max_attributes_per_link(mut self, max_attributes: u32) -> Self {
+        self.tracer_provider = self
+            .tracer_provider
+            .with_max_attributes_per_link(max_attributes);
+        self
+    }
+
+    /// Specify all limit via the span_limits
+    pub fn with_span_limits(mut self, span_limits: opentelemetry_sdk::trace::SpanLimits) -> Self {
+        self.tracer_provider = self.tracer_provider.with_span_limits(span_limits);
+        self
+    }
+}
+
+/// Initialize a new Datadog Tracing builder
 ///
 /// # Usage
+///
 /// ```rust
-/// use dd_trace::Config;
-/// use opentelemetry_sdk::trace::TracerProviderBuilder;
-///
-/// // This picks up env var configuration and other datadog configuration sources
-/// let datadog_config = Config::builder().build();
-///
-/// datadog_opentelemetry::init_datadog(
-///     datadog_config,
-///     TracerProviderBuilder::default(), // Pass any opentelemetry specific configuration here
-///     // .with_max_attributes_per_span(max_attributes)
-///     None,
-/// );
+/// // Default configuration
+/// datadog_opentelemetry::tracing()
+///     .init();
 /// ```
-pub fn init_datadog(
-    config: dd_trace::Config,
-    // TODO(paullgdc): Should we take a builder or create it ourselves?
-    // because some customer might want to set max_<things>_per_span using
-    // the builder APIs
-    // Or maybe we need a builder API called DatadogDistribution that takes
-    // all parameters and has an install method?
-    tracer_provider_builder: opentelemetry_sdk::trace::TracerProviderBuilder,
-    resource: Option<Resource>,
-) -> SdkTracerProvider {
-    let (tracer_provider, propagator) = make_tracer(config, tracer_provider_builder, resource);
-
-    opentelemetry::global::set_text_map_propagator(propagator);
-    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
-    tracer_provider
+///
+/// It is also possible to customize the datadog configuration passed to the tracer provider.
+///
+/// ```rust
+/// // Custom datadog configuration
+/// datadog_opentelemetry::tracing()
+///     .with_config(dd_trace::Config::builder()
+///         .set_service("my_service".to_string())
+///         .set_env("my_env".to_string())
+///         .set_version("1.0.0".to_string())
+///         .build()
+///     )
+///     .init();
+/// ```
+///
+/// Or to pass options to the OpenTelemetry SDK TracerProviderBuilder
+/// ```rust
+/// #[derive(Debug)]
+/// struct MySpanProcessor;
+///
+/// impl opentelemetry_sdk::trace::SpanProcessor for MySpanProcessor {
+///     fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, cx: &opentelemetry::Context) {}
+///     fn on_end(&self, span: opentelemetry_sdk::trace::SpanData) {}
+///     fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult { Ok(()) }
+///     fn shutdown_with_timeout(&self, timeout: std::time::Duration) -> opentelemetry_sdk::error::OTelSdkResult { Ok(()) }
+///     fn set_resource(&mut self, _resource: &opentelemetry_sdk::Resource) {}
+/// }
+///
+/// datadog_opentelemetry::tracing()
+///     .with_max_attributes_per_span(64)
+///     .with_span_processor(MySpanProcessor)
+///     .init();
+/// ```
+pub fn tracing() -> DatadogTracingBuilder {
+    DatadogTracingBuilder {
+        config: None,
+        tracer_provider: opentelemetry_sdk::trace::SdkTracerProvider::builder(),
+        resource: None,
+    }
 }
 
 /// Create an instance of the tracer provider


### PR DESCRIPTION
# What does this PR do?

* provide a fluent style API to provide parameters necessary for the tracer installation
* pass otel options through our own methods instead of getting a parameter
* add module doc to the crate with different usage

# Motivation

As I'm integrating the library in other people's code, I realized that I don't really like our API...
Having to pass both a `TracerProviderBuilder` and an optional resource to `init_datadog` isn't very clean, so I think I'd prefer using a fluent API instead.

# Additional Notes

Anything else we should know when reviewing?
