### PR TITLE
feat(config): remove mutex around config and instead use arc swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ name = "dd-trace"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "base64 0.21.7",
  "ddtelemetry",
  "http-body-util",

--- a/datadog-opentelemetry/tests/mod.rs
+++ b/datadog-opentelemetry/tests/mod.rs
@@ -7,7 +7,8 @@ mod datadog_test_agent {
         collections::{HashMap, HashSet},
         fmt,
         hash::{Hash, RandomState},
-        sync::{Arc, Mutex},
+        ops::Deref,
+        sync::Arc,
     };
 
     use datadog_opentelemetry::make_test_tracer;
@@ -55,7 +56,7 @@ mod datadog_test_agent {
 
         let mut config_builder = dd_trace::Config::builder();
         config_builder.set_trace_agent_url(test_agent.get_base_uri().await.to_string().into());
-        let config = Arc::new(Mutex::new(config_builder.build()));
+        let config = Arc::new(config_builder.build());
 
         let tracer_provider = make_test_tracer(
             config,
@@ -94,7 +95,7 @@ mod datadog_test_agent {
 
         let mut config_builder = dd_trace::Config::builder();
         config_builder.set_trace_agent_url(test_agent.get_base_uri().await.to_string().into());
-        let config = Arc::new(Mutex::new(config_builder.build()));
+        let config = Arc::new(config_builder.build());
 
         let (tracer_provider, propagator) = make_test_tracer(
             config,
@@ -180,7 +181,7 @@ mod datadog_test_agent {
             ..SamplingRuleConfig::default()
         }]);
         config_builder.set_trace_propagation_style(vec![TracePropagationStyle::TraceContext]);
-        let config = Arc::new(Mutex::new(config_builder.build()));
+        let config = Arc::new(config_builder.build());
 
         let (tracer_provider, propagator) = make_test_tracer(
             config,
@@ -268,7 +269,7 @@ mod datadog_test_agent {
             }])
             .set_log_level_filter(dd_trace::log::LevelFilter::Debug)
             .build();
-        let config = Arc::new(Mutex::new(config));
+        let config = Arc::new(config);
 
         let (tracer_provider, _propagator) = make_test_tracer(
             config.clone(),
@@ -281,7 +282,7 @@ mod datadog_test_agent {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         assert_eq!(
-            config.lock().unwrap().trace_sampling_rules(),
+            config.trace_sampling_rules().deref(),
             vec![dd_trace::SamplingRuleConfig {
                 resource: Some("test-span".into()),
                 sample_rate: 1.0,

--- a/dd-trace/Cargo.toml
+++ b/dd-trace/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] }
 base64 = "0.21"
 sha2 = "0.10"
 uuid = { version = "1.11.0", features = ["v4"] }
+arc-swap = "1.7.1"
 
 # Libdatadog dependencies
 ddtelemetry = { workspace = true }

--- a/dd-trace/src/configuration/mod.rs
+++ b/dd-trace/src/configuration/mod.rs
@@ -7,6 +7,6 @@ pub mod remote_config;
 mod sources;
 
 pub use configuration::{
-    Config, ConfigBuilder, ConfigItem, ConfigSource, RemoteConfigUpdate, SamplingRuleConfig,
+    Config, ConfigBuilder, ConfigItem, RemoteConfigUpdate, SamplingRuleConfig,
     TracePropagationStyle,
 };


### PR DESCRIPTION
# What does this PR do?

* Remove the mutex around the config we pass around and instead use ArcSwap to swap the remote config
* Unify the config origin struct between config and source files

# Motivation

We are currently passing an Arc<Mutex<Config>> around, and because the config itself contains an Arc<Mutex<Callbacks>> That seems like a recipe for a deadlock if you try to modify the config while inside the callback which you accessed by locking the config lock.

The Mutex is here so that the config can be updated for RC, but we can instead wrap it in an ArcSwap, which is lockless. Since the configs are written to by a single entity, and we don't need a linear view of it that will be fine, and probably more performant on concurrent access
