### PR TITLE
feat(dd-trace-propagation): export `datadog` mod

### DIFF
--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -21,13 +21,13 @@ use dd_trace::{
 };
 
 // Datadog Keys
-const DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY: &str = "_dd.p.tid";
-const DATADOG_TRACE_ID_KEY: &str = "x-datadog-trace-id";
-const DATADOG_ORIGIN_KEY: &str = "x-datadog-origin";
-const DATADOG_PARENT_ID_KEY: &str = "x-datadog-parent-id";
-const DATADOG_SAMPLING_PRIORITY_KEY: &str = "x-datadog-sampling-priority";
-const DATADOG_TAGS_KEY: &str = "x-datadog-tags";
-const DATADOG_PROPAGATION_ERROR_KEY: &str = "_dd.propagation_error";
+pub const DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY: &str = "_dd.p.tid";
+pub const DATADOG_TRACE_ID_KEY: &str = "x-datadog-trace-id";
+pub const DATADOG_ORIGIN_KEY: &str = "x-datadog-origin";
+pub const DATADOG_PARENT_ID_KEY: &str = "x-datadog-parent-id";
+pub const DATADOG_SAMPLING_PRIORITY_KEY: &str = "x-datadog-sampling-priority";
+pub const DATADOG_TAGS_KEY: &str = "x-datadog-tags";
+pub const DATADOG_PROPAGATION_ERROR_KEY: &str = "_dd.propagation_error";
 pub const DATADOG_LAST_PARENT_ID_KEY: &str = "_dd.parent_id";
 
 // TODO: get max_length from config: DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH

--- a/dd-trace-propagation/src/lib.rs
+++ b/dd-trace-propagation/src/lib.rs
@@ -11,7 +11,7 @@ use tracecontext::TRACESTATE_KEY;
 pub mod carrier;
 pub mod config;
 pub mod context;
-mod datadog;
+pub mod datadog;
 mod error;
 pub mod trace_propagation_style;
 pub mod tracecontext;


### PR DESCRIPTION
# What does this PR do?

Exports the `datadog` module and some constants

# Motivation

Need to replace the code in the Datadog Lambda Extension (precursor of this module) to use this crate

# Additional Notes

n/a
