### PR TITLE
chore(ci): move system-tests branch back to main after upgrade

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@94671a1af9d43d1df3bed4fb5a5622cd4fe6332e  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@fe54df1ab9bb126ffb337b72bb9a2793d2466bf5  # main
     secrets: inherit
     with:
       library: rust


### PR DESCRIPTION
# What does this PR do?

Change the pinned hash of system-tests

# Motivation

In a previous PR (#109) I changed the system-test pin to point to a dev branch, in order to validate non backward compatible changes. The dev branch has been merged in main and has been deleted.
So the pinned commit is not valid anymore, and we should use the pin to the latest commit of the main branch of system-tests.
