### PR TITLE
feat(propagation): Inject borrowed data

### DIFF
--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, str::FromStr, sync::Arc, vec};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use dd_trace::{catch_panic, sampling::priority, Config};
 use opentelemetry::{
@@ -10,7 +10,7 @@ use opentelemetry::{
 };
 
 use dd_trace_propagation::{
-    context::{Sampling, SpanContext, SpanLink, Tracestate},
+    context::{InjectSpanContext, Sampling, SpanContext, SpanLink, Tracestate},
     DatadogCompositePropagator,
 };
 
@@ -87,7 +87,7 @@ impl DatadogPropagator {
         }
 
         let trace_id = otel_span_context.trace_id().to_bytes();
-        let propagation_data = self.registry.get_trace_propagation_data(trace_id);
+        let mut propagation_data = self.registry.get_trace_propagation_data(trace_id);
 
         // get Trace's sampling decision and if it is not present obtain it from otel's SpanContext
         // flags
@@ -116,24 +116,20 @@ impl DatadogPropagator {
             Tracestate::from_str(&otel_tracestate.header()).ok()
         };
 
-        let mut tags = HashMap::new();
-        if let Some(propagation_tags) = propagation_data.tags {
-            propagation_tags.iter().for_each(|(key, value)| {
-                if key.starts_with("_dd.p.") {
-                    tags.insert(key.clone(), value.clone());
-                }
-            });
-        }
+        let tags = if let Some(propagation_tags) = &mut propagation_data.tags {
+            propagation_tags
+        } else {
+            &mut HashMap::new()
+        };
 
-        let dd_span_context = &mut SpanContext {
+        let dd_span_context = &mut InjectSpanContext {
             trace_id: u128::from_be_bytes(trace_id),
             span_id: u64::from_be_bytes(otel_span_context.span_id().to_bytes()),
             is_remote: otel_span_context.is_remote(),
-            links: vec![], // links don't affect injection
             sampling,
-            origin: propagation_data.origin,
+            origin: propagation_data.origin.as_deref(),
             tags,
-            tracestate,
+            tracestate: tracestate.as_ref(),
         };
 
         self.inner.inject(dd_span_context, &mut injector)

--- a/dd-trace-propagation/src/context.rs
+++ b/dd-trace-propagation/src/context.rs
@@ -66,6 +66,33 @@ impl SpanLink {
         }
     }
 }
+
+pub struct InjectSpanContext<'a> {
+    pub trace_id: u128,
+    pub span_id: u64,
+    pub sampling: Sampling,
+    pub origin: Option<&'a str>,
+    // tags needs to be mutable because we insert the error meta field
+    pub tags: &'a mut HashMap<String, String>,
+    pub is_remote: bool,
+    pub tracestate: Option<&'a Tracestate>,
+}
+
+#[cfg(test)]
+/// A helper function because creating synthetic borrowed data is a bit harder
+/// than owned data
+pub(crate) fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'_> {
+    InjectSpanContext {
+        trace_id: c.trace_id,
+        span_id: c.span_id,
+        sampling: c.sampling,
+        origin: c.origin.as_deref(),
+        tags: &mut c.tags,
+        is_remote: c.is_remote,
+        tracestate: c.tracestate.as_ref(),
+    }
+}
+
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct SpanContext {
     pub trace_id: u128,

--- a/dd-trace-propagation/src/datadog.rs
+++ b/dd-trace-propagation/src/datadog.rs
@@ -6,7 +6,8 @@ use std::{collections::HashMap, str::FromStr, sync::LazyLock};
 use crate::{
     carrier::{Extractor, Injector},
     context::{
-        combine_trace_id, split_trace_id, Sampling, SpanContext, DATADOG_PROPAGATION_TAG_PREFIX,
+        combine_trace_id, split_trace_id, InjectSpanContext, Sampling, SpanContext,
+        DATADOG_PROPAGATION_TAG_PREFIX,
     },
     error::Error,
 };
@@ -38,7 +39,7 @@ static DATADOG_HEADER_KEYS: LazyLock<[String; 5]> = LazyLock::new(|| {
     ]
 });
 
-pub fn inject(context: &mut SpanContext, carrier: &mut dyn Injector, config: &Config) {
+pub fn inject(context: &mut InjectSpanContext, carrier: &mut dyn Injector, config: &Config) {
     let tags = &mut context.tags;
 
     inject_trace_id(context.trace_id, carrier, tags);
@@ -366,7 +367,10 @@ mod test {
         sampling::{mechanism, priority},
     };
 
-    use crate::{context::split_trace_id, Propagator};
+    use crate::{
+        context::{span_context_to_inject, split_trace_id},
+        Propagator,
+    };
 
     use super::*;
 
@@ -557,7 +561,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier[DATADOG_TRACE_ID_KEY], "1234");
         assert_eq!(carrier[DATADOG_PARENT_ID_KEY], "5678");
@@ -596,7 +604,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier[DATADOG_TRACE_ID_KEY], lower.to_string());
         assert_eq!(carrier[DATADOG_ORIGIN_KEY], "synthetics");
@@ -617,7 +629,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier[DATADOG_TAGS_KEY], "_dd.p.dm=-4");
     }
@@ -632,7 +648,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier.get(DATADOG_TAGS_KEY), None);
     }
@@ -648,7 +668,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier.get(DATADOG_TAGS_KEY), None);
     }
@@ -663,7 +687,7 @@ mod test {
 
         let mut carrier = HashMap::new();
         propagator.inject(
-            &mut context,
+            &mut span_context_to_inject(&mut context),
             &mut carrier,
             &Config::builder().set_datadog_tags_max_length(0).build(),
         );
@@ -680,7 +704,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier.get(DATADOG_TAGS_KEY), None);
     }
@@ -695,7 +723,11 @@ mod test {
         let propagator = TracePropagationStyle::Datadog;
 
         let mut carrier = HashMap::new();
-        propagator.inject(&mut context, &mut carrier, &Config::builder().build());
+        propagator.inject(
+            &mut span_context_to_inject(&mut context),
+            &mut carrier,
+            &Config::builder().build(),
+        );
 
         assert_eq!(carrier[DATADOG_TAGS_KEY], "_dd.p.other=test");
     }

--- a/dd-trace-propagation/src/lib.rs
+++ b/dd-trace-propagation/src/lib.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use crate::context::{SpanContext, SpanLink};
+use crate::context::{InjectSpanContext, SpanContext, SpanLink};
 use carrier::{Extractor, Injector};
 use config::{get_extractors, get_injectors};
 use datadog::DATADOG_LAST_PARENT_ID_KEY;
@@ -20,7 +20,7 @@ pub mod tracecontext;
 
 pub trait Propagator {
     fn extract(&self, carrier: &dyn Extractor, config: &Config) -> Option<SpanContext>;
-    fn inject(&self, context: &mut SpanContext, carrier: &mut dyn Injector, config: &Config);
+    fn inject(&self, context: &mut InjectSpanContext, carrier: &mut dyn Injector, config: &Config);
     fn keys(&self) -> &[String];
 }
 
@@ -81,7 +81,7 @@ impl DatadogCompositePropagator {
         Some(context)
     }
 
-    pub fn inject(&self, context: &mut SpanContext, carrier: &mut dyn Injector) {
+    pub fn inject(&self, context: &mut InjectSpanContext, carrier: &mut dyn Injector) {
         self.injectors
             .iter()
             .for_each(|propagator| propagator.inject(context, carrier, &self.config));
@@ -990,7 +990,9 @@ pub mod tests {
             $(
                 #[test]
                 fn $name() {
-                    let (styles, context, expected) = $value;
+                    use crate::context::span_context_to_inject;
+
+                    let (styles, mut context, expected) = $value;
 
                     let builder = if let Some(styles) = styles {
                         let mut b = Config::builder();
@@ -1003,8 +1005,9 @@ pub mod tests {
                     let config = Arc::new(builder.build());
                     let propagator = DatadogCompositePropagator::new(config);
 
+                    let mut inject_context = span_context_to_inject(&mut context);
                     let mut carrier = HashMap::new();
-                    propagator.inject(context, &mut carrier);
+                    propagator.inject(&mut inject_context, &mut carrier);
 
                     assert_hashmap_keys(&expected, &carrier);
                     assert_hashmap_keys(&carrier, &expected);

--- a/dd-trace-propagation/src/trace_propagation_style.rs
+++ b/dd-trace-propagation/src/trace_propagation_style.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer};
 
 use crate::{
     carrier::{Extractor, Injector},
-    context::SpanContext,
+    context::{InjectSpanContext, SpanContext},
     datadog, tracecontext, Propagator,
 };
 
@@ -22,7 +22,7 @@ impl Propagator for TracePropagationStyle {
         }
     }
 
-    fn inject(&self, context: &mut SpanContext, carrier: &mut dyn Injector, config: &Config) {
+    fn inject(&self, context: &mut InjectSpanContext, carrier: &mut dyn Injector, config: &Config) {
         match self {
             Self::Datadog => datadog::inject(context, carrier, config),
             Self::TraceContext => tracecontext::inject(context, carrier),


### PR DESCRIPTION

# What does this PR do?

Injection needs to read fields such as propagation tags and origin. Currently the SpanContext struct needs to have ownership of these which forces copying when injecting the span context.

This PR introduces and InjectSpanContext which just borrows the fields

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
