### PR TITLE
chore(metrics): use hyper-client with isolated runtime for HTTP metrics export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,16 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,8 +1468,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "opentelemetry",
- "reqwest",
+ "tokio",
 ]
 
 [[package]]
@@ -1494,7 +1487,6 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.1",
- "reqwest",
  "thiserror 2.0.14",
  "tokio",
  "tonic",
@@ -1936,40 +1928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,18 +2072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,9 +2187,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -2510,24 +2453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,19 +2685,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -82,7 +82,7 @@ criterion = "0.5.1"
 [features]
 default = ["metrics-grpc"]
 metrics-grpc = ["opentelemetry-otlp", "opentelemetry-otlp/grpc-tonic"]
-metrics-http = ["opentelemetry-otlp", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-blocking-client"]
+metrics-http = ["opentelemetry-otlp", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/hyper-client"]
 test-utils = ["libdd-data-pipeline/test-utils", "criterion", "metrics-grpc", "metrics-http"]
 
 [[bench]]

--- a/datadog-opentelemetry/src/telemetry_metrics_exporter.rs
+++ b/datadog-opentelemetry/src/telemetry_metrics_exporter.rs
@@ -5,10 +5,17 @@ use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::metrics::Temporality;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::core::telemetry;
 use crate::metrics_exporter::OtlpProtocol;
+
+#[cfg(feature = "metrics-http")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "metrics-http")]
+static HTTP_RUNTIME: OnceLock<Option<Arc<tokio::runtime::Runtime>>> = OnceLock::new();
 
 #[derive(Debug)]
 pub struct TelemetryTrackingExporter<E> {
@@ -23,11 +30,47 @@ impl<E> TelemetryTrackingExporter<E> {
             protocol,
         }
     }
+
+    #[cfg(feature = "metrics-http")]
+    fn get_http_runtime() -> Option<Arc<tokio::runtime::Runtime>> {
+        HTTP_RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map(Arc::new)
+                .ok()
+        })
+        .clone()
+    }
+
+    #[cfg(feature = "metrics-http")]
+    async fn export_http(
+        &self,
+        metrics: &ResourceMetrics,
+    ) -> OTelSdkResult
+    where
+        E: PushMetricExporter + Send + Sync,
+    {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return self.inner.export(metrics).await;
+        }
+
+        let Some(runtime) = Self::get_http_runtime() else {
+            return self.inner.export(metrics).await;
+        };
+
+        // SAFETY: metrics valid for duration of block_on
+        let metrics_ptr = metrics as *const ResourceMetrics;
+        let inner = &self.inner;
+        runtime.block_on(async move {
+            unsafe { inner.export(&*metrics_ptr).await }
+        })
+    }
 }
 
 impl<E> PushMetricExporter for TelemetryTrackingExporter<E>
 where
-    E: PushMetricExporter,
+    E: PushMetricExporter + Send + Sync,
 {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
         use telemetry::TelemetryMetric::*;
@@ -47,7 +90,17 @@ where
 
         telemetry::add_point(1.0, attempts);
 
-        match self.inner.export(metrics).await {
+        #[cfg(feature = "metrics-http")]
+        let result = if matches!(self.protocol, OtlpProtocol::HttpProtobuf | OtlpProtocol::HttpJson) {
+            self.export_http(metrics).await
+        } else {
+            self.inner.export(metrics).await
+        };
+
+        #[cfg(not(feature = "metrics-http"))]
+        let result = self.inner.export(metrics).await;
+
+        match result {
             Ok(()) => {
                 telemetry::add_point(1.0, successes);
                 Ok(())


### PR DESCRIPTION
# What does this PR do?

Removes `reqwest-blocking-client` dependency and updates metrics HTTP export to use `hyper-client` with an isolated Tokio runtime.

# Motivation

- Aligns HTTP metrics export with other components using `hyper` (ex: remote config)
- Removes the `reqwest-blocking-client` dependency
- The regular `PeriodicReader` only supports `grpc-tonic` and `reqwest-blocking-client`; `hyper` is not supported. This PR makes `hyper` work synchronously by using an isolated Tokio runtime with `block_on` in the exporter, allowing us to use the regular `PeriodicReader` instead of the experimental `periodic_reader_with_async_runtime` feature.

# Additional Notes

- Introduces an isolated Tokio runtime (`HTTP_RUNTIME`) using `OnceLock` for HTTP metrics export
- The `export_http` method detects if already in a Tokio runtime and uses it directly, otherwise uses the isolated runtime