### PR TITLE
fix: config consistency fixes

### DIFF
--- a/datadog-opentelemetry/examples/propagator/src/server.rs
+++ b/datadog-opentelemetry/examples/propagator/src/server.rs
@@ -217,6 +217,7 @@ fn init_tracer() -> SdkTracerProvider {
     let config = dd_trace::Config::builder()
         .set_service("rust-propagator-service-example".to_string())
         .set_env("staging".to_string())
+        .set_version("0.0.42".to_string())
         .build();
 
     datadog_opentelemetry::tracing()

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -420,7 +420,7 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
         span: &mut opentelemetry_sdk::trace::Span,
         parent_ctx: &opentelemetry::Context,
     ) {
-        if !span.is_recording() || !span.span_context().is_valid() {
+        if !self.config.enabled() || !span.is_recording() || !span.span_context().is_valid() {
             return;
         }
 

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -412,6 +412,15 @@ impl DatadogSpanProcessor {
 
         trace.finished_spans
     }
+
+    fn add_config_metadata(&self, span: &mut opentelemetry_sdk::trace::Span) {
+        if let Some(env) = self.config.env() {
+            span.set_attribute(KeyValue::new("datadog.env", env.to_string()));
+        }
+        if let Some(version) = self.config.version() {
+            span.set_attribute(KeyValue::new("datadog.version", version.to_string()));
+        }
+    }
 }
 
 impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
@@ -426,6 +435,8 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
 
         let trace_id = span.span_context().trace_id().to_bytes();
         let span_id = span.span_context().span_id().to_bytes();
+
+        self.add_config_metadata(span);
 
         if parent_ctx.span().span_context().is_remote() {
             let propagation_data = self.get_remote_propagation_data(span, parent_ctx);

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -412,15 +412,6 @@ impl DatadogSpanProcessor {
 
         trace.finished_spans
     }
-
-    fn add_config_metadata(&self, span: &mut opentelemetry_sdk::trace::Span) {
-        if let Some(env) = self.config.env() {
-            span.set_attribute(KeyValue::new("datadog.env", env.to_string()));
-        }
-        if let Some(version) = self.config.version() {
-            span.set_attribute(KeyValue::new("datadog.version", version.to_string()));
-        }
-    }
 }
 
 impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
@@ -435,8 +426,6 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
 
         let trace_id = span.span_context().trace_id().to_bytes();
         let span_id = span.span_context().span_id().to_bytes();
-
-        self.add_config_metadata(span);
 
         if parent_ctx.span().span_context().is_remote() {
             let propagation_data = self.get_remote_propagation_data(span, parent_ctx);

--- a/dd-trace-propagation/src/error.rs
+++ b/dd-trace-propagation/src/error.rs
@@ -11,6 +11,8 @@ pub struct Error {
     propagator_name: &'static str,
     // what operation was attempted
     operation: &'static str,
+    // flag to indicate if error should be sent via telemetry
+    pub send_telemetry: bool,
 }
 
 impl Error {
@@ -21,6 +23,17 @@ impl Error {
             message,
             propagator_name,
             operation: "extract",
+            send_telemetry: true,
+        }
+    }
+
+    /// Error when extracting a value from a carrier with telemetry off
+    pub fn extract_silent(message: &'static str, propagator_name: &'static str) -> Self {
+        Self {
+            message,
+            propagator_name,
+            operation: "extract",
+            send_telemetry: false,
         }
     }
 
@@ -31,6 +44,7 @@ impl Error {
             message,
             propagator_name,
             operation: "inject",
+            send_telemetry: true,
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

- Ignore spans if `config.enabled()` is false
- Add `env` and `version` meta attributes when exporting after service has been resolved
- Mute one error sent via telemetry when `x-datadog-trace-id` header is not found (this is not related with the fix I can move it to another PR but I have noticed it when testing the other cases)

# Motivation

test_config_consistency::Test_Config_TraceEnabled
test_config_consistency::Test_Config_UnifiedServiceTagging

