### PR TITLE
perf(inject):  don't parse otel tracestate on injection

### DIFF
--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use dd_trace::{catch_panic, sampling::priority, Config};
 use opentelemetry::{
@@ -10,7 +10,7 @@ use opentelemetry::{
 };
 
 use dd_trace_propagation::{
-    context::{InjectSpanContext, Sampling, SpanContext, SpanLink, Tracestate},
+    context::{InjectSpanContext, InjectTraceState, Sampling, SpanContext, SpanLink},
     DatadogCompositePropagator,
 };
 
@@ -113,7 +113,7 @@ impl DatadogPropagator {
         let tracestate = if *otel_tracestate == opentelemetry::trace::TraceState::NONE {
             None
         } else {
-            Tracestate::from_str(&otel_tracestate.header()).ok()
+            Some(InjectTraceState::from_header(otel_tracestate.header()))
         };
 
         let tags = if let Some(propagation_tags) = &mut propagation_data.tags {
@@ -129,7 +129,7 @@ impl DatadogPropagator {
             sampling,
             origin: propagation_data.origin.as_deref(),
             tags,
-            tracestate: tracestate.as_ref(),
+            tracestate,
         };
 
         self.inner.inject(dd_span_context, &mut injector)

--- a/dd-trace-propagation/benches/inject_benchmark.rs
+++ b/dd-trace-propagation/benches/inject_benchmark.rs
@@ -26,7 +26,7 @@ fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'_> {
         origin: c.origin.as_deref(),
         tags: &mut c.tags,
         is_remote: c.is_remote,
-        tracestate: c.tracestate.as_ref(),
+        tracestate: None,
     }
 }
 


### PR DESCRIPTION
# Motivation

The otel tracestate API is obviously not optimal.
Currently we do a roundtrip of otel tracestate -> String -> dd tracestate. This PR removes one step on injection, and keeps the tracestate as a string, which we copy into the injected tracestate
