### PR TITLE
chore(versioning): add STS policy to freeze main branch

### DIFF
--- a/.github/chainguard/release-dispatch.sts.yml
+++ b/.github/chainguard/release-dispatch.sts.yml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-rs:.*
+
+claim_pattern:
+  event_name: (workflow_dispatch|push)
+  ref: refs/heads/(main|igor/versioning/.*)
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-rs/.github/workflows/release-dispatch.yaml@.*
+
+permissions:
+  admin: write


### PR DESCRIPTION
# What does this PR do?

Octo-STS file used by the releasing workflow with the permissions to freeze main branch.

# Additional Notes

It seems that it has to be in main branch for the workflow to find it.
