### PR TITLE
chore(api)!: cleanup metrics and logs API

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/mod.rs
+++ b/datadog-opentelemetry/src/core/configuration/mod.rs
@@ -25,5 +25,7 @@ pub(crate) mod remote_config;
 mod sources;
 mod supported_configurations;
 
-pub use configuration::{Config, ConfigBuilder, SamplingRuleConfig, TracePropagationStyle};
+pub use configuration::{
+    Config, ConfigBuilder, OtlpProtocol, SamplingRuleConfig, TracePropagationStyle,
+};
 pub(crate) use configuration::{ConfigurationProvider, RemoteConfigUpdate};

--- a/datadog-opentelemetry/src/otlp_utils.rs
+++ b/datadog-opentelemetry/src/otlp_utils.rs
@@ -1,53 +1,12 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-
 use opentelemetry_sdk::Resource;
 
-use crate::core::configuration::Config;
+use crate::{configuration::OtlpProtocol, core::configuration::Config};
 
 pub(crate) const DEFAULT_OTLP_GRPC_PORT: u16 = 4317;
 pub(crate) const DEFAULT_OTLP_HTTP_PORT: u16 = 4318;
-
-/// OTLP protocol types for OTLP export.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OtlpProtocol {
-    /// gRPC protocol
-    Grpc,
-    /// HTTP with protobuf encoding
-    HttpProtobuf,
-    /// HTTP with JSON encoding
-    HttpJson,
-}
-
-impl FromStr for OtlpProtocol {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
-        if s.eq_ignore_ascii_case("grpc") {
-            Ok(OtlpProtocol::Grpc)
-        } else if s.eq_ignore_ascii_case("http/protobuf") {
-            Ok(OtlpProtocol::HttpProtobuf)
-        } else if s.eq_ignore_ascii_case("http/json") {
-            Ok(OtlpProtocol::HttpJson)
-        } else {
-            Err(format!("Invalid OTLP protocol: {}", s))
-        }
-    }
-}
-
-impl OtlpProtocol {
-    /// Parse a protocol string, returning None for empty strings
-    pub(crate) fn parse_optional(s: String) -> Option<Self> {
-        if s.trim().is_empty() {
-            None
-        } else {
-            s.parse().ok()
-        }
-    }
-}
 
 /// Builds the OpenTelemetry Resource by merging Datadog config with provided resource.
 ///
@@ -217,16 +176,4 @@ pub(crate) fn get_otlp_logs_timeout(config: &Config) -> u32 {
         return timeout;
     }
     config.otlp_timeout()
-}
-
-/// Parse a temporality preference string to Temporality enum
-pub(crate) fn parse_temporality(s: String) -> Option<opentelemetry_sdk::metrics::Temporality> {
-    let s = s.trim().to_lowercase();
-    if s == "cumulative" {
-        Some(opentelemetry_sdk::metrics::Temporality::Cumulative)
-    } else if s == "delta" || s.is_empty() {
-        Some(opentelemetry_sdk::metrics::Temporality::Delta)
-    } else {
-        None
-    }
 }

--- a/datadog-opentelemetry/src/telemetry_logs_exporter.rs
+++ b/datadog-opentelemetry/src/telemetry_logs_exporter.rs
@@ -5,8 +5,8 @@ use opentelemetry_otlp::LogExporter;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::LogBatch;
 
+use crate::configuration::OtlpProtocol;
 use crate::core::telemetry;
-use crate::otlp_utils::OtlpProtocol;
 
 #[derive(Debug)]
 pub struct TelemetryTrackingLogExporter {

--- a/datadog-opentelemetry/src/telemetry_metrics_exporter.rs
+++ b/datadog-opentelemetry/src/telemetry_metrics_exporter.rs
@@ -7,8 +7,8 @@ use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::metrics::Temporality;
 use std::time::Duration;
 
+use crate::configuration::OtlpProtocol;
 use crate::core::telemetry;
-use crate::otlp_utils::OtlpProtocol;
 
 #[derive(Debug)]
 pub struct TelemetryTrackingExporter<E> {

--- a/datadog-opentelemetry/tests/integration_tests/logs.rs
+++ b/datadog-opentelemetry/tests/integration_tests/logs.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use datadog_opentelemetry::configuration::Config;
+use datadog_opentelemetry::configuration::OtlpProtocol;
 use datadog_opentelemetry::logs;
-use datadog_opentelemetry::OtlpProtocol;
 use opentelemetry::logs::LoggerProvider;
 
 const TEST_LOGGER_NAME: &str = "test-logger";

--- a/datadog-opentelemetry/tests/integration_tests/metrics.rs
+++ b/datadog-opentelemetry/tests/integration_tests/metrics.rs
@@ -4,8 +4,8 @@
 use std::time::Duration;
 
 use datadog_opentelemetry::configuration::Config;
+use datadog_opentelemetry::configuration::OtlpProtocol;
 use datadog_opentelemetry::metrics;
-use datadog_opentelemetry::OtlpProtocol;
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
 


### PR DESCRIPTION
# What does this PR do?

* Move `OtlpProtocol` to the config module an expose it in the documentation
* Make `init_local` methods for logs and metrics __not__ return an empty tuple 

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
