### PR TITLE
fix(telemetry): mute telemetry error and propagation debug logs

### DIFF
--- a/datadog-opentelemetry/examples/propagator/src/server.rs
+++ b/datadog-opentelemetry/examples/propagator/src/server.rs
@@ -217,6 +217,7 @@ fn init_tracer() -> SdkTracerProvider {
     let config = dd_trace::Config::builder()
         .set_service("rust-propagator-service-example".to_string())
         .set_env("staging".to_string())
+        .set_log_level_filter(dd_trace::log::LevelFilter::Debug)
         .build();
 
     datadog_opentelemetry::tracing()

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -108,7 +108,12 @@ impl DatadogPropagator {
 
         // otel tracestate only contains 'additional_values'
         // TODO: optimize Tracestate conversion
-        let tracestate = Tracestate::from_str(&otel_span_context.trace_state().header()).ok();
+        let otel_tracestate = otel_span_context.trace_state();
+        let tracestate = if *otel_tracestate == opentelemetry::trace::TraceState::NONE {
+            None
+        } else {
+            Tracestate::from_str(&otel_tracestate.header()).ok()
+        };
 
         let mut tags = HashMap::new();
         if let Some(propagation_tags) = propagation_data.tags {

--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -160,7 +160,7 @@ impl FromStr for Tracestate {
             let value = parts.next().unwrap_or_default();
 
             if !Tracestate::valid_key(key) || value.is_empty() || !Tracestate::valid_value(value) {
-                dd_debug!("Received invalid tracestate key or header value: {v}");
+                dd_debug!("Tracestate: invalid key or header value: {v}");
                 return Err(String::from("Invalid tracestate"));
             }
 

--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -145,10 +145,6 @@ impl Tracestate {
 impl FromStr for Tracestate {
     type Err = String;
     fn from_str(tracestate: &str) -> Result<Self, Self::Err> {
-        if tracestate.is_empty() {
-            return Err(String::from("Empty tracestate"));
-        }
-
         let ts_v = tracestate.split(',');
 
         let mut dd: Option<HashMap<String, String>> = None;

--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -145,6 +145,10 @@ impl Tracestate {
 impl FromStr for Tracestate {
     type Err = String;
     fn from_str(tracestate: &str) -> Result<Self, Self::Err> {
+        if tracestate.is_empty() {
+            return Err(String::from("Empty tracestate"));
+        }
+
         let ts_v = tracestate.split(',');
 
         let mut dd: Option<HashMap<String, String>> = None;
@@ -156,7 +160,7 @@ impl FromStr for Tracestate {
             let value = parts.next().unwrap_or_default();
 
             if !Tracestate::valid_key(key) || value.is_empty() || !Tracestate::valid_value(value) {
-                dd_debug!("Received invalid tracestate header value: {v}");
+                dd_debug!("Received invalid tracestate key or header value: {v}");
                 return Err(String::from("Invalid tracestate"));
             }
 

--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -157,6 +157,8 @@ fn validate_tag_value(value: &str) -> bool {
 }
 
 pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
+    carrier.get(DATADOG_TRACE_ID_KEY)?;
+
     let lower_trace_id = match extract_trace_id(carrier) {
         Ok(trace_id) => trace_id,
         Err(e) => {
@@ -224,7 +226,7 @@ fn extract_trace_id(carrier: &dyn Extractor) -> Result<u64, Error> {
 fn extract_parent_id(carrier: &dyn Extractor) -> Result<u64, Error> {
     carrier
         .get(DATADOG_PARENT_ID_KEY)
-        .ok_or(Error::extract("`trace_id` not found", "datadog"))?
+        .ok_or(Error::extract("`parent_id` not found", "datadog"))?
         .parse::<u64>()
         .map_err(|_| Error::extract("Failed to decode `parent_id`", "datadog"))
 }

--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -17,6 +17,7 @@ use crate::{
 use dd_trace::{
     constants::SAMPLING_DECISION_MAKER_TAG_KEY,
     dd_error, dd_warn,
+    log::Level,
     sampling::{mechanism, priority, SamplingMechanism, SamplingPriority},
 };
 
@@ -157,12 +158,12 @@ fn validate_tag_value(value: &str) -> bool {
 }
 
 pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
-    carrier.get(DATADOG_TRACE_ID_KEY)?;
-
     let lower_trace_id = match extract_trace_id(carrier) {
         Ok(trace_id) => trace_id,
         Err(e) => {
-            dd_error!("Propagator (datadog): Error extracting trace_id {e}");
+            if let Level::Error = e.log_level {
+                dd_error!("Propagator (datadog): Error extracting trace_id {e}");
+            }
             return None;
         }
     };
@@ -212,7 +213,11 @@ pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
 fn extract_trace_id(carrier: &dyn Extractor) -> Result<u64, Error> {
     let trace_id = carrier
         .get(DATADOG_TRACE_ID_KEY)
-        .ok_or(Error::extract("`trace_id` not found", "datadog"))?;
+        .ok_or(Error::extract_with_level(
+            "`trace_id` not found",
+            "datadog",
+            Level::Debug,
+        ))?;
 
     if INVALID_SEGMENT_REGEX.is_match(trace_id) {
         return Err(Error::extract("Invalid `trace_id` found", "datadog"));

--- a/dd-trace-propagation/src/error.rs
+++ b/dd-trace-propagation/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use dd_trace::log::Level;
 use thiserror::Error;
 
 #[derive(Error, Debug, Copy, Clone)]
@@ -11,6 +12,8 @@ pub struct Error {
     propagator_name: &'static str,
     // what operation was attempted
     operation: &'static str,
+    // error log level
+    pub log_level: Level,
 }
 
 impl Error {
@@ -21,6 +24,20 @@ impl Error {
             message,
             propagator_name,
             operation: "extract",
+            log_level: Level::Error,
+        }
+    }
+
+    pub fn extract_with_level(
+        message: &'static str,
+        propagator_name: &'static str,
+        log_level: Level,
+    ) -> Self {
+        Self {
+            message,
+            propagator_name,
+            operation: "extract",
+            log_level,
         }
     }
 
@@ -31,6 +48,7 @@ impl Error {
             message,
             propagator_name,
             operation: "inject",
+            log_level: Level::Error,
         }
     }
 }

--- a/dd-trace-propagation/src/error.rs
+++ b/dd-trace-propagation/src/error.rs
@@ -1,7 +1,6 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use dd_trace::log::Level;
 use thiserror::Error;
 
 #[derive(Error, Debug, Copy, Clone)]
@@ -12,8 +11,6 @@ pub struct Error {
     propagator_name: &'static str,
     // what operation was attempted
     operation: &'static str,
-    // error log level
-    pub log_level: Level,
 }
 
 impl Error {
@@ -24,20 +21,6 @@ impl Error {
             message,
             propagator_name,
             operation: "extract",
-            log_level: Level::Error,
-        }
-    }
-
-    pub fn extract_with_level(
-        message: &'static str,
-        propagator_name: &'static str,
-        log_level: Level,
-    ) -> Self {
-        Self {
-            message,
-            propagator_name,
-            operation: "extract",
-            log_level,
         }
     }
 
@@ -48,7 +31,6 @@ impl Error {
             message,
             propagator_name,
             operation: "inject",
-            log_level: Level::Error,
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

- Mute telemetry error when `x-datadog-trace-id` header is not present
- Add debug logs to propagation modules

# Motivation

Reduce telemetry noise and increase propagation info in case of debugging.

