### PR TITLE
fix(ci): make the free disk space step faster

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: false
           swap-storage: true
       - name: Checkout sources


### PR DESCRIPTION
Free Disk Space is currently the longest step in the ubuntu test job, and lasts up to 8mn!! By not removing large packages, this is reduced to 4mn and increase the disk size by 4GB of packages, which should not be an issue

# What does this PR do?

A brief description of the change being made with this pull request.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
