### PR TITLE
chore(versioning): sts policy (take 2)

### DIFF
--- a/.github/chainguard/release-dispatch.sts.yaml
+++ b/.github/chainguard/release-dispatch.sts.yaml
@@ -5,8 +5,8 @@ subject: repo:DataDog/dd-trace-rs:.*
 claim_pattern:
   event_name: (workflow_dispatch|push)
   ref: refs/heads/(main|igor/versioning/.*)
-  ref_protected: "true"
+  # ref_protected: "true" # TODO: Uncomment this once the workflow is working
   job_workflow_ref: DataDog/dd-trace-rs/.github/workflows/release-dispatch.yaml@.*
 
 permissions:
-  admin: write
+  administration: write


### PR DESCRIPTION
# What does this PR do?

Change yaml file extension, comment out `ref_protected` temporarily and fix `administration` permission

# Motivation

Workflow is unable to find trust policy for `"release-dispatch"`. Octo STS only takes .yaml and not .yml man :rage:  
