### PR TITLE
perf(injection): precompute the injection tag size

### DIFF
--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -128,7 +128,12 @@ fn get_propagation_tags(
         .iter()
         .filter(|(k, _)| k.starts_with(DATADOG_PROPAGATION_TAG_PREFIX))
         .enumerate()
-        .map(|(i, (k, v))| k.len() + v.len() + 1 + if i == 0 { 0 } else { 1 })
+        .map(|(i, (k, v))| {
+            // Length of the tag is  len(key) + len(":") + len(value)
+            // and then we add a "," separator prefix but only if the tag is not
+            // the first one
+            k.len() + v.len() + 1 + if i == 0 { 0 } else { 1 }
+        })
         .sum();
     if total_size > max_length {
         return Err(Error::inject("inject_max_size", "datadog"));


### PR DESCRIPTION

# What does this PR do?

This saves us reallocation of the String, as if we add only the _dd.p.dm tag and _dd.p.tid tags, we are at least at more than 32 bytes. Since the Vec smallest allocation is 8 bytes, and doubles on growth than means were perform probably 2 re-allocations in the best case scenario.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
