### PR TITLE
chore(ci): adds schedule and workflow_dispatch on test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,11 @@
 name: Test
 permissions:
    contents: read
-on: [push]
+on:
+   push:
+   workflow_dispatch:
+   schedule:
+      - cron:  '00 03 * * 1-5'
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.84.1


### PR DESCRIPTION
# What does this PR do?

Per title.

# Motivation

Main reason : it will help to identify more precisely when an  incompatibility is introduced  with another component.

Secondary reason :  it will smooth the CI health SLI. When  a commit with an issue reach the default branch, but is tackled just after, this kind of event is considered as ok. But since there are not so many commit on this repo, it has a huge effect on the CI health SLI. Two of them  even make it  dropping [below the incident SLO](https://app.datadoghq.com/s/yB5yjZ/i9k-hu5-82f). Having a daily schedule will reduce the weight of this kind of event, preventing any false alarm.

# Additional Notes

Anything else we should know when reviewing?
