### PR TITLE
fix(remote_config): clear sampling rules on explicit null

### DIFF
--- a/dd-trace/src/configuration/remote_config.rs
+++ b/dd-trace/src/configuration/remote_config.rs
@@ -171,6 +171,20 @@ struct TargetFile {
     raw: String,
 }
 
+// Custom deserializer that preserves explicit null as Some(Value::Null)
+fn missing_field_and_null_value<'de, D>(
+    deserializer: D,
+) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Deserialize as Value directly, which preserves null
+    match serde_json::Value::deserialize(deserializer) {
+        Ok(value) => Ok(Some(value)),
+        Err(_) => Ok(None), // Field missing
+    }
+}
+
 /// Configuration payload for APM tracing
 /// Based on the apm-tracing.json schema from dd-go
 /// See: https://github.com/DataDog/dd-go/blob/prod/remote-config/apps/rc-schema-validation/schemas/apm-tracing.json
@@ -181,7 +195,11 @@ struct ApmTracingConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 struct LibConfig {
-    #[serde(default, rename = "tracing_sampling_rules")]
+    #[serde(
+        deserialize_with = "missing_field_and_null_value",
+        default,
+        rename = "tracing_sampling_rules"
+    )]
     tracing_sampling_rules: Option<serde_json::Value>,
     // Add other APM tracing config fields as needed (e.g., tracing_header_tags, etc.)
 }
@@ -844,6 +862,7 @@ impl ProductHandler for ApmTracingHandler {
                 crate::dd_debug!(
                     "RemoteConfigClient: APM tracing config received but tracing_sampling_rules is null"
                 );
+                config.clear_remote_sampling_rules();
             }
         } else {
             crate::dd_debug!(
@@ -1895,5 +1914,28 @@ mod tests {
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].sample_rate, 0.75);
         assert_eq!(rules[0].service, Some("test-app-service".to_string()));
+    }
+
+    #[test]
+    fn test_deserialize_tracing_sampling_rules_null() {
+        let config_json = r#"{"lib_config": {"tracing_sampling_rules": null}}"#;
+        let tracing_config: ApmTracingConfig =
+            serde_json::from_str(config_json).expect("Json should be parsed");
+
+        assert!(tracing_config.lib_config.tracing_sampling_rules.is_some());
+        assert!(tracing_config
+            .lib_config
+            .tracing_sampling_rules
+            .unwrap()
+            .is_null());
+    }
+
+    #[test]
+    fn test_deserialize_tracing_sampling_rules_missing() {
+        let config_json = r#"{"lib_config": {}}"#;
+        let tracing_config: ApmTracingConfig =
+            serde_json::from_str(config_json).expect("Json should be parsed");
+
+        assert!(tracing_config.lib_config.tracing_sampling_rules.is_none());
     }
 }


### PR DESCRIPTION
# What does this PR do?

- Add a new deserializer to distinguish between missing `tracing_sampling_rules` field and `tracing_sampling_rules: null`
- Call `clear_remote_sampling_rules()` when null is received

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
