### PR TITLE
feat(benches): add scaffolding for memory allocation benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
@@ -480,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +530,58 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "concurrent-queue"
@@ -578,6 +648,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +695,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -795,6 +911,8 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "base64 0.21.7",
+ "criterion",
+ "dd-trace",
  "ddtelemetry",
  "http-body-util",
  "hyper 1.6.0",
@@ -1303,6 +1421,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1933,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2462,34 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2551,6 +2733,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3435,6 +3637,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,7 +5,9 @@ aho-corasick,https://github.com/BurntSushi/aho-corasick,Unlicense OR MIT,Andrew 
 allocator-api2,https://github.com/zakarumych/allocator-api2,MIT OR Apache-2.0,Zakarum <zaq.dev@icloud.com>
 android-tzdata,https://github.com/RumovZ/android-tzdata,MIT OR Apache-2.0,RumovZ
 android_system_properties,https://github.com/nical/android_system_properties,MIT OR Apache-2.0,Nicolas Silva <nical@fastmail.com>
+anes,https://github.com/zrzka/anes-rs,MIT OR Apache-2.0,Robert Vojta <rvojta@me.com>
 ansi_term,https://github.com/ogham/rust-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>"
+anstyle,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The anstyle Authors
 anyhow,https://github.com/dtolnay/anyhow,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 arc-swap,https://github.com/vorner/arc-swap,MIT OR Apache-2.0,Michal 'vorner' Vaner <vorner@vorner.cz>
 ascii-canvas,https://github.com/nikomatsakis/ascii-canvas,Apache-2.0 OR MIT,Niko Matsakis <niko@alum.mit.edu>
@@ -41,17 +43,27 @@ cadence,https://github.com/56quarters/cadence,Apache-2.0 OR MIT,Nick Pillitteri
 camino,https://github.com/camino-rs/camino,MIT OR Apache-2.0,"Without Boats <saoirse@without.boats>, Ashley Williams <ashley666ashley@gmail.com>, Steve Klabnik <steve@steveklabnik.com>, Rain <rain@sunshowers.io>"
 cargo-platform,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,The cargo-platform Authors
 cargo_metadata,https://github.com/oli-obk/cargo_metadata,MIT,Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>
+cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
+ciborium,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-io,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-ll,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+clap,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap Authors
+clap_builder,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_builder Authors
+clap_lex,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_lex Authors
 concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>"
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 core-foundation,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+criterion,https://github.com/bheisler/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
+criterion-plot,https://github.com/bheisler/criterion.rs,MIT OR Apache-2.0,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
 critical-section,https://github.com/rust-embedded/critical-section,MIT OR Apache-2.0,The critical-section Authors
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
+crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
 crossbeam-epoch,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-epoch Authors
 crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-utils Authors
 crunchy,https://github.com/eira-fransham/crunchy,MIT,Eira Fransham <jackefransham@gmail.com>
@@ -108,6 +120,7 @@ getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Pr
 gimli,https://github.com/gimli-rs/gimli,MIT OR Apache-2.0,The gimli Authors
 gloo-timers,https://github.com/rustwasm/gloo/tree/master/crates/timers,MIT OR Apache-2.0,Rust and WebAssembly Working Group
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
+half,https://github.com/VoidStarKat/half-rs,MIT OR Apache-2.0,Kathryn Long <squeeself@gmail.com>
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hermit-abi,https://github.com/hermit-os/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
@@ -144,6 +157,7 @@ io-uring,https://github.com/tokio-rs/io-uring,MIT OR Apache-2.0,quininer <quinin
 ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
 iri-string,https://github.com/lo48576/iri-string,MIT OR Apache-2.0,YOSHIOKA Takuma <nop_thread@nops.red>
+is-terminal,https://github.com/sunfishcode/is-terminal,MIT,"softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 js-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
@@ -173,6 +187,7 @@ num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jaco
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
 object,https://github.com/gimli-rs/object,Apache-2.0 OR MIT,The object Authors
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
+oorandom,https://hg.sr.ht/~icefox/oorandom,MIT,Simon Heath <icefox@dreamquest.io>
 openssl-probe,https://github.com/alexcrichton/openssl-probe,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 opentelemetry,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry,Apache-2.0,The opentelemetry Authors
 opentelemetry-appender-tracing,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing,Apache-2.0,The opentelemetry-appender-tracing Authors
@@ -197,6 +212,9 @@ pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,Th
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
 pin-utils,https://github.com/rust-lang-nursery/pin-utils,MIT OR Apache-2.0,Josef Brandl <mail@josefbrandl.de>
 piper,https://github.com/smol-rs/piper,MIT OR Apache-2.0,"Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>"
+plotters,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-backend,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-svg,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
 polling,https://github.com/smol-rs/polling,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>"
 portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
@@ -214,6 +232,8 @@ r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The 
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
 rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
+rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
 redox_users,https://gitlab.redox-os.org/redox-os/users,MIT,"Jose Narvaez <goyox86@gmail.com>, Wesley Hershberger <mggmugginsmc@gmail.com>"
 ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
@@ -292,6 +312,7 @@ time-macros,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open
 tiny-keccak,https://github.com/debris/tiny-keccak,CC0-1.0,debris <marek.kotewicz@gmail.com>
 tinybytes,https://github.com/Datadog/libdatadog,Apache-2.0,The tinybytes Authors
 tinystr,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+tinytemplate,https://github.com/bheisler/TinyTemplate,Apache-2.0 OR MIT,Brook Heisler <brookheisler@gmail.com>
 tinyvec,https://github.com/Lokathor/tinyvec,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
 tinyvec_macros,https://github.com/Soveu/tinyvec_macros,MIT OR Apache-2.0 OR Zlib,Soveu <marx.tomasz@gmail.com>
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>

--- a/dd-trace/Cargo.toml
+++ b/dd-trace/Cargo.toml
@@ -17,7 +17,12 @@ rustc_version_runtime = "0.3.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 hyper = { version = "1.6", features = ["client", "http1"] }
-hyper-util = { version = "0.1.16", features = ["client", "client-legacy", "http1", "tokio"] }
+hyper-util = { version = "0.1.16", features = [
+    "client",
+    "client-legacy",
+    "http1",
+    "tokio",
+] }
 http-body-util = "0.1"
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] }
 base64 = "0.21"
@@ -29,5 +34,16 @@ arc-swap = "1.7.1"
 ddtelemetry = { workspace = true }
 tokio-util = "0.7"
 
+# Test utils
+criterion = { version = "0.5.1", optional = true }
+
+[dev-dependencies]
+dd-trace = { path = "./", features = ["test-utils"] }
+
 [features]
-test-utils = []
+test-utils = ["criterion"]
+
+[[bench]]
+name = "smoke"
+harness = false
+path = "benches/smoke.rs"

--- a/dd-trace/benches/smoke.rs
+++ b/dd-trace/benches/smoke.rs
@@ -1,0 +1,39 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{alloc::System, hint::black_box, thread, time::Duration};
+
+use criterion::{
+    criterion_group, criterion_main, measurement::Measurement, Criterion, PlottingBackend,
+};
+use dd_trace::test_utils::benchmarks::{
+    memory_allocated_measurement, MeasurementName, ReportingAllocator,
+};
+
+#[global_allocator]
+static GLOBAL: ReportingAllocator<System> = ReportingAllocator::new(System);
+
+fn benchmark<M: Measurement + MeasurementName + 'static>(c: &mut Criterion<M>) {
+    c.bench_function(&format!("sleep/{}", M::name()), |b| {
+        b.iter(|| {
+            thread::sleep(Duration::from_nanos(10));
+        })
+    });
+
+    c.bench_function(&format!("allocate/{}", M::name()), |b| {
+        b.iter(|| black_box(Box::new(101_u64)))
+    });
+}
+
+criterion_group!(
+    name = wall_time_benches;
+    // Run for only a short time since this benchmark is useless
+    config = Criterion::default()
+        .measurement_time(Duration::from_millis(1))
+        .warm_up_time(Duration::from_millis(1))
+        .sample_size(10)
+        .plotting_backend(PlottingBackend::None);
+    targets = benchmark
+);
+criterion_group!(name = memory_benches; config = memory_allocated_measurement(&GLOBAL); targets = benchmark);
+criterion_main!(wall_time_benches, memory_benches);

--- a/dd-trace/src/lib.rs
+++ b/dd-trace/src/lib.rs
@@ -12,6 +12,9 @@ pub use error::{Error, Result};
 pub mod log;
 pub mod telemetry;
 
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
+
 /// Macro to catch panics and return a fallback value with error logging
 /// The fallback is only evaluated if a panic occurs
 #[macro_export]

--- a/dd-trace/src/test_utils.rs
+++ b/dd-trace/src/test_utils.rs
@@ -1,0 +1,168 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod benchmarks {
+    //! Scaffolding for memory usage benchmarks
+    //!
+    //! See dd-trace/benches/smoke.rs for usage
+
+    use std::{
+        alloc::{GlobalAlloc, System},
+        cell::Cell,
+        time::Duration,
+    };
+
+    use criterion::{Criterion, Throughput};
+
+    pub trait MeasurementName {
+        fn name() -> &'static str;
+    }
+
+    impl MeasurementName for criterion::measurement::WallTime {
+        fn name() -> &'static str {
+            "wall_time"
+        }
+    }
+
+    pub fn memory_allocated_measurement(
+        global_alloc: &'static ReportingAllocator<System>,
+    ) -> Criterion<AllocatedBytesMeasurement<System>> {
+        Criterion::default()
+            .with_measurement(AllocatedBytesMeasurement(Cell::new(false), global_alloc))
+            .measurement_time(Duration::from_millis(1))
+            .warm_up_time(Duration::from_millis(1))
+            .without_plots()
+            .plotting_backend(criterion::PlottingBackend::None)
+            .sample_size(10)
+    }
+
+    #[derive(Debug)]
+    struct AllocStats {
+        allocated_bytes: usize,
+        #[allow(dead_code)]
+        allocations: usize,
+    }
+
+    pub struct ReportingAllocator<T: GlobalAlloc> {
+        alloc: T,
+        allocated_bytes: std::sync::atomic::AtomicUsize,
+        allocations: std::sync::atomic::AtomicUsize,
+    }
+
+    impl<T: GlobalAlloc> ReportingAllocator<T> {
+        pub const fn new(alloc: T) -> Self {
+            Self {
+                alloc,
+                allocated_bytes: std::sync::atomic::AtomicUsize::new(0),
+                allocations: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn stats(&self) -> AllocStats {
+            AllocStats {
+                allocated_bytes: self
+                    .allocated_bytes
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                allocations: self.allocations.load(std::sync::atomic::Ordering::Relaxed),
+            }
+        }
+    }
+
+    unsafe impl<T: GlobalAlloc> GlobalAlloc for ReportingAllocator<T> {
+        unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+            self.allocated_bytes
+                .fetch_add(layout.size(), std::sync::atomic::Ordering::Relaxed);
+            self.allocations
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.alloc.alloc(layout)
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+            self.alloc.dealloc(ptr, layout);
+        }
+    }
+
+    pub struct AllocatedBytesMeasurement<T: GlobalAlloc + 'static>(
+        Cell<bool>,
+        &'static ReportingAllocator<T>,
+    );
+
+    impl<T: GlobalAlloc> MeasurementName for AllocatedBytesMeasurement<T> {
+        fn name() -> &'static str {
+            "allocated_bytes"
+        }
+    }
+
+    impl<T: GlobalAlloc> criterion::measurement::Measurement for AllocatedBytesMeasurement<T> {
+        type Intermediate = usize;
+
+        type Value = usize;
+
+        fn start(&self) -> Self::Intermediate {
+            self.1.stats().allocated_bytes
+        }
+
+        fn end(&self, i: Self::Intermediate) -> Self::Value {
+            self.1.stats().allocated_bytes - i
+        }
+
+        fn add(&self, v1: &Self::Value, v2: &Self::Value) -> Self::Value {
+            *v1 + *v2
+        }
+
+        fn zero(&self) -> Self::Value {
+            0
+        }
+
+        fn to_f64(&self, value: &Self::Value) -> f64 {
+            let b = self.0.get();
+            self.0.set(!b);
+            // Criterion really doesn't like when all results have the same value, and since
+            // allocation is deterministic, that tend to happen a lot...
+            // We add a small +/- epsilon to have two measurements each time, without affecting the
+            // overall distribution of values.
+            *value as f64 + if b { 0.01 } else { -0.01 }
+        }
+
+        fn formatter(&self) -> &dyn criterion::measurement::ValueFormatter {
+            &AllocationFormatter
+        }
+    }
+
+    struct AllocationFormatter;
+
+    impl criterion::measurement::ValueFormatter for AllocationFormatter {
+        fn scale_values(&self, typical_value: f64, values: &mut [f64]) -> &'static str {
+            let log_scale: f64 = typical_value.log10().round();
+            if log_scale.is_infinite() || log_scale.is_nan() || log_scale < 0.0 {
+                return "b";
+            }
+            let scale = (log_scale as i32 / 3).min(4);
+            values.iter_mut().for_each(|v| *v /= 10_f64.powi(scale * 3));
+            match scale {
+                0 => "b",
+                1 => "Kb",
+                2 => "Mb",
+                3 => "Gb",
+                _ => "Tb",
+            }
+        }
+
+        fn scale_throughputs(
+            &self,
+            _typical_value: f64,
+            throughput: &criterion::Throughput,
+            _values: &mut [f64],
+        ) -> &'static str {
+            match throughput {
+                Throughput::Bytes(_) => "B/s",
+                Throughput::BytesDecimal(_) => "B/s",
+                Throughput::Elements(_) => "elements/s",
+            }
+        }
+
+        fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+            "b"
+        }
+    }
+}


### PR DESCRIPTION
# What does the PR do

This PR adds a criterion Measurement which can be used to report the number of allocations performed during a benchmarks.

Memory benches are fairly different from normal wall time benchmarks because they are (fairly) deterministic. We run the benchmark for a lot less time and iterations, and have to add a small epsilon to the measures so criterion doesn't explode. But otherwise this works well.

Benchmarks can be made generic on the measurement to run both for wall_time and allocated bytes.

# Example bench outputs

```
sleep/wall_time         time:   [5.2452 µs 5.9154 µs 6.6433 µs]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

allocate/wall_time      time:   [17.678 ns 17.717 ns 17.830 ns]

sleep/allocated_bytes   time:   [-0.0003 b 0.0000 b 0.0004 b]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

allocate/allocated_bytes
                        time:   [8.0000 b 8.0000 b 8.0000 b]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
  ```
