### PR TITLE
fix(system-test): use ST main branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@65bd7a6cd426f30bcabab6616fecdac7a882654e  # main
     secrets: inherit
     with:
       library: rust

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,4 +133,3 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      _experimental_runs_on: '{ "group": "Large Runner Shared Public" }'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,12 +126,11 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@a675fcc0b1d582485c57c4ab0c30cf2f9eb217ea # igor/rust-the-germ
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
     secrets: inherit
     with:
       library: rust
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: igor/rust-the-germ
       _experimental_runs_on: '{ "group": "Large Runner Shared Public" }'


### PR DESCRIPTION
# What does this PR do?

- Changes parametric job to use ST main branch
- Removes `_experimental_runs_on` parameter (`dd-trace-rs` is on the `APM Larger Runners` group now)
