### PR TITLE
feat(trace exporter): improve logging in the trace exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 [[package]]
 name = "data-pipeline"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "datadog-ddsketch"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "prost",
 ]
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-normalization"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-protobuf"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "prost",
  "serde",
@@ -758,7 +758,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-utils"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "bytes",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "ddcommon"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "cc",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "ddtelemetry"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd-client"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "anyhow",
  "cadence",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "tinybytes"
 version = "20.0.0"
-source = "git+https://github.com/Datadog/libdatadog?rev=0f88ff8acf5aff557fa9b786383b62b3f51d17a0#0f88ff8acf5aff557fa9b786383b62b3f51d17a0"
+source = "git+https://github.com/Datadog/libdatadog?rev=64985ae2c4d33c07bb3f36be4ea0d3073ca0d461#64985ae2c4d33c07bb3f36be4ea0d3073ca0d461"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ description = "Reserved future DataDog package, contact info@datadoghq.com if yo
 
 [workspace.dependencies]
 # Libdatadog dependencies - change to a stable version once we release
-data-pipeline = { git = "https://github.com/Datadog/libdatadog", rev = "0f88ff8acf5aff557fa9b786383b62b3f51d17a0", default-features = false }
-datadog-trace-utils = { git = "https://github.com/Datadog/libdatadog", rev = "0f88ff8acf5aff557fa9b786383b62b3f51d17a0", default-features = false }
-ddtelemetry = { git = "https://github.com/Datadog/libdatadog", rev = "0f88ff8acf5aff557fa9b786383b62b3f51d17a0", default-features = false }
-tinybytes = { git = "https://github.com/Datadog/libdatadog", rev = "0f88ff8acf5aff557fa9b786383b62b3f51d17a0", default-features = false }
+data-pipeline = { git = "https://github.com/Datadog/libdatadog", rev = "64985ae2c4d33c07bb3f36be4ea0d3073ca0d461", default-features = false }
+datadog-trace-utils = { git = "https://github.com/Datadog/libdatadog", rev = "64985ae2c4d33c07bb3f36be4ea0d3073ca0d461", default-features = false }
+ddtelemetry = { git = "https://github.com/Datadog/libdatadog", rev = "64985ae2c4d33c07bb3f36be4ea0d3073ca0d461", default-features = false }
+tinybytes = { git = "https://github.com/Datadog/libdatadog", rev = "64985ae2c4d33c07bb3f36be4ea0d3073ca0d461", default-features = false }
 
 futures = "0.3.31"
 opentelemetry_sdk = { version = "0.30.0", features = [

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use data_pipeline::trace_exporter::{
-    agent_response::AgentResponse, error::TraceExporterError, TraceExporter, TraceExporterBuilder,
-    TraceExporterOutputFormat,
+    agent_response::AgentResponse, error as trace_exporter_error, error::TraceExporterError,
+    TraceExporter, TraceExporterBuilder, TraceExporterOutputFormat,
 };
 use datadog_opentelemetry_mappings::CachedConfig;
 use opentelemetry_sdk::{
@@ -300,13 +300,32 @@ impl DatadogExporter {
             .take()
             .ok_or(OTelSdkError::AlreadyShutdown)?
             .join()
-            .map_err(|_| {
-                OTelSdkError::InternalFailure("DatadogExporter.join: worker panicked".to_string())
+            .map_err(|p| {
+                if let Some(panic) = p
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| p.downcast_ref::<&str>().copied())
+                {
+                    OTelSdkError::InternalFailure(format!(
+                        "DatadogExporter.join: worker panicked: {}",
+                        panic
+                    ))
+                } else {
+                    OTelSdkError::InternalFailure(
+                        "DatadogExporter.join: worker panicked: error message unknown".to_string(),
+                    )
+                }
             })?
             .map_err(|e| {
-                OTelSdkError::InternalFailure(format!(
-                    "DatadogExporter.join: worker exited with error: {e}"
-                ))
+                log_trace_exporter_error(&e);
+                match e {
+                    TraceExporterError::Shutdown(
+                        trace_exporter_error::ShutdownError::TimedOut(t),
+                    ) => OTelSdkError::Timeout(t),
+                    _ => OTelSdkError::InternalFailure(format!(
+                        "DatadogExporter.join: worker exited with error: {e}"
+                    )),
+                }
             })
     }
 }
@@ -554,22 +573,7 @@ impl TraceExporterWorker {
             if !data.is_empty() {
                 match self.export_trace_chunks(data) {
                     Ok(()) => {}
-                    Err(e) => {
-                        match e {
-                            OTelSdkError::AlreadyShutdown => dd_trace::dd_error!(
-                                "DatadogExporter: Export error - Shutdown already invoked {}",
-                                e,
-                            ),
-                            OTelSdkError::Timeout(_) => dd_trace::dd_error!(
-                                "DatadogExporter: Export error - Operation timed out {}",
-                                e,
-                            ),
-                            OTelSdkError::InternalFailure(_) => dd_trace::dd_error!(
-                                "DatadogExporter: Export error - Operation failed {}",
-                                e,
-                            ),
-                        };
-                    }
+                    Err(e) => log_trace_exporter_error(&e),
                 };
             }
             match message {
@@ -585,7 +589,10 @@ impl TraceExporterWorker {
             .shutdown(Some(SPAN_EXPORTER_SHUTDOWN_TIMEOUT))
     }
 
-    fn export_trace_chunks(&mut self, trace_chunks: Vec<TraceChunk>) -> OTelSdkResult {
+    fn export_trace_chunks(
+        &mut self,
+        trace_chunks: Vec<TraceChunk>,
+    ) -> Result<(), TraceExporterError> {
         let trace_chunks = trace_chunks
             .into_iter()
             .map(|TraceChunk { chunk }| -> Vec<_> {
@@ -596,13 +603,10 @@ impl TraceExporterWorker {
                 )
             })
             .collect();
-        match self.trace_exporter.send_trace_chunks(trace_chunks) {
-            Ok(agent_response) => {
-                self.handle_agent_response(agent_response);
-                Ok(())
-            }
-            Err(e) => Err(OTelSdkError::InternalFailure(e.to_string())),
-        }
+
+        let agent_response = self.trace_exporter.send_trace_chunks(trace_chunks)?;
+        self.handle_agent_response(agent_response);
+        Ok(())
     }
 
     fn handle_agent_response(&self, agent_response: AgentResponse) {
@@ -615,6 +619,64 @@ impl TraceExporterWorker {
             }
         }
     }
+}
+
+#[track_caller]
+fn log_trace_exporter_error(e: &TraceExporterError) {
+    match e {
+        // Exceptional errors
+        TraceExporterError::Builder(e) => {
+            dd_trace::dd_error!("DatadogExporter: Export error: Builder error: {}", e);
+        }
+        TraceExporterError::Internal(
+            trace_exporter_error::InternalErrorKind::InvalidWorkerState(state),
+        ) => {
+            dd_trace::dd_error!(
+                "DatadogExporter: Export error: Internal error: Invalid worker state: {}",
+                state
+            );
+        }
+
+        // Runtime errors
+        TraceExporterError::Deserialization(e) => {
+            dd_trace::dd_debug!(
+                "DatadogExporter: Export error: Deserialization error: {}",
+                e
+            );
+        }
+        TraceExporterError::Io(error) => {
+            dd_trace::dd_debug!("DatadogExporter: Export error: IO error: {}", error);
+        }
+        TraceExporterError::Network(e) => {
+            dd_trace::dd_debug!("DatadogExporter: Export error: Network error: {}", e);
+        }
+        TraceExporterError::Request(e) => {
+            dd_trace::dd_debug!("DatadogExporter: Export error: Request error: {}", e);
+        }
+        TraceExporterError::Serialization(error) => {
+            dd_trace::dd_debug!(
+                "DatadogExporter: Export error: Serialization error: {}",
+                error
+            );
+        }
+        TraceExporterError::Agent(trace_exporter_error::AgentErrorKind::EmptyResponse) => {
+            dd_trace::dd_debug!("DatadogExporter: Export error: Agent error: empty response");
+        }
+        TraceExporterError::Shutdown(
+            data_pipeline::trace_exporter::error::ShutdownError::TimedOut(duration),
+        ) => {
+            dd_trace::dd_debug!(
+                "DatadogExporter: Export error: Shutdown error: timed out after {}ms",
+                duration.as_millis()
+            );
+        }
+        TraceExporterError::Telemetry(e) => {
+            dd_trace::dd_debug!(
+                "DatadogExporter: Export error: Instrumentation telemetry error: {}",
+                e
+            );
+        }
+    };
 }
 
 #[derive(Debug, PartialEq)]

--- a/dd-trace/src/log.rs
+++ b/dd-trace/src/log.rs
@@ -128,14 +128,13 @@ impl PartialOrd<LevelFilter> for Level {
     }
 }
 
-pub fn print_log<I: Into<String>>(
+pub fn print_log(
     lvl: crate::log::Level,
-    log: I,
+    log: fmt::Arguments,
     file: &str,
     line: u32,
     template: Option<&str>,
 ) {
-    let log = log.into();
     if lvl == crate::log::LevelFilter::Error {
         eprintln!("\x1b[91m{lvl}\x1b[0m {file}:{line} - {log}");
 
@@ -188,14 +187,16 @@ macro_rules! dd_log {
     ($lvl:expr, $first:expr, $($rest:tt)*) => {{
       let lvl = $lvl;
       if lvl <= $crate::log::max_level() {
-        $crate::log::print_log(lvl, format!($first, $($rest)*), file!(), line!(), Some($first));
+        let loc = std::panic::Location::caller();
+        $crate::log::print_log(lvl, format_args!($first, $($rest)*), loc.file(), loc.line(), Some($first));
       }
     }};
 
     ($lvl:expr, $first:expr) => {
       let lvl = $lvl;
       if lvl <= $crate::log::max_level() {
-        $crate::log::print_log(lvl, format!($first), file!(), line!(), Some($first));
+        let loc = std::panic::Location::caller();
+        $crate::log::print_log(lvl, format_args!($first), loc.file(), loc.line(), Some($first));
       }
     };
 }


### PR DESCRIPTION
# Motivations

We have some errors in the telemetry logs, but they are not the most relevant. This is for two reasons:
* We log any export error with the ERROR level, even though this might be a "normal" (like a failure to connect to the agent, which should either be a debug log or a warn that is emitted once but definitely not for every export)
* The template is not very descriptive and so the error logs we receive through telemetry are not good enough to know if it's a real issue or not

# Changes

This PR:
* Switches on the TraceExporter error kind to differentiate between exceptional cases, which we want to know about and the "runtime" errors which will be logged at a debug level
* Changes some internal detail on the logging macros.
  * Use std::panic::Location::caller() to determine the logging location, which means we can use #[track_caller] to wrap logging code and still point to where the wrapper is called
  * We pass an fmt::Arguments instead of a string, which doesn't allocate
