### PR TITLE
chore(versioning): sts policy use pattern (take 3)

### DIFF
--- a/.github/chainguard/release-dispatch.sts.yaml
+++ b/.github/chainguard/release-dispatch.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/dd-trace-rs:.*
+subject_pattern: repo:DataDog/dd-trace-rs:.*
 
 claim_pattern:
   event_name: (workflow_dispatch|push)


### PR DESCRIPTION
# What does this PR do?

`subject` doesn't allow regexes, use `subject_pattern` instead :rage: 