### PR TITLE
chore: remove warning and clippy suggestion

### DIFF
--- a/datadog-opentelemetry/src/core/sampling.rs
+++ b/datadog-opentelemetry/src/core/sampling.rs
@@ -124,8 +124,8 @@ impl SamplingMechanism {
     }
 
     /// Returns the string representation of the sampling mechanism.
-    pub fn to_cow(&self) -> Cow<'static, str> {
-        match *self {
+    pub fn to_cow(self) -> Cow<'static, str> {
+        match self {
             mechanism::DEFAULT => Cow::Borrowed("-0"),
             mechanism::AGENT_RATE_BY_SERVICE => Cow::Borrowed("-1"),
             mechanism::REMOTE_RATE => Cow::Borrowed("-2"),

--- a/datadog-opentelemetry/src/propagation/carrier.rs
+++ b/datadog-opentelemetry/src/propagation/carrier.rs
@@ -26,6 +26,7 @@ pub trait Extractor {
     fn get(&self, key: &str) -> Option<&str>;
 
     /// Get all keys from the carrier.
+    #[allow(unused)]
     fn keys(&self) -> Vec<&str>;
 }
 


### PR DESCRIPTION
# What does this PR do?

Remove warning and clippy suggestion that idk how they got in.