### PR TITLE
fix(clippy): rust stable upgraded to 1.90 and enabled new lints

### DIFF
--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -109,7 +109,7 @@ impl Tracestate {
             return false;
         }
 
-        let allowed_special = |b: u8| (b == b'_' || b == b'-' || b == b'*' || b == b'/');
+        let allowed_special = |b: u8| b == b'_' || b == b'-' || b == b'*' || b == b'/';
         let mut vendor_start = None;
         for (i, &b) in key.as_bytes().iter().enumerate() {
             if !(b.is_ascii_lowercase() || b.is_ascii_digit() || allowed_special(b) || b == b'@') {


### PR DESCRIPTION
# What does this PR do

Fix a clippy lint failing on main. It wasn't before but rust stable upgraded to 1.90 and enabled new lints, one of which is failing
