### PR TITLE
fix(rc): make path parsing stricter and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,11 +484,13 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "pretty_assertions",
+ "proptest",
  "rand 0.8.5",
  "rustc_version_runtime",
  "serde",
  "serde_json",
  "sha2",
+ "test-case",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -1661,6 +1663,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2137,6 +2163,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2406,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -160,6 +160,7 @@ r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The 
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
 rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
 rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
@@ -202,6 +203,8 @@ sys-info,https://github.com/FillZpp/sys-info-rs,MIT,Siyu Wang <FillZpp.pub@gmail
 system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 system-configuration-sys,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 tabwriter,https://github.com/BurntSushi/tabwriter,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+test-case-core,https://github.com/frondeus/test-case,MIT,"Marcin Sas-Szymanski <marcin.sas-szymanski@anixe.pl>, Wojciech Polak <frondeus@gmail.com>, Łukasz Biel <lukasz.p.biel@gmail.com>"
+test-case-macros,https://github.com/frondeus/test-case,MIT,"Marcin Sas-Szymanski <marcin.sas-szymanski@anixe.pl>, Wojciech Polak <frondeus@gmail.com>, Łukasz Biel <lukasz.p.biel@gmail.com>"
 thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thiserror-impl,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
@@ -218,6 +221,7 @@ tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tok
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
+unarray,https://github.com/cameron1024/unarray,MIT OR Apache-2.0,The unarray Authors
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
 unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -57,6 +57,8 @@ libdd-common = { workspace = true }
 [dev-dependencies]
 assert_unordered = "0.3"
 pretty_assertions = "1.4.1"
+proptest = {version = "1.9", features = ["std"], default-features = false}
+test-case = "3.3.1"
 tokio = { workspace = true }
 
 # Libdatadog dependencies - change to a stable version once we release

--- a/datadog-opentelemetry/src/core/configuration/remote_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/remote_config.rs
@@ -866,7 +866,13 @@ fn extract_product_and_id_from_path(path: &str) -> Option<(String, String)> {
         .strip_prefix("datadog/")
         .map_or_else(
             || path.strip_prefix("employee/"),
-            |rest| Some(rest.trim_start_matches(|c| c == '/' || char::is_numeric(c))),
+            |rest| {
+                if !rest.starts_with(char::is_numeric) {
+                    None
+                } else {
+                    rest.trim_start_matches(char::is_numeric).strip_prefix("/")
+                }
+            },
         )?
         .split("/");
 
@@ -877,7 +883,7 @@ fn extract_product_and_id_from_path(path: &str) -> Option<(String, String)> {
     // Remove the last name part
     let _ = components.next()?;
     // Check if there are any remaining components after product, config_id, name
-    if components.next().is_some() {
+    if components.next().is_some() || product.is_empty() || config_id.is_empty() {
         return None;
     }
     Some((product, config_id))
@@ -886,6 +892,9 @@ fn extract_product_and_id_from_path(path: &str) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use proptest::prelude::*;
+    use test_case::test_case;
 
     #[test]
     fn test_client_capabilities() {
@@ -1520,75 +1529,292 @@ mod tests {
         assert_eq!(cws_custom.get("v").unwrap().as_u64().unwrap(), 1);
     }
 
-    #[test]
-    fn test_extract_product_from_path() {
-        // Test APM_TRACING path
-        assert_eq!(
-            extract_product_and_id_from_path("datadog/2/APM_TRACING/config123/config")
-                .map(|(p, _)| p),
-            Some("APM_TRACING".to_string())
-        );
+    // ===== Valid Path Tests =====
 
-        // Test LIVE_DEBUGGING path
+    #[test_case("datadog/2/APM_TRACING/config123/config", "APM_TRACING", "config123")]
+    #[test_case(
+        "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
+        "LIVE_DEBUGGING",
+        "LIVE_DEBUGGING-base"
+    )]
+    #[test_case(
+        "datadog/2/AGENT_CONFIG/dynamic_rates/config",
+        "AGENT_CONFIG",
+        "dynamic_rates"
+    )]
+    #[test_case(
+        "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config",
+        "ASM_FEATURES",
+        "ASM_FEATURES-base"
+    )]
+    #[test_case(
+        "datadog/2/APM_SAMPLING/dynamic_rates/config",
+        "APM_SAMPLING",
+        "dynamic_rates"
+    )]
+    fn test_valid_datadog_paths(path: &str, expected_product: &str, expected_id: &str) {
+        let result = extract_product_and_id_from_path(path);
         assert_eq!(
-            extract_product_and_id_from_path("datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config")
-                .map(|(p, _)| p),
-            Some("LIVE_DEBUGGING".to_string())
+            result,
+            Some((expected_product.to_string(), expected_id.to_string()))
         );
-
-        // Test AGENT_CONFIG path
-        assert_eq!(
-            extract_product_and_id_from_path("datadog/2/AGENT_CONFIG/dynamic_rates/config")
-                .map(|(p, _)| p),
-            Some("AGENT_CONFIG".to_string())
-        );
-
-        // Test invalid paths
-        assert_eq!(
-            extract_product_and_id_from_path("invalid/path").map(|(p, _)| p),
-            None
-        );
-        assert_eq!(
-            extract_product_and_id_from_path("datadog/1/APM_TRACING/config").map(|(p, _)| p),
-            None
-        );
-        assert_eq!(
-            extract_product_and_id_from_path("datadog/APM_TRACING/config").map(|(p, _)| p),
-            None
-        );
-        assert_eq!(extract_product_and_id_from_path("").map(|(p, _)| p), None);
     }
 
-    #[test]
-    fn test_extract_config_id_from_path() {
-        // Test APM_TRACING path
+    #[test_case(
+        "employee/ASM_DD/1.recommended.json/config",
+        "ASM_DD",
+        "1.recommended.json"
+    )]
+    #[test_case(
+        "employee/CWS_DD/4.default.policy/config",
+        "CWS_DD",
+        "4.default.policy"
+    )]
+    #[test_case("employee/TEST_PRODUCT/test-id/some-name", "TEST_PRODUCT", "test-id")]
+    fn test_valid_employee_paths(path: &str, expected_product: &str, expected_id: &str) {
+        let result = extract_product_and_id_from_path(path);
         assert_eq!(
-            extract_product_and_id_from_path("datadog/2/APM_TRACING/config123/config")
-                .map(|(_, id)| id),
-            Some("config123".to_string())
+            result,
+            Some((expected_product.to_string(), expected_id.to_string()))
         );
+    }
 
-        // Test ASM_FEATURES path
+    #[test_case("datadog/0/PRODUCT/id/name", "PRODUCT", "id")]
+    #[test_case("datadog/1/PRODUCT/id/name", "PRODUCT", "id")]
+    #[test_case("datadog/2/PRODUCT/id/name", "PRODUCT", "id")]
+    #[test_case("datadog/99/PRODUCT/id/name", "PRODUCT", "id")]
+    #[test_case("datadog/123/PRODUCT/id/name", "PRODUCT", "id")]
+    #[test_case("datadog/999999/PRODUCT/id/name", "PRODUCT", "id")]
+    fn test_various_numeric_versions(path: &str, expected_product: &str, expected_id: &str) {
+        let result = extract_product_and_id_from_path(path);
         assert_eq!(
-            extract_product_and_id_from_path("datadog/2/ASM_FEATURES/ASM_FEATURES-base/config")
-                .map(|(_, id)| id),
-            Some("ASM_FEATURES-base".to_string())
+            result,
+            Some((expected_product.to_string(), expected_id.to_string()))
         );
+    }
 
-        // Test invalid paths
+    #[test_case("datadog/2/PRODUCT-NAME/config-id-123/file.json", "PRODUCT-NAME", "config-id-123" ; "hyphens")]
+    #[test_case("datadog/2/PRODUCT_NAME/config_id_123/file_name", "PRODUCT_NAME", "config_id_123" ; "underscores")]
+    #[test_case("datadog/2/PRODUCT.NAME/config.id.123/file.name", "PRODUCT.NAME", "config.id.123" ; "dots")]
+    #[test_case("employee/PR0D-UCT_123/id-with.chars/name", "PR0D-UCT_123", "id-with.chars" ; "mixed special chars")]
+    fn test_special_characters_in_components(
+        path: &str,
+        expected_product: &str,
+        expected_id: &str,
+    ) {
+        let result = extract_product_and_id_from_path(path);
         assert_eq!(
-            extract_product_and_id_from_path("invalid/path").map(|(_, id)| id),
-            None
+            result,
+            Some((expected_product.to_string(), expected_id.to_string()))
         );
+    }
+
+    // ===== Invalid Path Tests =====
+
+    #[test_case("" ; "empty string")]
+    #[test_case(" " ; "single space")]
+    #[test_case("   " ; "multiple spaces")]
+    fn test_empty_and_whitespace(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    #[test_case("invalid/path" ; "invalid prefix")]
+    #[test_case("invalid/2/PRODUCT/id/name" ; "invalid prefix with components")]
+    #[test_case("datadogs/2/PRODUCT/id/name" ; "typo in datadog")]
+    #[test_case("employe/PRODUCT/id/name" ; "typo in employee")]
+    #[test_case("PRODUCT/id/name" ; "missing prefix entirely")]
+    #[test_case("2/PRODUCT/id/name" ; "numeric prefix only")]
+    fn test_missing_prefix(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    #[test_case("datadog/2" ; "datadog only version")]
+    #[test_case("datadog/2/PRODUCT" ; "datadog missing id and name")]
+    #[test_case("datadog/2/PRODUCT/config" ; "datadog missing name")]
+    #[test_case("employee/PRODUCT" ; "employee missing id and name")]
+    #[test_case("employee/PRODUCT/id" ; "employee missing name")]
+    fn test_insufficient_components(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    #[test_case("datadog/2/PRODUCT/id/name/extra" ; "datadog one extra")]
+    #[test_case("datadog/2/PRODUCT/id/name/extra/more" ; "datadog two extra")]
+    #[test_case("employee/PRODUCT/id/name/extra" ; "employee one extra")]
+    #[test_case("employee/PRODUCT/id/name/extra/and/more" ; "employee three extra")]
+    fn test_too_many_components(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    #[test_case("datadog/2/PROD/UCT/id/name" ; "slash in product")]
+    #[test_case("datadog/2/PRODUCT/conf/ig/name" ; "slash in config_id")]
+    #[test_case("datadog/2/PRODUCT/id/na/me" ; "slash in name")]
+    fn test_slashes_in_components(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    #[test_case("/datadog/2/PRODUCT/id/name" ; "leading slash datadog")]
+    #[test_case("datadog/2/PRODUCT/id/name/" ; "trailing slash datadog")]
+    #[test_case("/employee/PRODUCT/id/name" ; "leading slash employee")]
+    fn test_leading_trailing_slashes(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
+    }
+
+    // ===== Property-Based Tests =====
+
+    proptest! {
+        #[test]
+        fn test_valid_datadog_paths_property(
+            version in 0u32..1000000,
+            product in "[A-Z_]{1,20}",
+            config_id in "[a-zA-Z0-9_-]{1,30}",
+            name in "[a-zA-Z0-9_.-]{1,30}"
+        ) {
+            let path = format!("datadog/{}/{}/{}/{}", version, product, config_id, name);
+            let result = extract_product_and_id_from_path(&path);
+
+            prop_assert_eq!(
+                result,
+                Some((product.clone(), config_id.clone())),
+                "Valid datadog path should parse successfully: {}",
+                path
+            );
+        }
+
+        #[test]
+        fn test_valid_employee_paths_property(
+            product in "[A-Z_]{1,20}",
+            config_id in "[a-zA-Z0-9_.-]{1,30}",
+            name in "[a-zA-Z0-9_.-]{1,30}"
+        ) {
+            let path = format!("employee/{}/{}/{}", product, config_id, name);
+            let result = extract_product_and_id_from_path(&path);
+
+            prop_assert_eq!(
+                result,
+                Some((product.clone(), config_id.clone())),
+                "Valid employee path should parse successfully: {}",
+                path
+            );
+        }
+
+        #[test]
+        fn test_invalid_prefix_property(
+            prefix in "[a-z]{1,20}",
+            rest in "[a-zA-Z0-9/_-]{1,50}"
+        ) {
+            prop_assume!(prefix != "datadog" && prefix != "employee");
+            let path = format!("{}/{}", prefix, rest);
+            let result = extract_product_and_id_from_path(&path);
+
+            prop_assert_eq!(
+                result,
+                None,
+                "Path with invalid prefix should fail: {}",
+                path
+            );
+        }
+
+        #[test]
+        fn test_too_few_components_property(
+            version in 0u32..100,
+            component_count in 0usize..3
+        ) {
+            let mut components = vec![format!("datadog/{}", version)];
+            for i in 0..component_count {
+                components.push(format!("comp{}", i));
+            }
+            let path = components.join("/");
+            let result = extract_product_and_id_from_path(&path);
+
+            prop_assert_eq!(
+                result,
+                None,
+                "Path with {} components should fail: {}",
+                component_count,
+                path
+            );
+        }
+
+        #[test]
+        fn test_too_many_components_property(
+            version in 0u32..100,
+            product in "[A-Z_]{1,20}",
+            config_id in "[a-zA-Z0-9_-]{1,30}",
+            name in "[a-zA-Z0-9_.-]{1,30}",
+            extra_count in 1usize..5
+        ) {
+            let mut path = format!("datadog/{}/{}/{}/{}", version, product, config_id, name);
+            for i in 0..extra_count {
+                path.push_str(&format!("/extra{}", i));
+            }
+            let result = extract_product_and_id_from_path(&path);
+
+            prop_assert_eq!(
+                result,
+                None,
+                "Path with {} extra components should fail: {}",
+                extra_count,
+                path
+            );
+        }
+    }
+
+    // ===== Regression Tests for Real-World Paths =====
+
+    #[test_case(
+        "datadog/2/APM_SAMPLING/dynamic_rates/config",
+        "APM_SAMPLING",
+        "dynamic_rates"
+    )]
+    #[test_case(
+        "employee/ASM_DD/1.recommended.json/config",
+        "ASM_DD",
+        "1.recommended.json"
+    )]
+    #[test_case(
+        "employee/CWS_DD/4.default.policy/config",
+        "CWS_DD",
+        "4.default.policy"
+    )]
+    #[test_case(
+        "datadog/2/APM_TRACING/apm-tracing-sampling/config",
+        "APM_TRACING",
+        "apm-tracing-sampling"
+    )]
+    #[test_case(
+        "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config",
+        "ASM_FEATURES",
+        "ASM_FEATURES-base"
+    )]
+    #[test_case(
+        "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
+        "LIVE_DEBUGGING",
+        "LIVE_DEBUGGING-base"
+    )]
+    fn test_real_world_examples(path: &str, expected_product: &str, expected_id: &str) {
+        let result = extract_product_and_id_from_path(path);
         assert_eq!(
-            extract_product_and_id_from_path("datadog/2/APM_TRACING/config").map(|(_, id)| id),
-            None
-        ); // Missing /config at end
-        assert_eq!(
-            extract_product_and_id_from_path("datadog/2/APM_TRACING").map(|(_, id)| id),
-            None
-        ); // Too short
-        assert_eq!(extract_product_and_id_from_path("").map(|(_, id)| id), None);
+            result,
+            Some((expected_product.to_string(), expected_id.to_string()))
+        );
+    }
+
+    // ===== Edge Cases =====
+
+    #[test_case("datadog/2/PRODUCT/id-\u{00E9}/name" ; "unicode e with acute")]
+    #[test_case("employee/PRODUCT/id-\u{4E2D}/name" ; "unicode chinese character")]
+    fn test_unicode_in_components(path: &str) {
+        // These should parse successfully since unicode chars are valid in [^/]+
+        let result = extract_product_and_id_from_path(path);
+        assert!(result.is_some());
+    }
+
+    #[test_case("DATADOG/2/PRODUCT/id/name" ; "uppercase DATADOG")]
+    #[test_case("Datadog/2/PRODUCT/id/name" ; "capitalized Datadog")]
+    #[test_case("EMPLOYEE/PRODUCT/id/name" ; "uppercase EMPLOYEE")]
+    #[test_case("Employee/PRODUCT/id/name" ; "capitalized Employee")]
+    fn test_case_sensitivity(path: &str) {
+        assert_eq!(extract_product_and_id_from_path(path), None);
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

* Makes the RC path parsing stricter to require the required fields.
* Adds tests cases and property tests to check the code.

# Motivation

Can't have enough tests...
