### PR TITLE
fix(remote_config): add lib_config parent ||

### DIFF
--- a/datadog-opentelemetry/tests/mod.rs
+++ b/datadog-opentelemetry/tests/mod.rs
@@ -247,13 +247,15 @@ mod datadog_test_agent {
                 r##"{
             "path": "datadog/2/APM_TRACING/1234/config",
             "msg": {
-                "tracing_sampling_rules": [
-                    {
-                        "resource": "test-span",
-                        "sample_rate": 1.0,
-                        "provenance": "customer"
-                    }
-                ]
+                "lib_config": {
+                    "tracing_sampling_rules": [
+                        {
+                            "resource": "test-span",
+                            "sample_rate": 1.0,
+                            "provenance": "customer"
+                        }
+                    ]
+                }
             }
         }"##,
                 None,


### PR DESCRIPTION
# What does this PR do?

tracing_sampling_rules is a child of lib_config in the remote configuration payload, this fixes the parsing.

Continuation of #68 
