### PR TITLE
refactor(sampling): split out types and otel dependencies

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libdd_telemetry::data::Configuration;
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
+use std::fmt::Display;
 use std::ops::Deref;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::{borrow::Cow, fmt::Display, str::FromStr, sync::OnceLock};
+use std::{borrow::Cow, sync::OnceLock};
 
 use rustc_version_runtime::version;
 
+use crate::core::configuration::sampling_rule_config::{ParsedSamplingRules, SamplingRuleConfig};
 use crate::core::configuration::sources::{
     CompositeConfigSourceResult, CompositeSource, ConfigKey, ConfigSourceOrigin,
 };
@@ -83,91 +85,10 @@ impl Default for RemoteConfigCallbacks {
         Self::new()
     }
 }
-
-/// Configuration for a single sampling rule
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct SamplingRuleConfig {
-    /// The sample rate to apply (0.0-1.0)
-    pub sample_rate: f64,
-
-    /// Optional service name pattern to match
-    #[serde(default)]
-    pub service: Option<String>,
-
-    /// Optional span name pattern to match
-    #[serde(default)]
-    pub name: Option<String>,
-
-    /// Optional resource name pattern to match
-    #[serde(default)]
-    pub resource: Option<String>,
-
-    /// Tags that must match (key-value pairs)
-    #[serde(default)]
-    pub tags: HashMap<String, String>,
-
-    /// Where this rule comes from (customer, dynamic, default)
-    // TODO(paullgdc): this value should not be definable by customers
-    #[serde(default = "default_provenance")]
-    pub provenance: String,
-}
-
-impl Display for SamplingRuleConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::json!(self))
-    }
-}
-
-fn default_provenance() -> String {
-    "default".to_string()
-}
-
 pub const TRACER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const DATADOG_TAGS_MAX_LENGTH: usize = 512;
 const RC_DEFAULT_POLL_INTERVAL: f64 = 5.0; // 5 seconds is the highest interval allowed by the spec
-
-#[derive(Debug, Default, Clone, PartialEq)]
-struct ParsedSamplingRules {
-    rules: Vec<SamplingRuleConfig>,
-}
-
-impl Deref for ParsedSamplingRules {
-    type Target = [SamplingRuleConfig];
-
-    fn deref(&self) -> &Self::Target {
-        &self.rules
-    }
-}
-
-impl From<ParsedSamplingRules> for Vec<SamplingRuleConfig> {
-    fn from(parsed: ParsedSamplingRules) -> Self {
-        parsed.rules
-    }
-}
-
-impl FromStr for ParsedSamplingRules {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.trim().is_empty() {
-            return Ok(ParsedSamplingRules::default());
-        }
-        // DD_TRACE_SAMPLING_RULES is expected to be a JSON array of SamplingRuleConfig objects.
-        let rules_vec: Vec<SamplingRuleConfig> = serde_json::from_str(s)?;
-        Ok(ParsedSamplingRules { rules: rules_vec })
-    }
-}
-
-impl Display for ParsedSamplingRules {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            serde_json::to_string(&self.rules).unwrap_or_default()
-        )
-    }
-}
 
 /// OTLP protocol types for OTLP export.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2467,6 +2388,7 @@ impl ConfigBuilder {
 #[cfg(test)]
 mod tests {
     use libdd_telemetry::data::ConfigurationOrigin;
+    use std::collections::HashMap;
 
     use super::Config;
     use super::*;

--- a/datadog-opentelemetry/src/core/configuration/mod.rs
+++ b/datadog-opentelemetry/src/core/configuration/mod.rs
@@ -22,10 +22,10 @@
 #[allow(clippy::module_inception)]
 mod configuration;
 pub(crate) mod remote_config;
+mod sampling_rule_config;
 mod sources;
 mod supported_configurations;
 
-pub use configuration::{
-    Config, ConfigBuilder, OtlpProtocol, SamplingRuleConfig, TracePropagationStyle,
-};
+pub use configuration::{Config, ConfigBuilder, OtlpProtocol, TracePropagationStyle};
 pub(crate) use configuration::{ConfigurationProvider, RemoteConfigUpdate};
+pub use sampling_rule_config::SamplingRuleConfig;

--- a/datadog-opentelemetry/src/core/configuration/sampling_rule_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/sampling_rule_config.rs
@@ -1,0 +1,88 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::ops::Deref;
+use std::str::FromStr;
+
+/// Configuration for a single sampling rule
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct SamplingRuleConfig {
+    /// The sample rate to apply (0.0-1.0)
+    pub sample_rate: f64,
+
+    /// Optional service name pattern to match
+    #[serde(default)]
+    pub service: Option<String>,
+
+    /// Optional span name pattern to match
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Optional resource name pattern to match
+    #[serde(default)]
+    pub resource: Option<String>,
+
+    /// Tags that must match (key-value pairs)
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+
+    /// Where this rule comes from (customer, dynamic, default)
+    // TODO(paullgdc): this value should not be definable by customers
+    #[serde(default = "default_provenance")]
+    pub provenance: String,
+}
+
+impl Display for SamplingRuleConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::json!(self))
+    }
+}
+
+fn default_provenance() -> String {
+    "default".to_string()
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct ParsedSamplingRules {
+    pub(crate) rules: Vec<SamplingRuleConfig>,
+}
+
+impl Deref for ParsedSamplingRules {
+    type Target = [SamplingRuleConfig];
+
+    fn deref(&self) -> &Self::Target {
+        &self.rules
+    }
+}
+
+impl From<ParsedSamplingRules> for Vec<SamplingRuleConfig> {
+    fn from(parsed: ParsedSamplingRules) -> Self {
+        parsed.rules
+    }
+}
+
+impl FromStr for ParsedSamplingRules {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            return Ok(ParsedSamplingRules::default());
+        }
+        // DD_TRACE_SAMPLING_RULES is expected to be a JSON array of SamplingRuleConfig objects.
+        let rules_vec: Vec<SamplingRuleConfig> = serde_json::from_str(s)?;
+        Ok(ParsedSamplingRules { rules: rules_vec })
+    }
+}
+
+impl Display for ParsedSamplingRules {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self.rules).unwrap_or_default()
+        )
+    }
+}

--- a/datadog-opentelemetry/src/sampling/datadog_sampler.rs
+++ b/datadog-opentelemetry/src/sampling/datadog_sampler.rs
@@ -23,6 +23,10 @@ use super::rate_limiter::RateLimiter;
 use super::rate_sampler::RateSampler;
 use super::rules_sampler::RulesSampler;
 
+// HTTP status code attribute constants
+const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
+const HTTP_STATUS_CODE: &str = "http.status_code";
+
 fn matcher_from_rule(rule: &str) -> Option<GlobMatcher> {
     (rule != NO_RULE).then(|| GlobMatcher::new(rule))
 }
@@ -140,9 +144,7 @@ impl SamplingRule {
 
             // Special handling for rules defined with "http.status_code" or
             // "http.response.status_code"
-            if rule_tag_key_str == "http.status_code"
-                || rule_tag_key_str
-                    == opentelemetry_semantic_conventions::trace::HTTP_RESPONSE_STATUS_CODE
+            if rule_tag_key_str == HTTP_STATUS_CODE || rule_tag_key_str == HTTP_RESPONSE_STATUS_CODE
             {
                 match self.match_http_status_code_rule(matcher, span) {
                     Some(true) => continue,             // Status code matched
@@ -200,7 +202,7 @@ impl SamplingRule {
         span: &impl SpanProperties,
     ) -> Option<bool> {
         span.status_code().and_then(|status_code| {
-            let status_value = opentelemetry::Value::I64(i64::from(status_code));
+            let status_value = ValueI64(i64::from(status_code));
             self.match_attribute_value(&status_value, matcher)
         })
     }
@@ -470,6 +472,18 @@ fn format_sampling_rate(rate: f64) -> Option<String> {
     })
 }
 
+struct ValueI64(i64);
+
+impl ValueLike for ValueI64 {
+    fn extract_float(&self) -> Option<f64> {
+        Some(self.0 as f64)
+    }
+
+    fn extract_string(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Owned(self.0.to_string()))
+    }
+}
+
 pub struct TraceRootSamplingInfo {
     mechanism: SamplingMechanism,
     rate: f64,
@@ -571,76 +585,292 @@ impl DdSamplingResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mappings::get_otel_operation_name_v2;
     use crate::sampling::constants::{
         attr::{ENV_TAG, RESOURCE_TAG},
         pattern,
     };
-    use crate::sampling::otel_mappings::{OtelSamplingData, PreSampledSpan};
-    use opentelemetry::trace::{SpanKind, TraceId};
-    use opentelemetry::{Key, KeyValue, Value};
-    use opentelemetry_sdk::Resource as SdkResource;
-    use opentelemetry_semantic_conventions::{
-        attribute::{
-            DB_SYSTEM_NAME, HTTP_REQUEST_METHOD, MESSAGING_OPERATION_TYPE, MESSAGING_SYSTEM,
-        },
-        resource::SERVICE_NAME,
-        trace::{HTTP_RESPONSE_STATUS_CODE, NETWORK_PROTOCOL_NAME},
-    };
-    use std::sync::{Arc, RwLock};
+    use std::borrow::Cow;
+    use std::collections::HashMap;
 
-    fn create_empty_resource() -> opentelemetry_sdk::Resource {
-        opentelemetry_sdk::Resource::builder_empty().build()
+    // Test-only semantic convention constants
+    const HTTP_REQUEST_METHOD: &str = "http.request.method";
+    const SERVICE_NAME: &str = "service.name";
+
+    use super::{HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE};
+
+    // ============================================================================
+    // Test-only data structures
+    // ============================================================================
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestTraceId {
+        bytes: [u8; 16],
     }
 
-    // Helper function to create an empty resource wrapped in Arc<RwLock> for DatadogSampler
-    fn create_empty_resource_arc() -> Arc<RwLock<opentelemetry_sdk::Resource>> {
-        Arc::new(RwLock::new(
-            opentelemetry_sdk::Resource::builder_empty().build(),
-        ))
+    impl TestTraceId {
+        fn from_bytes(bytes: [u8; 16]) -> Self {
+            Self { bytes }
+        }
     }
 
-    fn create_resource(res: String) -> Arc<RwLock<SdkResource>> {
-        let attributes = vec![
-            KeyValue::new(SERVICE_NAME, res), // String `res` is Into<Value>
-        ];
-        let resource: SdkResource = SdkResource::builder_empty()
-            .with_attributes(attributes)
-            .build();
-        Arc::new(RwLock::new(resource))
+    impl TraceIdLike for TestTraceId {
+        fn to_u128(&self) -> u128 {
+            u128::from_be_bytes(self.bytes)
+        }
     }
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestValue {
+        String(String),
+        I64(i64),
+        F64(f64),
+    }
+
+    impl ValueLike for TestValue {
+        fn extract_float(&self) -> Option<f64> {
+            match self {
+                TestValue::I64(i) => Some(*i as f64),
+                TestValue::F64(f) => Some(*f),
+                _ => None,
+            }
+        }
+
+        fn extract_string(&self) -> Option<Cow<'_, str>> {
+            match self {
+                TestValue::String(s) => Some(Cow::Borrowed(s.as_str())),
+                TestValue::I64(i) => Some(Cow::Owned(i.to_string())),
+                TestValue::F64(f) => Some(Cow::Owned(f.to_string())),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestAttribute {
+        key: String,
+        value: TestValue,
+    }
+
+    impl TestAttribute {
+        fn new(key: impl Into<String>, value: impl Into<TestValue>) -> Self {
+            Self {
+                key: key.into(),
+                value: value.into(),
+            }
+        }
+    }
+
+    impl AttributeLike for TestAttribute {
+        type Value = TestValue;
+
+        fn key(&self) -> &str {
+            &self.key
+        }
+
+        fn value(&self) -> &Self::Value {
+            &self.value
+        }
+    }
+
+    impl From<&str> for TestValue {
+        fn from(s: &str) -> Self {
+            TestValue::String(s.to_string())
+        }
+    }
+
+    impl From<String> for TestValue {
+        fn from(s: String) -> Self {
+            TestValue::String(s)
+        }
+    }
+
+    struct TestSpan<'a> {
+        name: &'a str,
+        attributes: &'a [TestAttribute],
+    }
+
+    impl<'a> TestSpan<'a> {
+        fn new(name: &'a str, attributes: &'a [TestAttribute]) -> Self {
+            Self { name, attributes }
+        }
+
+        fn get_operation_name(&self) -> Cow<'_, str> {
+            // Check for HTTP spans - label them all as client spans
+            if self
+                .attributes
+                .iter()
+                .any(|attr| attr.key() == HTTP_REQUEST_METHOD)
+            {
+                return Cow::Borrowed("http.client.request");
+            }
+
+            // Default fallback
+            Cow::Borrowed("internal")
+        }
+    }
+
+    impl<'a> SpanProperties for TestSpan<'a> {
+        type Attribute = TestAttribute;
+
+        fn operation_name(&self) -> Cow<'_, str> {
+            self.get_operation_name()
+        }
+
+        fn service(&self) -> Cow<'_, str> {
+            self.attributes
+                .iter()
+                .find(|attr| attr.key() == SERVICE_NAME)
+                .and_then(|attr| attr.value().extract_string())
+                .unwrap_or(Cow::Borrowed(""))
+        }
+
+        fn env(&self) -> Cow<'_, str> {
+            self.attributes
+                .iter()
+                .find(|attr| attr.key() == "datadog.env" || attr.key() == ENV_TAG)
+                .and_then(|attr| attr.value().extract_string())
+                .unwrap_or(Cow::Borrowed(""))
+        }
+
+        fn resource(&self) -> Cow<'_, str> {
+            self.attributes
+                .iter()
+                .find(|attr| attr.key() == RESOURCE_TAG)
+                .and_then(|attr| attr.value().extract_string())
+                .unwrap_or(Cow::Borrowed(self.name))
+        }
+
+        fn status_code(&self) -> Option<u32> {
+            self.attributes
+                .iter()
+                .find(|attr| {
+                    attr.key() == HTTP_RESPONSE_STATUS_CODE || attr.key() == HTTP_STATUS_CODE
+                })
+                .and_then(|attr| match attr.value() {
+                    TestValue::I64(i) => Some(*i as u32),
+                    _ => None,
+                })
+        }
+
+        fn attributes<'b>(&'b self) -> impl Iterator<Item = &'b Self::Attribute>
+        where
+            Self: 'b,
+        {
+            self.attributes.iter()
+        }
+
+        fn get_alternate_key<'b>(&self, key: &'b str) -> Option<Cow<'b, str>> {
+            match key {
+                HTTP_RESPONSE_STATUS_CODE => Some(Cow::Borrowed(HTTP_STATUS_CODE)),
+                HTTP_REQUEST_METHOD => Some(Cow::Borrowed("http.method")),
+                _ => None,
+            }
+        }
+    }
+
+    struct TestSamplingData<'a> {
+        is_parent_sampled: Option<bool>,
+        trace_id: &'a TestTraceId,
+        name: &'a str,
+        attributes: &'a [TestAttribute],
+    }
+
+    impl<'a> TestSamplingData<'a> {
+        fn new(
+            is_parent_sampled: Option<bool>,
+            trace_id: &'a TestTraceId,
+            name: &'a str,
+            attributes: &'a [TestAttribute],
+        ) -> Self {
+            Self {
+                is_parent_sampled,
+                trace_id,
+                name,
+                attributes,
+            }
+        }
+    }
+
+    impl<'a> SamplingData for TestSamplingData<'a> {
+        type TraceId = TestTraceId;
+        type Properties<'b>
+            = TestSpan<'b>
+        where
+            Self: 'b;
+
+        fn is_parent_sampled(&self) -> Option<bool> {
+            self.is_parent_sampled
+        }
+
+        fn trace_id(&self) -> &Self::TraceId {
+            self.trace_id
+        }
+
+        fn with_span_properties<S, T, F>(&self, s: &S, f: F) -> T
+        where
+            F: for<'b> Fn(&S, &TestSpan<'b>) -> T,
+        {
+            let span = TestSpan::new(self.name, self.attributes);
+            f(s, &span)
+        }
+    }
+
+    struct TestAttributeFactory;
+
+    impl crate::sampling::AttributeFactory for TestAttributeFactory {
+        type Attribute = TestAttribute;
+
+        fn create_i64(&self, key: &'static str, value: i64) -> Self::Attribute {
+            TestAttribute::new(key, TestValue::I64(value))
+        }
+
+        fn create_f64(&self, key: &'static str, value: f64) -> Self::Attribute {
+            TestAttribute::new(key, TestValue::F64(value))
+        }
+
+        fn create_string(&self, key: &'static str, value: Cow<'static, str>) -> Self::Attribute {
+            TestAttribute::new(key, TestValue::String(value.into_owned()))
+        }
+    }
+
+    // ============================================================================
+    // Test helper functions
+    // ============================================================================
 
     // Helper function to create a trace ID
-    fn create_trace_id() -> TraceId {
+    fn create_trace_id() -> TestTraceId {
         let bytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-        TraceId::from_bytes(bytes)
+        TestTraceId::from_bytes(bytes)
     }
 
-    // Helper function to create attributes for testing
-    fn create_attributes(resource: &'static str, env: &'static str) -> Vec<KeyValue> {
+    // Helper function to create attributes for testing (with resource and env)
+    fn create_attributes(resource: &'static str, env: &'static str) -> Vec<TestAttribute> {
         vec![
-            KeyValue::new(RESOURCE_TAG, resource),
-            KeyValue::new("datadog.env", env),
+            TestAttribute::new(RESOURCE_TAG, resource),
+            TestAttribute::new("datadog.env", env),
+        ]
+    }
+
+    // Helper function to create attributes with service
+    fn create_attributes_with_service(
+        service: String,
+        resource: &'static str,
+        env: &'static str,
+    ) -> Vec<TestAttribute> {
+        vec![
+            TestAttribute::new(SERVICE_NAME, service),
+            TestAttribute::new(RESOURCE_TAG, resource),
+            TestAttribute::new("datadog.env", env),
         ]
     }
 
     // Helper function to create SamplingData for testing
     fn create_sampling_data<'a>(
         is_parent_sampled: Option<bool>,
-        trace_id: &'a TraceId,
+        trace_id: &'a TestTraceId,
         name: &'a str,
-        span_kind: SpanKind,
-        attributes: &'a [KeyValue],
-        resource: &'a RwLock<opentelemetry_sdk::Resource>,
-    ) -> OtelSamplingData<'a> {
-        OtelSamplingData::new(
-            is_parent_sampled,
-            trace_id,
-            name,
-            span_kind,
-            attributes,
-            resource,
-        )
+        attributes: &'a [TestAttribute],
+    ) -> TestSamplingData<'a> {
+        TestSamplingData::new(is_parent_sampled, trace_id, name, attributes)
     }
 
     #[test]
@@ -718,11 +948,8 @@ mod tests {
         // Create a span with some attributes
         let attributes = create_attributes("some-resource", "some-env");
 
-        // Empty resource for testing (unwrapped for the test)
-        let empty_resource = create_empty_resource();
-
         // Both rules should match any span since they have no criteria
-        let span = PreSampledSpan::new("", SpanKind::Client, &attributes, &empty_resource);
+        let span = TestSpan::new("", &attributes);
         assert!(rule.matches(&span));
         assert!(rule_with_empty_strings.matches(&span));
     }
@@ -773,35 +1000,26 @@ mod tests {
 
     #[test]
     fn test_service_key_generation() {
-        // Create resource with test service name
         let test_service_name = "test-service".to_string();
-        let resource = create_resource(test_service_name.clone());
         let sampler = DatadogSampler::new(vec![], 100);
 
         // Test with service and env
-        // The 'service' in create_attributes is not used for the service part of the key,
-        // but ENV_TAG is still correctly picked up from attributes.
-        let attrs = create_attributes("resource", "production");
-        let res = &resource.read().unwrap();
-        let span = PreSampledSpan::new("test-span", SpanKind::Internal, attrs.as_slice(), res);
+        let attrs =
+            create_attributes_with_service(test_service_name.clone(), "resource", "production");
+        let span = TestSpan::new("test-span", attrs.as_slice());
         assert_eq!(
             sampler.service_key(&span),
-            // Expect the service name from the resource
             format!("service:{test_service_name},env:production")
         );
 
         // Test with missing env
-        // The 'service' in these attributes is also not used for the service part of the key.
-        let attrs_no_env = vec![KeyValue::new(RESOURCE_TAG, "resource")];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Internal,
-            attrs_no_env.as_slice(),
-            res,
-        );
+        let attrs_no_env = vec![
+            TestAttribute::new(SERVICE_NAME, test_service_name.clone()),
+            TestAttribute::new(RESOURCE_TAG, "resource"),
+        ];
+        let span = TestSpan::new("test-span", attrs_no_env.as_slice());
         assert_eq!(
             sampler.service_key(&span),
-            // Expect the service name from the resource and an empty env
             format!("service:{test_service_name},env:")
         );
     }
@@ -876,10 +1094,12 @@ mod tests {
 
         // Test with a specific service that should match the first rule (rule1)
         {
-            let resource = create_resource("service1".to_string());
-            let attrs1 = create_attributes("resource_val_for_attr1", "prod");
-            let res = resource.read().unwrap();
-            let span = PreSampledSpan::new("test-span", SpanKind::Client, attrs1.as_slice(), &res);
+            let attrs1 = create_attributes_with_service(
+                "service1".to_string(),
+                "resource_val_for_attr1",
+                "prod",
+            );
+            let span = TestSpan::new("test-span", attrs1.as_slice());
             let matching_rule_for_attrs1 = sampler.find_matching_rule(&span);
             assert!(
                 matching_rule_for_attrs1.is_some(),
@@ -892,10 +1112,12 @@ mod tests {
 
         // Test with a specific service that should match the second rule (rule2)
         {
-            let resource = create_resource("service2".to_string());
-            let attrs2 = create_attributes("resource_val_for_attr2", "prod");
-            let res = resource.read().unwrap();
-            let span = PreSampledSpan::new("test-span", SpanKind::Client, attrs2.as_slice(), &res);
+            let attrs2 = create_attributes_with_service(
+                "service2".to_string(),
+                "resource_val_for_attr2",
+                "prod",
+            );
+            let span = TestSpan::new("test-span", attrs2.as_slice());
             let matching_rule_for_attrs2 = sampler.find_matching_rule(&span);
             assert!(
                 matching_rule_for_attrs2.is_some(),
@@ -908,10 +1130,12 @@ mod tests {
 
         // Test with a service that matches the wildcard rule (rule3)
         {
-            let resource = create_resource("service3".to_string());
-            let attrs3 = create_attributes("resource_val_for_attr3", "prod");
-            let res = resource.read().unwrap();
-            let span = PreSampledSpan::new("test-span", SpanKind::Client, attrs3.as_slice(), &res);
+            let attrs3 = create_attributes_with_service(
+                "service3".to_string(),
+                "resource_val_for_attr3",
+                "prod",
+            );
+            let span = TestSpan::new("test-span", attrs3.as_slice());
             let matching_rule_for_attrs3 = sampler.find_matching_rule(&span);
             assert!(
                 matching_rule_for_attrs3.is_some(),
@@ -924,10 +1148,12 @@ mod tests {
 
         // Test with a service that doesn't match any rule's service pattern
         {
-            let resource = create_resource("other_sampler_service".to_string());
-            let attrs4 = create_attributes("resource_val_for_attr4", "prod");
-            let res = resource.read().unwrap();
-            let span = PreSampledSpan::new("test-span", SpanKind::Client, attrs4.as_slice(), &res);
+            let attrs4 = create_attributes_with_service(
+                "other_sampler_service".to_string(),
+                "resource_val_for_attr4",
+                "prod",
+            );
+            let span = TestSpan::new("test-span", attrs4.as_slice());
             let matching_rule_for_attrs4 = sampler.find_matching_rule(&span);
             assert!(
                 matching_rule_for_attrs4.is_none(),
@@ -985,7 +1211,7 @@ mod tests {
         };
 
         let attrs = sampling_result
-            .to_dd_sampling_tags(&crate::sampling::OtelAttributeFactory)
+            .to_dd_sampling_tags(&TestAttributeFactory)
             .unwrap_or_default();
 
         // Verify the number of attributes (decision_maker + priority + rule_rate + ksr)
@@ -998,10 +1224,10 @@ mod tests {
         let mut found_ksr = false;
 
         for attr in &attrs {
-            match attr.key.as_str() {
+            match attr.key() {
                 SAMPLING_DECISION_MAKER_TAG_KEY => {
-                    let value_str = match &attr.value {
-                        opentelemetry::Value::String(s) => s.to_string(),
+                    let value_str = match attr.value() {
+                        TestValue::String(s) => s.to_string(),
                         _ => panic!("Expected string value for decision maker tag"),
                     };
                     assert_eq!(value_str, mechanism.to_cow());
@@ -1011,16 +1237,16 @@ mod tests {
                     // For LocalUserTraceSamplingRule with KEEP, it should be USER_KEEP
                     let expected_priority = mechanism.to_priority(true).into_i8() as i64;
 
-                    let value_int = match attr.value {
-                        opentelemetry::Value::I64(i) => i,
+                    let value_int = match attr.value() {
+                        TestValue::I64(i) => *i,
                         _ => panic!("Expected integer value for priority tag"),
                     };
                     assert_eq!(value_int, expected_priority);
                     found_priority = true;
                 }
                 SAMPLING_RULE_RATE_TAG_KEY => {
-                    let value_float = match attr.value {
-                        opentelemetry::Value::F64(f) => f,
+                    let value_float = match attr.value() {
+                        TestValue::F64(f) => *f,
                         _ => panic!("Expected float value for rule rate tag"),
                     };
                     assert_eq!(value_float, sample_rate);
@@ -1056,7 +1282,7 @@ mod tests {
             }),
         };
         let attrs_with_limit = sampling_result
-            .to_dd_sampling_tags(&crate::sampling::OtelAttributeFactory)
+            .to_dd_sampling_tags(&TestAttributeFactory)
             .unwrap_or_default();
 
         // With rate limiting, there should be one more attribute
@@ -1065,9 +1291,9 @@ mod tests {
         // Check for rate limit attribute
         let mut found_limit = false;
         for attr in &attrs_with_limit {
-            if attr.key.as_str() == RL_EFFECTIVE_RATE {
-                let value_float = match attr.value {
-                    opentelemetry::Value::F64(f) => f,
+            if attr.key() == RL_EFFECTIVE_RATE {
+                let value_float = match attr.value() {
+                    TestValue::F64(f) => *f,
                     _ => panic!("Expected float value for rate limit tag"),
                 };
                 assert_eq!(value_float, rate_limit);
@@ -1093,7 +1319,7 @@ mod tests {
         };
 
         let agent_attrs = sampling_result
-            .to_dd_sampling_tags(&crate::sampling::OtelAttributeFactory)
+            .to_dd_sampling_tags(&TestAttributeFactory)
             .unwrap_or_default();
 
         // Verify the number of attributes (should be 4: decision_maker + priority +
@@ -1104,18 +1330,18 @@ mod tests {
         let mut found_agent_rate = false;
         let mut found_ksr = false;
         for attr in &agent_attrs {
-            match attr.key.as_str() {
+            match attr.key() {
                 SAMPLING_AGENT_RATE_TAG_KEY => {
-                    let value_float = match attr.value {
-                        opentelemetry::Value::F64(f) => f,
+                    let value_float = match attr.value() {
+                        TestValue::F64(f) => *f,
                         _ => panic!("Expected float value for agent rate tag"),
                     };
                     assert_eq!(value_float, agent_rate);
                     found_agent_rate = true;
                 }
                 SAMPLING_KNUTH_RATE_TAG_KEY => {
-                    let value_str = match &attr.value {
-                        opentelemetry::Value::String(s) => s.to_string(),
+                    let value_str = match attr.value() {
+                        TestValue::String(s) => s.to_string(),
                         _ => panic!("Expected string value for ksr tag"),
                     };
                     assert_eq!(value_str, "0.75");
@@ -1134,7 +1360,7 @@ mod tests {
         // Also check that the SAMPLING_RULE_RATE_TAG_KEY is NOT present for agent mechanism
         for attr in &agent_attrs {
             assert_ne!(
-                attr.key.as_str(),
+                attr.key(),
                 SAMPLING_RULE_RATE_TAG_KEY,
                 "Rule rate tag should not be present for agent mechanism"
             );
@@ -1183,20 +1409,11 @@ mod tests {
         let sampler = DatadogSampler::new(vec![], 100);
 
         // Create empty slices for attributes and links
-        let empty_attrs: &[KeyValue] = &[];
+        let empty_attrs: &[TestAttribute] = &[];
         let trace_id = create_trace_id();
-        let span_kind = SpanKind::Client;
-        let resource = create_empty_resource_arc();
 
         // Test with sampled parent context
-        let data_sampled = create_sampling_data(
-            Some(true),
-            &trace_id,
-            "span",
-            span_kind.clone(),
-            empty_attrs,
-            resource.as_ref(),
-        );
+        let data_sampled = create_sampling_data(Some(true), &trace_id, "span", empty_attrs);
         let result_sampled = sampler.sample(&data_sampled);
 
         // Should inherit the sampling decision from parent
@@ -1206,14 +1423,7 @@ mod tests {
             .is_none());
 
         // Test with non-sampled parent context
-        let data_not_sampled = create_sampling_data(
-            Some(false),
-            &trace_id,
-            "span",
-            span_kind,
-            empty_attrs,
-            resource.as_ref(),
-        );
+        let data_not_sampled = create_sampling_data(Some(false), &trace_id, "span", empty_attrs);
         let result_not_sampled = sampler.sample(&data_not_sampled);
 
         // Should inherit the sampling decision from parent
@@ -1238,19 +1448,10 @@ mod tests {
         let sampler = DatadogSampler::new(vec![rule], 100);
 
         let trace_id = create_trace_id();
-        let span_kind = SpanKind::Client;
-        let resource = create_empty_resource_arc();
 
         // Test with matching attributes
         let attrs = create_attributes("resource", "prod");
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "span",
-            span_kind.clone(),
-            attrs.as_slice(),
-            resource.as_ref(),
-        );
+        let data = create_sampling_data(None, &trace_id, "span", attrs.as_slice());
         let result = sampler.sample(&data);
 
         // Should sample and add attributes
@@ -1261,14 +1462,8 @@ mod tests {
 
         // Test with non-matching attributes
         let attrs_no_match = create_attributes("other-resource", "prod");
-        let data_no_match = create_sampling_data(
-            None,
-            &trace_id,
-            "span",
-            span_kind,
-            attrs_no_match.as_slice(),
-            resource.as_ref(),
-        );
+        let data_no_match =
+            create_sampling_data(None, &trace_id, "span", attrs_no_match.as_slice());
         let result_no_match = sampler.sample(&data_no_match);
 
         // Should still sample (default behavior when no rules match) and add attributes
@@ -1291,18 +1486,18 @@ mod tests {
         sampler.update_service_rates(rates);
 
         let trace_id = create_trace_id();
-        let span_kind = SpanKind::Client;
 
         // Test with attributes that should lead to "service:test-service,env:prod" key
-        let resource_test_service = create_resource("test-service".to_string());
-        let attrs_sample = create_attributes("any_resource_name_matching_env", "prod");
+        let attrs_sample = create_attributes_with_service(
+            "test-service".to_string(),
+            "any_resource_name_matching_env",
+            "prod",
+        );
         let data_sample = create_sampling_data(
             None,
             &trace_id,
             "span_for_test_service",
-            span_kind.clone(),
             attrs_sample.as_slice(),
-            resource_test_service.as_ref(),
         );
         let result_sample = sampler.sample(&data_sample);
         // Expect RecordAndSample because service_key will be "service:test-service,env:prod" ->
@@ -1313,15 +1508,16 @@ mod tests {
         );
 
         // Test with attributes that should lead to "service:other-service,env:prod" key
-        let resource_other_service = create_resource("other-service".to_string());
-        let attrs_no_sample = create_attributes("any_resource_name_matching_env", "prod");
+        let attrs_no_sample = create_attributes_with_service(
+            "other-service".to_string(),
+            "any_resource_name_matching_env",
+            "prod",
+        );
         let data_no_sample = create_sampling_data(
             None,
             &trace_id,
             "span_for_other_service",
-            span_kind,
             attrs_no_sample.as_slice(),
-            resource_other_service.as_ref(),
         );
         let result_no_sample = sampler.sample(&data_no_sample);
         // Expect Drop because service_key will be "service:other-service,env:prod" -> rate 0.0
@@ -1333,14 +1529,15 @@ mod tests {
 
     #[test]
     fn test_sampling_rule_matches_float_attributes() {
-        use opentelemetry::Value;
-
         // Helper to create attributes with a float value
-        fn create_attributes_with_float(tag_key: &'static str, float_value: f64) -> Vec<KeyValue> {
+        fn create_attributes_with_float(
+            tag_key: &'static str,
+            float_value: f64,
+        ) -> Vec<TestAttribute> {
             vec![
-                KeyValue::new(RESOURCE_TAG, "resource"),
-                KeyValue::new(ENV_TAG, "prod"),
-                KeyValue::new(tag_key, Value::F64(float_value)),
+                TestAttribute::new(RESOURCE_TAG, "resource"),
+                TestAttribute::new(ENV_TAG, "prod"),
+                TestAttribute::new(tag_key, TestValue::F64(float_value)),
             ]
         }
 
@@ -1356,13 +1553,7 @@ mod tests {
 
         // Should match integer float
         let integer_float_attrs = create_attributes_with_float("float_tag", 42.0);
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            integer_float_attrs.as_slice(),
-            &resource,
-        );
+        let span = TestSpan::new("test-span", integer_float_attrs.as_slice());
         assert!(rule_integer.matches(&span));
 
         // Test case 2: Rule with wildcard pattern and non-integer float
@@ -1377,13 +1568,7 @@ mod tests {
 
         // Should match non-integer float with wildcard pattern
         let decimal_float_attrs = create_attributes_with_float("float_tag", 42.5);
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            decimal_float_attrs.as_slice(),
-            &resource,
-        );
+        let span = TestSpan::new("test-span", decimal_float_attrs.as_slice());
         assert!(rule_wildcard.matches(&span));
 
         // Test case 3: Rule with specific pattern and non-integer float
@@ -1402,13 +1587,7 @@ mod tests {
 
         // Should NOT match the exact decimal value because non-integer floats only match wildcards
         let decimal_float_attrs = create_attributes_with_float("float_tag", 42.5);
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            decimal_float_attrs.as_slice(),
-            &resource,
-        );
+        let span = TestSpan::new("test-span", decimal_float_attrs.as_slice());
         assert!(!rule_specific.matches(&span));
         // Test case 4: Pattern with partial wildcard '*' for suffix
         let rule_prefix = SamplingRule::new(
@@ -1425,433 +1604,37 @@ mod tests {
 
         // Should NOT match decimal values as we don't do partial pattern matching for non-integer
         // floats
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            decimal_float_attrs.as_slice(),
-            &resource,
-        );
+        let span = TestSpan::new("test-span", decimal_float_attrs.as_slice());
         assert!(!rule_prefix.matches(&span));
     }
 
     #[test]
-    fn test_otel_to_datadog_attribute_mapping() {
-        // Test with a rule that matches against a Datadog attribute name
-        let rule = SamplingRule::new(
+    fn test_operation_name() {
+        // Test that the sampler correctly matches rules based on operation names
+        // Operation name generation itself is tested in otel_mappings unit tests
+
+        let http_rule = SamplingRule::new(
             1.0,
             None,
+            Some("http.*.request".to_string()),
             None,
             None,
-            Some(HashMap::from([(
-                "http.response.status_code".to_string(),
-                "5*".to_string(),
-            )])),
-            None,
+            Some("default".to_string()),
         );
 
-        // Create attributes with OpenTelemetry naming convention
-        let otel_attrs = vec![KeyValue::new("http.response.status_code", 500)];
+        let sampler = DatadogSampler::new(vec![http_rule], 100);
 
-        // The rule should match because both use the same OpenTelemetry attribute name
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            otel_attrs.as_slice(),
-            &resource,
-        );
-        assert!(rule.matches(&span));
-
-        // Attributes that don't match the value pattern shouldn't match
-        let non_matching_attrs = vec![KeyValue::new("http.response.status_code", 200)];
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            non_matching_attrs.as_slice(),
-            &resource,
-        );
-        assert!(!rule.matches(&span));
-
-        // Attributes that have no mapping to the rule tag shouldn't match
-        let unrelated_attrs = vec![KeyValue::new("unrelated.attribute", "value")];
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            unrelated_attrs.as_slice(),
-            &resource,
-        );
-        assert!(!rule.matches(&span));
-    }
-
-    #[test]
-    fn test_multiple_otel_attribute_mappings() {
-        // Test with a rule that has multiple tag criteria
-        let mut tags = HashMap::new();
-        tags.insert("http.status_code".to_string(), "5*".to_string());
-        tags.insert("http.method".to_string(), "POST".to_string());
-        tags.insert("http.url".to_string(), "*api*".to_string());
-
-        let rule = SamplingRule::new(1.0, None, None, None, Some(tags), None);
-
-        // Create attributes with mixed OpenTelemetry and Datadog naming
-        let mixed_attrs = vec![
-            // OTel attribute that maps to http.status_code
-            KeyValue::new("http.response.status_code", 503),
-            // OTel attribute that maps to http.method
-            KeyValue::new("http.request.method", "POST"),
-            // OTel attribute that maps to http.url
-            KeyValue::new("url.full", "https://example.com/api/v1/resource"),
-        ];
-
-        // The rule should match because all three criteria are satisfied through mapping
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new("test-span", SpanKind::Client, &mixed_attrs, &resource);
-        assert!(rule.matches(&span));
-
-        // If any criteria is not met, the rule shouldn't match
-        let missing_method = vec![
-            KeyValue::new("http.response.status_code", 503),
-            // Missing http.method/http.request.method
-            KeyValue::new("url.full", "https://example.com/api/v1/resource"),
-        ];
-
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new("test-span", SpanKind::Client, &missing_method, &resource);
-        assert!(!rule.matches(&span));
-
-        // Wrong value should also not match
-        let wrong_method = vec![
-            KeyValue::new("http.response.status_code", 503),
-            KeyValue::new("http.request.method", "GET"), // Not POST
-            KeyValue::new("url.full", "https://example.com/api/v1/resource"),
-        ];
-
-        let resource = create_empty_resource();
-        let span = PreSampledSpan::new("test-span", SpanKind::Client, &wrong_method, &resource);
-        assert!(!rule.matches(&span));
-    }
-
-    #[test]
-    fn test_direct_and_mapped_mixed_attributes() {
-        // Constants for key names to improve readability and ensure consistency
-        let dd_status_key_str = HTTP_RESPONSE_STATUS_CODE;
-        let otel_response_status_key_str = HTTP_RESPONSE_STATUS_CODE;
-        let custom_tag_key = "custom.tag";
-        let custom_tag_value = "value";
-
-        let empty_resource = create_empty_resource();
-        let span_kind_client = SpanKind::Client;
-
-        // Test with both direct matches and mapped attributes
-        let mut tags_rule1 = HashMap::new();
-        tags_rule1.insert(dd_status_key_str.to_string(), "5*".to_string());
-        tags_rule1.insert(custom_tag_key.to_string(), custom_tag_value.to_string());
-
-        let rule1 = SamplingRule::new(1.0, None, None, None, Some(tags_rule1), None);
-
-        // Case 1: OTel attribute that maps to http.status_code (503 matches "5*") + Direct
-        // custom.tag match
-        let mixed_attrs_match = vec![
-            KeyValue::new(otel_response_status_key_str, 503),
-            KeyValue::new(custom_tag_key, custom_tag_value),
-        ];
-        let span = PreSampledSpan::new(
-            "test-span",
-            span_kind_client,
-            &mixed_attrs_match,
-            &empty_resource,
-        );
-        assert!(rule1.matches(&span), "Rule with dd_status_key (5*) and custom.tag should match span with otel_response_status_key (503) and custom.tag");
-
-        // Case 2: Datadog convention for status code (503 matches "5*") + Direct custom.tag match
-        let dd_attrs_match = vec![
-            KeyValue::new(dd_status_key_str, 503),
-            KeyValue::new(custom_tag_key, custom_tag_value),
-        ];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            &dd_attrs_match,
-            &empty_resource,
-        );
-        assert!(rule1.matches(&span), "Rule with dd_status_key (5*) and custom.tag should match span with dd_status_key (503) and custom.tag");
-
-        // Case 3: Missing the custom tag should fail (status code would match)
-        let missing_custom_tag_attrs = vec![KeyValue::new(otel_response_status_key_str, 503)];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            &missing_custom_tag_attrs,
-            &empty_resource,
-        );
-        assert!(
-            !rule1.matches(&span),
-            "Rule with dd_status_key (5*) and custom.tag should NOT match span missing custom.tag"
-        );
-
-        // Case 4: OTel status code 200 (does NOT match "5*") + custom.tag present
-        let non_matching_otel_status_attrs = vec![
-            KeyValue::new(otel_response_status_key_str, 200),
-            KeyValue::new(custom_tag_key, custom_tag_value),
-        ];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            &non_matching_otel_status_attrs,
-            &empty_resource,
-        );
-        assert!(!rule1.matches(&span), "Rule with dd_status_key (5*) and custom.tag should NOT match span with non-matching otel_response_status_key (200)");
-
-        // Case 5: No recognizable status code + custom.tag present
-        let no_status_code_attrs = vec![
-            KeyValue::new("another.tag", "irrelevant"),
-            KeyValue::new(custom_tag_key, custom_tag_value),
-        ];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            &no_status_code_attrs,
-            &empty_resource,
-        );
-        assert!(!rule1.matches(&span), "Rule with dd_status_key (5*) and custom.tag should NOT match span with no status code attribute");
-
-        // Case 6: Rule uses OTel key http.response.status_code directly, span has matching OTel
-        // key.
-        let mut tags_rule2 = HashMap::new();
-        tags_rule2.insert(otel_response_status_key_str.to_string(), "200".to_string());
-        tags_rule2.insert(custom_tag_key.to_string(), custom_tag_value.to_string());
-        let rule2 = SamplingRule::new(1.0, None, None, None, Some(tags_rule2), None);
-
-        let otel_key_rule_match_attrs = vec![
-            KeyValue::new(otel_response_status_key_str, 200),
-            KeyValue::new(custom_tag_key, custom_tag_value),
-        ];
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            &otel_key_rule_match_attrs,
-            &empty_resource,
-        );
-        assert!(rule2.matches(&span), "Rule with otel_response_status_key (200) and custom.tag should match span with otel_response_status_key (200) and custom.tag");
-    }
-
-    #[test]
-    fn test_operation_name_integration() {
-        // Create rules that match different operation name patterns
-        let http_rule = SamplingRule::new(
-            1.0,                                // 100% sample rate
-            None,                               // no service matcher
-            Some("http.*.request".to_string()), // matches both client and server HTTP requests
-            None,                               // no resource matcher
-            None,                               // no tag matchers
-            Some("default".to_string()),        // rule name - default provenance
-        );
-
-        let db_rule = SamplingRule::new(
-            1.0,                                  // 100% sample rate
-            None,                                 // no service matcher
-            Some("postgresql.query".to_string()), // matches database queries
-            None,                                 // no resource matcher
-            None,                                 // no tag matchers
-            Some("default".to_string()),          // rule name - default provenance
-        );
-
-        let messaging_rule = SamplingRule::new(
-            1.0,                               // 100% sample rate
-            None,                              // no service matcher
-            Some("kafka.process".to_string()), // matches Kafka messaging operations
-            None,                              // no resource matcher
-            None,                              // no tag matchers
-            Some("default".to_string()),       // rule name - default provenance
-        );
-
-        // Create a sampler with these rules
-        let sampler = DatadogSampler::new(vec![http_rule, db_rule, messaging_rule], 100);
-
-        // Create a trace ID for testing
         let trace_id = create_trace_id();
-        let resource = create_empty_resource_arc();
 
-        // Test cases for different span kinds and attributes
+        // HTTP client request should match http_rule (operation name: http.client.request)
+        let http_client_attrs = vec![TestAttribute::new(HTTP_REQUEST_METHOD, "GET")];
+        let data = create_sampling_data(None, &trace_id, "test-span", &http_client_attrs);
+        assert!(sampler.sample(&data).get_priority().is_keep());
 
-        // 1. HTTP client request
-        let http_client_attrs = vec![KeyValue::new(
-            Key::from_static_str(HTTP_REQUEST_METHOD),
-            Value::String("GET".into()),
-        )];
-
-        let empty_resource: SdkResource = create_empty_resource();
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new("", SpanKind::Client, &http_client_attrs, &empty_resource);
-        let http_client_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            http_client_op_name, "http.client.request",
-            "HTTP client operation name should be correct"
-        );
-
-        let span_kind_client = SpanKind::Client;
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_client.clone(),
-            &http_client_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should be sampled due to matching the http_rule
-        assert!(result.get_priority().is_keep());
-
-        // 2. HTTP server request
-        let http_server_attrs = vec![KeyValue::new(
-            Key::from_static_str(HTTP_REQUEST_METHOD),
-            Value::String("POST".into()),
-        )];
-
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new("", SpanKind::Server, &http_server_attrs, &empty_resource);
-        let http_server_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            http_server_op_name, "http.server.request",
-            "HTTP server operation name should be correct"
-        );
-
-        let span_kind_server = SpanKind::Server;
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_server.clone(),
-            &http_server_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should be sampled due to matching the http_rule
-        assert!(result.get_priority().is_keep());
-
-        // 3. Database query
-        let db_attrs = vec![KeyValue::new(
-            Key::from_static_str(DB_SYSTEM_NAME),
-            Value::String("postgresql".into()),
-        )];
-
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new("", SpanKind::Client, &db_attrs, &empty_resource);
-        let db_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            db_op_name, "postgresql.query",
-            "Database operation name should be correct"
-        );
-
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_client, // DB queries use client span kind
-            &db_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should be sampled due to matching the db_rule
-        assert!(result.get_priority().is_keep());
-
-        // 4. Messaging operation
-        let messaging_attrs = vec![
-            KeyValue::new(
-                Key::from_static_str(MESSAGING_SYSTEM),
-                Value::String("kafka".into()),
-            ),
-            KeyValue::new(
-                Key::from_static_str(MESSAGING_OPERATION_TYPE),
-                Value::String("process".into()),
-            ),
-        ];
-
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new("", SpanKind::Consumer, &messaging_attrs, &empty_resource);
-        let messaging_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            messaging_op_name, "kafka.process",
-            "Messaging operation name should be correct"
-        );
-
-        let span_kind_consumer = SpanKind::Consumer;
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_consumer, // Messaging uses consumer span kind
-            &messaging_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should be sampled due to matching the messaging_rule
-        assert!(result.get_priority().is_keep());
-
-        // 5. Generic internal span (should not match any rules)
-        let internal_attrs = vec![KeyValue::new("custom.tag", "value")];
-
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new("", SpanKind::Internal, &internal_attrs, &empty_resource);
-        let internal_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            internal_op_name, "internal",
-            "Internal operation name should be the span kind"
-        );
-
-        let span_kind_internal = SpanKind::Internal;
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_internal,
-            &internal_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should still be sampled (default behavior when no rules match)
-        assert!(result.get_priority().is_keep());
-
-        // 6. Server with protocol but no HTTP method
-        let server_protocol_attrs = vec![KeyValue::new(
-            Key::from_static_str(NETWORK_PROTOCOL_NAME),
-            Value::String("http".into()),
-        )];
-
-        // Print the operation name that will be generated
-        let span = PreSampledSpan::new(
-            "",
-            SpanKind::Server,
-            &server_protocol_attrs,
-            &empty_resource,
-        );
-        let server_protocol_op_name = get_otel_operation_name_v2(&span);
-        assert_eq!(
-            server_protocol_op_name, "http.server.request",
-            "Server with protocol operation name should use protocol"
-        );
-
-        let data = create_sampling_data(
-            None,
-            &trace_id,
-            "test-span",
-            span_kind_server,
-            &server_protocol_attrs,
-            resource.as_ref(),
-        );
-        let result = sampler.sample(&data);
-
-        // Should not match our http rule since operation name would be "http.server.request"
-        // But should still be sampled (default behavior)
-        assert!(result.get_priority().is_keep());
+        // Span that doesn't match the rule should still be sampled (default behavior)
+        let internal_attrs = vec![TestAttribute::new("custom.tag", "value")];
+        let data = create_sampling_data(None, &trace_id, "test-span", &internal_attrs);
+        assert!(sampler.sample(&data).get_priority().is_keep());
     }
 
     #[test]
@@ -1865,13 +1648,6 @@ mod tests {
             None,
             Some("default".to_string()),
         );
-
-        // Create a resource with a service name that will match our test rule
-        let test_resource = Arc::new(RwLock::new(
-            opentelemetry_sdk::Resource::builder_empty()
-                .with_attributes(vec![KeyValue::new(SERVICE_NAME, "web-frontend")])
-                .build(),
-        ));
 
         let sampler = DatadogSampler::new(vec![initial_rule], 100);
 
@@ -1909,17 +1685,13 @@ mod tests {
 
         // Test that the new rules work by finding a matching rule
         // Create attributes that will generate an operation name matching "http.*"
+        // and service matching "web-*"
         let attrs = vec![
-            KeyValue::new(HTTP_REQUEST_METHOD, "GET"), /* This will make operation name
-                                                        * "http.client.request" */
+            TestAttribute::new(SERVICE_NAME, "web-frontend"),
+            TestAttribute::new(HTTP_REQUEST_METHOD, "GET"), /* This will make operation name
+                                                             * "http.client.request" */
         ];
-        let resource_guard = test_resource.read().unwrap();
-        let span = PreSampledSpan::new(
-            "test-span",
-            SpanKind::Client,
-            attrs.as_slice(),
-            &resource_guard,
-        );
+        let span = TestSpan::new("test-span", attrs.as_slice());
 
         let matching_rule = sampler.find_matching_rule(&span);
         assert!(matching_rule.is_some(), "Expected to find a matching rule for service 'web-frontend' and name 'http.client.request'");

--- a/datadog-opentelemetry/src/sampling/datadog_sampler.rs
+++ b/datadog-opentelemetry/src/sampling/datadog_sampler.rs
@@ -12,249 +12,12 @@ use crate::core::sampling::{mechanism, priority, SamplingMechanism, SamplingPrio
 /// Consolidated callback type used across crates for remote config sampling updates
 pub type SamplingRulesCallback = Box<dyn for<'a> Fn(&'a [SamplingRuleConfig]) + Send + Sync>;
 
-use crate::sampling::{AttributeLike, SamplingData, SpanProperties, TraceIdLike, ValueLike};
-use std::collections::HashMap;
+use crate::sampling::{SamplingData, SpanProperties};
 
 use super::agent_service_sampler::{AgentRates, ServicesSampler};
-// Import the attr constants
-use super::constants::pattern::NO_RULE;
-use super::glob_matcher::GlobMatcher;
 use super::rate_limiter::RateLimiter;
-use super::rate_sampler::RateSampler;
 use super::rules_sampler::RulesSampler;
-
-// HTTP status code attribute constants
-const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
-const HTTP_STATUS_CODE: &str = "http.status_code";
-
-fn matcher_from_rule(rule: &str) -> Option<GlobMatcher> {
-    (rule != NO_RULE).then(|| GlobMatcher::new(rule))
-}
-
-/// Represents a sampling rule with criteria for matching spans
-#[derive(Clone, Debug)]
-pub struct SamplingRule {
-    /// The sample rate to apply when this rule matches (0.0-1.0)
-    sample_rate: f64,
-
-    /// Where this rule comes from (customer, dynamic, default)
-    provenance: String,
-
-    /// Internal rate sampler used when this rule matches
-    rate_sampler: RateSampler,
-
-    /// Glob matchers for pattern matching
-    name_matcher: Option<GlobMatcher>,
-    service_matcher: Option<GlobMatcher>,
-    resource_matcher: Option<GlobMatcher>,
-    tag_matchers: HashMap<String, GlobMatcher>,
-}
-
-impl SamplingRule {
-    /// Converts a vector of SamplingRuleConfig into SamplingRule objects
-    /// Centralizes the conversion logic
-    pub fn from_configs(configs: Vec<SamplingRuleConfig>) -> Vec<Self> {
-        configs
-            .into_iter()
-            .map(|config| {
-                Self::new(
-                    config.sample_rate,
-                    config.service,
-                    config.name,
-                    config.resource,
-                    Some(config.tags),
-                    Some(config.provenance),
-                )
-            })
-            .collect()
-    }
-
-    /// Creates a new sampling rule
-    pub fn new(
-        sample_rate: f64,
-        service: Option<String>,
-        name: Option<String>,
-        resource: Option<String>,
-        tags: Option<HashMap<String, String>>,
-        provenance: Option<String>,
-    ) -> Self {
-        // Create glob matchers for the patterns
-        let name_matcher = name.as_deref().and_then(matcher_from_rule);
-        let service_matcher = service.as_deref().and_then(matcher_from_rule);
-        let resource_matcher = resource.as_deref().and_then(matcher_from_rule);
-
-        // Create matchers for tag values
-        let tag_map = tags.clone().unwrap_or_default();
-        let mut tag_matchers = HashMap::with_capacity(tag_map.len());
-        for (key, value) in &tag_map {
-            if let Some(matcher) = matcher_from_rule(value) {
-                tag_matchers.insert(key.clone(), matcher);
-            }
-        }
-
-        SamplingRule {
-            sample_rate,
-            provenance: provenance.unwrap_or_else(|| "default".to_string()),
-            rate_sampler: RateSampler::new(sample_rate),
-            name_matcher,
-            service_matcher,
-            resource_matcher,
-            tag_matchers,
-        }
-    }
-
-    /// Checks if this rule matches the given span's attributes and name
-    /// The name is derived from the attributes and span kind
-    fn matches(&self, span: &impl SpanProperties) -> bool {
-        // Get the operation name from the span
-        let name = span.operation_name();
-
-        // Check name using glob matcher if specified
-        if let Some(ref matcher) = self.name_matcher {
-            if !matcher.matches(name.as_ref()) {
-                return false;
-            }
-        }
-
-        // Check service if specified using glob matcher
-        if let Some(ref matcher) = self.service_matcher {
-            // Get service from the span
-            let service = span.service();
-
-            // Match against the service
-            if !matcher.matches(&service) {
-                return false;
-            }
-        }
-
-        // Get the resource string for matching
-        let resource_str = span.resource();
-
-        // Check resource if specified using glob matcher
-        if let Some(ref matcher) = self.resource_matcher {
-            // Use the resource from the span
-            if !matcher.matches(resource_str.as_ref()) {
-                return false;
-            }
-        }
-
-        // Check all tags using glob matchers
-        for (key, matcher) in &self.tag_matchers {
-            let rule_tag_key_str = key.as_str();
-
-            // Special handling for rules defined with "http.status_code" or
-            // "http.response.status_code"
-            if rule_tag_key_str == HTTP_STATUS_CODE || rule_tag_key_str == HTTP_RESPONSE_STATUS_CODE
-            {
-                match self.match_http_status_code_rule(matcher, span) {
-                    Some(true) => continue,             // Status code matched
-                    Some(false) | None => return false, // Status code didn't match or wasn't found
-                }
-            } else {
-                // Logic for other tags:
-                // First, try to match directly with the provided tag key
-                let direct_match = span
-                    .attributes()
-                    .find(|attr| attr.key() == rule_tag_key_str)
-                    .and_then(|attr| self.match_attribute_value(attr.value(), matcher));
-
-                if direct_match.unwrap_or(false) {
-                    continue;
-                }
-
-                // If no direct match, try to find the corresponding OpenTelemetry attribute that
-                // maps to the Datadog tag key This handles cases where the rule key
-                // is a Datadog key (e.g., "http.method") and the attribute is an
-                // OTel key (e.g., "http.request.method")
-                if rule_tag_key_str.starts_with("http.") {
-                    let tag_match = span.attributes().any(|attr| {
-                        if let Some(alternate_key) = span.get_alternate_key(attr.key()) {
-                            if alternate_key == rule_tag_key_str {
-                                return self
-                                    .match_attribute_value(attr.value(), matcher)
-                                    .unwrap_or(false);
-                            }
-                        }
-                        false
-                    });
-
-                    if !tag_match {
-                        return false; // Mapped attribute not found or did not match
-                    }
-                    // If tag_match is true, loop continues to next rule_tag_key.
-                } else {
-                    // For non-HTTP attributes, if we don't have a direct match, the rule doesn't
-                    // match
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-
-    /// Helper method to specifically match a rule against an HTTP status code extracted from
-    /// attributes. Returns Some(true) if status code found and matches, Some(false) if found
-    /// but not matched, None if not found.
-    fn match_http_status_code_rule(
-        &self,
-        matcher: &GlobMatcher,
-        span: &impl SpanProperties,
-    ) -> Option<bool> {
-        span.status_code().and_then(|status_code| {
-            let status_value = ValueI64(i64::from(status_code));
-            self.match_attribute_value(&status_value, matcher)
-        })
-    }
-
-    // Helper method to match attribute values considering different value types
-    fn match_attribute_value(&self, value: &impl ValueLike, matcher: &GlobMatcher) -> Option<bool> {
-        // Floating point values are handled with special rules
-        if let Some(float_val) = value.extract_float() {
-            // Check if the float has a non-zero decimal part
-            let has_decimal = float_val != (float_val as i64) as f64;
-
-            // For non-integer floats, only match if it's a wildcard pattern
-            if has_decimal {
-                // All '*' pattern returns true, any other pattern returns false
-                return Some(matcher.pattern().chars().all(|c| c == '*'));
-            }
-
-            // For integer floats, convert to string for matching
-            return Some(matcher.matches(&float_val.to_string()));
-        }
-
-        // For non-float values, use normal matching
-        value
-            .extract_string()
-            .map(|string_value| matcher.matches(&string_value))
-    }
-
-    /// Samples a trace ID using this rule's sample rate
-    pub fn sample(&self, trace_id: &impl TraceIdLike) -> bool {
-        // Delegate to the internal rate sampler's new sample method
-        self.rate_sampler.sample(trace_id)
-    }
-}
-
-/// Represents a priority for sampling rules
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum RuleProvenance {
-    Customer = 0,
-    Dynamic = 1,
-    Default = 2,
-}
-
-impl From<&str> for RuleProvenance {
-    fn from(s: &str) -> Self {
-        match s {
-            "customer" => RuleProvenance::Customer,
-            "dynamic" => RuleProvenance::Dynamic,
-            _ => RuleProvenance::Default,
-        }
-    }
-}
+use super::sampling_rule::SamplingRule;
 
 /// A composite sampler that applies rules in order of precedence
 #[derive(Clone, Debug)]
@@ -472,18 +235,6 @@ fn format_sampling_rate(rate: f64) -> Option<String> {
     })
 }
 
-struct ValueI64(i64);
-
-impl ValueLike for ValueI64 {
-    fn extract_float(&self) -> Option<f64> {
-        Some(self.0 as f64)
-    }
-
-    fn extract_string(&self) -> Option<std::borrow::Cow<'_, str>> {
-        Some(std::borrow::Cow::Owned(self.0.to_string()))
-    }
-}
-
 pub struct TraceRootSamplingInfo {
     mechanism: SamplingMechanism,
     rate: f64,
@@ -589,6 +340,7 @@ mod tests {
         attr::{ENV_TAG, RESOURCE_TAG},
         pattern,
     };
+    use crate::sampling::{AttributeLike, TraceIdLike, ValueLike};
     use std::borrow::Cow;
     use std::collections::HashMap;
 
@@ -596,7 +348,9 @@ mod tests {
     const HTTP_REQUEST_METHOD: &str = "http.request.method";
     const SERVICE_NAME: &str = "service.name";
 
-    use super::{HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE};
+    // HTTP status code attribute constants (for tests)
+    const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
+    const HTTP_STATUS_CODE: &str = "http.status_code";
 
     // ============================================================================
     // Test-only data structures
@@ -1253,8 +1007,8 @@ mod tests {
                     found_rule_rate = true;
                 }
                 SAMPLING_KNUTH_RATE_TAG_KEY => {
-                    let value_str = match &attr.value {
-                        opentelemetry::Value::String(s) => s.to_string(),
+                    let value_str = match attr.value() {
+                        TestValue::String(s) => s.to_string(),
                         _ => panic!("Expected string value for ksr tag"),
                     };
                     assert_eq!(value_str, "0.5");

--- a/datadog-opentelemetry/src/sampling/mod.rs
+++ b/datadog-opentelemetry/src/sampling/mod.rs
@@ -11,12 +11,14 @@ pub(crate) mod otel_mappings;
 pub(crate) mod rate_limiter;
 pub(crate) mod rate_sampler;
 pub(crate) mod rules_sampler;
+pub(crate) mod sampling_rule;
 mod types;
 pub(crate) mod utils;
 
 // Re-export key public types
-pub use datadog_sampler::{DatadogSampler, SamplingRule, SamplingRulesCallback};
+pub use datadog_sampler::{DatadogSampler, SamplingRulesCallback};
 pub use otel_mappings::{OtelAttributeFactory, OtelSamplingData};
+pub use sampling_rule::SamplingRule;
 pub use types::{
     AttributeFactory, AttributeLike, SamplingData, SpanProperties, TraceIdLike, ValueLike,
 };

--- a/datadog-opentelemetry/src/sampling/otel_mappings.rs
+++ b/datadog-opentelemetry/src/sampling/otel_mappings.rs
@@ -120,6 +120,28 @@ impl SpanProperties for PreSampledSpan<'_> {
     }
 }
 
+impl crate::sampling::AttributeLike for opentelemetry::KeyValue {
+    type Value = opentelemetry::Value;
+
+    fn key(&self) -> &str {
+        self.key.as_str()
+    }
+
+    fn value(&self) -> &Self::Value {
+        &self.value
+    }
+}
+
+impl crate::sampling::ValueLike for opentelemetry::Value {
+    fn extract_float(&self) -> Option<f64> {
+        crate::sampling::utils::extract_float_value(self)
+    }
+
+    fn extract_string(&self) -> Option<Cow<'_, str>> {
+        crate::sampling::utils::extract_string_value(self)
+    }
+}
+
 /// OpenTelemetry Sampling Data implementation.
 ///
 /// Provides the necessary data for making sampling decisions on OpenTelemetry spans.
@@ -236,5 +258,375 @@ pub(crate) fn priority_to_otel_decision(
         opentelemetry::trace::SamplingDecision::RecordAndSample
     } else {
         opentelemetry::trace::SamplingDecision::RecordOnly
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mappings::get_otel_operation_name_v2;
+    use opentelemetry::trace::SpanKind;
+    use opentelemetry::{Key, KeyValue, Value};
+    use opentelemetry_semantic_conventions::attribute::{
+        DB_SYSTEM_NAME, HTTP_REQUEST_METHOD, MESSAGING_OPERATION_TYPE, MESSAGING_SYSTEM,
+    };
+    use opentelemetry_semantic_conventions::trace::{
+        HTTP_RESPONSE_STATUS_CODE, NETWORK_PROTOCOL_NAME,
+    };
+
+    fn create_empty_resource() -> opentelemetry_sdk::Resource {
+        opentelemetry_sdk::Resource::builder_empty().build()
+    }
+
+    #[test]
+    fn test_operation_name_http_client() {
+        let attrs = vec![KeyValue::new(
+            Key::from_static_str(HTTP_REQUEST_METHOD),
+            Value::String("GET".into()),
+        )];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Client, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "http.client.request");
+
+        // Also verify using get_otel_operation_name_v2
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "http.client.request");
+    }
+
+    #[test]
+    fn test_operation_name_http_server() {
+        let attrs = vec![KeyValue::new(
+            Key::from_static_str(HTTP_REQUEST_METHOD),
+            Value::String("POST".into()),
+        )];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Server, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "http.server.request");
+
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "http.server.request");
+    }
+
+    #[test]
+    fn test_operation_name_database() {
+        let attrs = vec![KeyValue::new(
+            Key::from_static_str(DB_SYSTEM_NAME),
+            Value::String("postgresql".into()),
+        )];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Client, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "postgresql.query");
+
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "postgresql.query");
+    }
+
+    #[test]
+    fn test_operation_name_messaging() {
+        let attrs = vec![
+            KeyValue::new(
+                Key::from_static_str(MESSAGING_SYSTEM),
+                Value::String("kafka".into()),
+            ),
+            KeyValue::new(
+                Key::from_static_str(MESSAGING_OPERATION_TYPE),
+                Value::String("process".into()),
+            ),
+        ];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Consumer, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "kafka.process");
+
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "kafka.process");
+    }
+
+    #[test]
+    fn test_operation_name_generic_server_with_protocol() {
+        let attrs = vec![KeyValue::new(
+            Key::from_static_str(NETWORK_PROTOCOL_NAME),
+            Value::String("http".into()),
+        )];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Server, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "http.server.request");
+
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "http.server.request");
+    }
+
+    #[test]
+    fn test_operation_name_internal_fallback() {
+        let attrs = vec![KeyValue::new("custom.tag", "value")];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("", SpanKind::Internal, &attrs, &resource);
+
+        let op_name = span.operation_name();
+        assert_eq!(op_name, "internal");
+
+        let op_name_v2 = get_otel_operation_name_v2(&span);
+        assert_eq!(op_name_v2, "internal");
+    }
+
+    #[test]
+    fn test_service_from_resource() {
+        use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+
+        let resource = opentelemetry_sdk::Resource::builder_empty()
+            .with_attributes(vec![KeyValue::new(SERVICE_NAME, "my-service")])
+            .build();
+        let attrs = vec![];
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        assert_eq!(span.service(), "my-service");
+    }
+
+    #[test]
+    fn test_env_from_attributes() {
+        let attrs = vec![KeyValue::new("datadog.env", "production")];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        assert_eq!(span.env(), "production");
+    }
+
+    #[test]
+    fn test_env_empty_when_not_present() {
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        assert_eq!(span.env(), "");
+    }
+
+    #[test]
+    fn test_status_code_from_attributes() {
+        let attrs = vec![KeyValue::new(
+            Key::from_static_str(HTTP_RESPONSE_STATUS_CODE),
+            Value::I64(404),
+        )];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        assert_eq!(span.status_code(), Some(404));
+    }
+
+    #[test]
+    fn test_status_code_none_when_not_present() {
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        assert_eq!(span.status_code(), None);
+    }
+
+    #[test]
+    fn test_attributes_iteration() {
+        let attrs = vec![
+            KeyValue::new("key1", "value1"),
+            KeyValue::new("key2", Value::I64(42)),
+        ];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        let collected: Vec<_> = span.attributes().collect();
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0].key.as_str(), "key1");
+        assert_eq!(collected[1].key.as_str(), "key2");
+    }
+
+    #[test]
+    fn test_get_alternate_key_http_status() {
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        // Test HTTP status code mapping
+        let alternate = span.get_alternate_key("http.response.status_code");
+        assert_eq!(alternate, Some("http.status_code".into()));
+    }
+
+    #[test]
+    fn test_get_alternate_key_http_method() {
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        // Test HTTP method mapping
+        let alternate = span.get_alternate_key("http.request.method");
+        assert_eq!(alternate, Some("http.method".into()));
+    }
+
+    #[test]
+    fn test_get_alternate_key_no_mapping() {
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        // Test key with no mapping
+        let alternate = span.get_alternate_key("custom.attribute");
+        assert_eq!(alternate, None);
+    }
+
+    #[test]
+    fn test_attribute_key_mapping_comprehensive() {
+        // Test that OTel attribute keys are correctly mapped to Datadog keys
+        let attrs = vec![];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test", SpanKind::Server, &attrs, &resource);
+
+        // HTTP attribute mappings (OTel -> DD)
+        assert_eq!(
+            span.get_alternate_key("http.response.status_code"),
+            Some("http.status_code".into())
+        );
+        assert_eq!(
+            span.get_alternate_key("http.request.method"),
+            Some("http.method".into())
+        );
+        assert_eq!(span.get_alternate_key("url.full"), Some("http.url".into()));
+        assert_eq!(
+            span.get_alternate_key("user_agent.original"),
+            Some("http.useragent".into())
+        );
+        assert_eq!(
+            span.get_alternate_key("server.address"),
+            Some("http.server_name".into())
+        );
+        assert_eq!(
+            span.get_alternate_key("client.address"),
+            Some("http.client_ip".into())
+        );
+
+        // Keys without mappings (same in both OTel and DD) should return None
+        assert_eq!(span.get_alternate_key("custom.tag"), None);
+        assert_eq!(span.get_alternate_key("application.name"), None);
+        assert_eq!(span.get_alternate_key("http.route"), None); // Maps to itself
+
+        // Datadog convention keys map to empty string (filtered out), which get_alternate_key
+        // returns as None
+        assert_eq!(span.get_alternate_key("service.name"), None);
+        assert_eq!(span.get_alternate_key("operation.name"), None);
+        assert_eq!(span.get_alternate_key("datadog.custom"), None);
+    }
+
+    #[test]
+    fn test_otel_to_datadog_attribute_mapping_in_span() {
+        // Test that a span with OTel attribute names can be queried using DD keys via
+        // get_alternate_key
+        let otel_attrs = vec![
+            KeyValue::new("http.response.status_code", Value::I64(500)),
+            KeyValue::new("http.request.method", "POST"),
+            KeyValue::new("url.full", "https://example.com/api"),
+        ];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test-span", SpanKind::Client, &otel_attrs, &resource);
+
+        // Verify the OTel attributes are present
+        let attrs: Vec<_> = span.attributes().collect();
+        assert_eq!(attrs.len(), 3);
+
+        // Verify we can find the DD equivalent keys for these OTel attributes
+        assert_eq!(
+            span.get_alternate_key("http.response.status_code"),
+            Some("http.status_code".into())
+        );
+        assert_eq!(
+            span.get_alternate_key("http.request.method"),
+            Some("http.method".into())
+        );
+        assert_eq!(span.get_alternate_key("url.full"), Some("http.url".into()));
+
+        // Verify the actual attributes can be found by their original keys
+        let status_code_attr = attrs
+            .iter()
+            .find(|a| a.key.as_str() == "http.response.status_code");
+        assert!(status_code_attr.is_some());
+
+        let method_attr = attrs
+            .iter()
+            .find(|a| a.key.as_str() == "http.request.method");
+        assert!(method_attr.is_some());
+    }
+
+    #[test]
+    fn test_multiple_attribute_mappings() {
+        // Test that a span with multiple OTel attributes correctly maps them all to DD keys
+        let mixed_attrs = vec![
+            KeyValue::new("http.response.status_code", Value::I64(503)),
+            KeyValue::new("http.request.method", "POST"),
+            KeyValue::new("url.full", "https://example.com/api/v1/resource"),
+        ];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test-span", SpanKind::Client, &mixed_attrs, &resource);
+
+        // Verify all three OTel attributes have correct DD mappings
+        assert_eq!(
+            span.get_alternate_key("http.response.status_code"),
+            Some("http.status_code".into())
+        );
+        assert_eq!(
+            span.get_alternate_key("http.request.method"),
+            Some("http.method".into())
+        );
+        assert_eq!(span.get_alternate_key("url.full"), Some("http.url".into()));
+
+        // Verify all attributes are present
+        let attrs: Vec<_> = span.attributes().collect();
+        assert_eq!(attrs.len(), 3);
+
+        // Verify each attribute can be found by its original OTel key
+        assert!(attrs
+            .iter()
+            .any(|a| a.key.as_str() == "http.response.status_code"));
+        assert!(attrs
+            .iter()
+            .any(|a| a.key.as_str() == "http.request.method"));
+        assert!(attrs.iter().any(|a| a.key.as_str() == "url.full"));
+    }
+
+    #[test]
+    fn test_mixed_direct_and_mapped_attributes() {
+        // Test that spans with both OTel attributes (that have DD mappings) and
+        // custom attributes (that don't have mappings) work correctly together
+        let mixed_attrs = vec![
+            // OTel attribute with DD mapping
+            KeyValue::new("http.response.status_code", Value::I64(503)),
+            // Custom attribute without mapping
+            KeyValue::new("custom.tag", "custom_value"),
+        ];
+        let resource = create_empty_resource();
+        let span = PreSampledSpan::new("test-span", SpanKind::Client, &mixed_attrs, &resource);
+
+        // OTel attribute should have alternate DD key
+        assert_eq!(
+            span.get_alternate_key("http.response.status_code"),
+            Some("http.status_code".into())
+        );
+
+        // Custom attribute should not have alternate key
+        assert_eq!(span.get_alternate_key("custom.tag"), None);
+
+        // Both attributes should be present and accessible
+        let attrs: Vec<_> = span.attributes().collect();
+        assert_eq!(attrs.len(), 2);
+
+        assert!(attrs
+            .iter()
+            .any(|a| a.key.as_str() == "http.response.status_code"));
+        assert!(attrs.iter().any(|a| a.key.as_str() == "custom.tag"));
+
+        // Verify the status code is accessible
+        assert_eq!(span.status_code(), Some(503));
     }
 }

--- a/datadog-opentelemetry/src/sampling/rate_sampler.rs
+++ b/datadog-opentelemetry/src/sampling/rate_sampler.rs
@@ -71,7 +71,28 @@ impl RateSampler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::TraceId;
+
+    // Test-only TraceId implementation
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestTraceId {
+        bytes: [u8; 16],
+    }
+
+    impl TestTraceId {
+        fn from_bytes(bytes: [u8; 16]) -> Self {
+            Self { bytes }
+        }
+
+        fn to_bytes(&self) -> [u8; 16] {
+            self.bytes
+        }
+    }
+
+    impl TraceIdLike for TestTraceId {
+        fn to_u128(&self) -> u128 {
+            u128::from_be_bytes(self.bytes)
+        }
+    }
 
     #[test]
     fn check_debug_impl() {
@@ -120,7 +141,7 @@ mod tests {
         let sampler_zero = RateSampler::new(0.0);
         let mut bytes_zero = [0u8; 16];
         bytes_zero[15] = 1; // Example ID
-        let trace_id_zero = TraceId::from_bytes(bytes_zero);
+        let trace_id_zero = TestTraceId::from_bytes(bytes_zero);
         assert!(
             !sampler_zero.sample(&trace_id_zero),
             "sampler_zero should return false"
@@ -130,7 +151,7 @@ mod tests {
         let sampler_one = RateSampler::new(1.0);
         let mut bytes_one = [0u8; 16];
         bytes_one[15] = 2; // Example ID
-        let trace_id_one = TraceId::from_bytes(bytes_one);
+        let trace_id_one = TestTraceId::from_bytes(bytes_one);
         assert!(
             sampler_one.sample(&trace_id_one),
             "sampler_one should return true"
@@ -142,7 +163,7 @@ mod tests {
 
         // Trace ID that should be sampled (hashed value <= threshold)
         let bytes_sample = [0u8; 16]; // Hashes to 0
-        let trace_id_sample = TraceId::from_bytes(bytes_sample);
+        let trace_id_sample = TestTraceId::from_bytes(bytes_sample);
         let sample_u64 = u128::from_be_bytes(trace_id_sample.to_bytes()) as u64;
         let sample_hash = sample_u64.wrapping_mul(KNUTH_FACTOR);
         assert!(sample_hash <= threshold);
@@ -154,7 +175,7 @@ mod tests {
         // Trace ID that should be dropped (hashed value > threshold)
         let mut bytes_drop = [0u8; 16];
         bytes_drop[8..16].copy_from_slice(&u64::MAX.to_be_bytes()); // High lower 64 bits
-        let trace_id_drop = TraceId::from_bytes(bytes_drop);
+        let trace_id_drop = TestTraceId::from_bytes(bytes_drop);
         let drop_u64 = u128::from_be_bytes(trace_id_drop.to_bytes()) as u64;
         let drop_hash = drop_u64.wrapping_mul(KNUTH_FACTOR);
         // For rate 0.5, threshold is MAX/2. Hashing MAX should result in something > MAX/2
@@ -173,7 +194,7 @@ mod tests {
         let sampler_half = RateSampler::new(0.5);
         // Trace ID with all zeros hashes to 0, which is always <= threshold for rate > 0
         let bytes_to_sample = [0u8; 16];
-        let trace_id_to_sample = TraceId::from_bytes(bytes_to_sample);
+        let trace_id_to_sample = TestTraceId::from_bytes(bytes_to_sample);
         assert!(
             sampler_half.sample(&trace_id_to_sample),
             "Sampler with 0.5 rate should sample trace ID 0"

--- a/datadog-opentelemetry/src/sampling/rules_sampler.rs
+++ b/datadog-opentelemetry/src/sampling/rules_sampler.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use super::datadog_sampler::SamplingRule;
+use super::sampling_rule::SamplingRule;
 
 /// Thread-safe container for sampling rules
 #[derive(Debug, Default, Clone)]

--- a/datadog-opentelemetry/src/sampling/sampling_rule.rs
+++ b/datadog-opentelemetry/src/sampling/sampling_rule.rs
@@ -1,0 +1,256 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::core::configuration::SamplingRuleConfig;
+use crate::sampling::{AttributeLike, SpanProperties, TraceIdLike, ValueLike};
+use std::collections::HashMap;
+
+use super::constants::pattern::NO_RULE;
+use super::glob_matcher::GlobMatcher;
+use super::rate_sampler::RateSampler;
+
+// HTTP status code attribute constants
+const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
+const HTTP_STATUS_CODE: &str = "http.status_code";
+
+fn matcher_from_rule(rule: &str) -> Option<GlobMatcher> {
+    (rule != NO_RULE).then(|| GlobMatcher::new(rule))
+}
+
+/// Represents a sampling rule with criteria for matching spans
+#[derive(Clone, Debug)]
+pub struct SamplingRule {
+    /// The sample rate to apply when this rule matches (0.0-1.0)
+    pub(crate) sample_rate: f64,
+
+    /// Where this rule comes from (customer, dynamic, default)
+    pub(crate) provenance: String,
+
+    /// Internal rate sampler used when this rule matches
+    rate_sampler: RateSampler,
+
+    /// Glob matchers for pattern matching
+    pub(crate) name_matcher: Option<GlobMatcher>,
+    pub(crate) service_matcher: Option<GlobMatcher>,
+    pub(crate) resource_matcher: Option<GlobMatcher>,
+    pub(crate) tag_matchers: HashMap<String, GlobMatcher>,
+}
+
+impl SamplingRule {
+    /// Converts a vector of SamplingRuleConfig into SamplingRule objects
+    /// Centralizes the conversion logic
+    pub fn from_configs(configs: Vec<SamplingRuleConfig>) -> Vec<Self> {
+        configs
+            .into_iter()
+            .map(|config| {
+                Self::new(
+                    config.sample_rate,
+                    config.service,
+                    config.name,
+                    config.resource,
+                    Some(config.tags),
+                    Some(config.provenance),
+                )
+            })
+            .collect()
+    }
+
+    /// Creates a new sampling rule
+    pub fn new(
+        sample_rate: f64,
+        service: Option<String>,
+        name: Option<String>,
+        resource: Option<String>,
+        tags: Option<HashMap<String, String>>,
+        provenance: Option<String>,
+    ) -> Self {
+        // Create glob matchers for the patterns
+        let name_matcher = name.as_deref().and_then(matcher_from_rule);
+        let service_matcher = service.as_deref().and_then(matcher_from_rule);
+        let resource_matcher = resource.as_deref().and_then(matcher_from_rule);
+
+        // Create matchers for tag values
+        let tag_map = tags.clone().unwrap_or_default();
+        let mut tag_matchers = HashMap::with_capacity(tag_map.len());
+        for (key, value) in &tag_map {
+            if let Some(matcher) = matcher_from_rule(value) {
+                tag_matchers.insert(key.clone(), matcher);
+            }
+        }
+
+        SamplingRule {
+            sample_rate,
+            provenance: provenance.unwrap_or_else(|| "default".to_string()),
+            rate_sampler: RateSampler::new(sample_rate),
+            name_matcher,
+            service_matcher,
+            resource_matcher,
+            tag_matchers,
+        }
+    }
+
+    /// Checks if this rule matches the given span's attributes and name
+    /// The name is derived from the attributes and span kind
+    pub(crate) fn matches(&self, span: &impl SpanProperties) -> bool {
+        // Get the operation name from the span
+        let name = span.operation_name();
+
+        // Check name using glob matcher if specified
+        if let Some(ref matcher) = self.name_matcher {
+            if !matcher.matches(name.as_ref()) {
+                return false;
+            }
+        }
+
+        // Check service if specified using glob matcher
+        if let Some(ref matcher) = self.service_matcher {
+            // Get service from the span
+            let service = span.service();
+
+            // Match against the service
+            if !matcher.matches(&service) {
+                return false;
+            }
+        }
+
+        // Get the resource string for matching
+        let resource_str = span.resource();
+
+        // Check resource if specified using glob matcher
+        if let Some(ref matcher) = self.resource_matcher {
+            // Use the resource from the span
+            if !matcher.matches(resource_str.as_ref()) {
+                return false;
+            }
+        }
+
+        // Check all tags using glob matchers
+        for (key, matcher) in &self.tag_matchers {
+            let rule_tag_key_str = key.as_str();
+
+            // Special handling for rules defined with "http.status_code" or
+            // "http.response.status_code"
+            if rule_tag_key_str == HTTP_STATUS_CODE || rule_tag_key_str == HTTP_RESPONSE_STATUS_CODE
+            {
+                match self.match_http_status_code_rule(matcher, span) {
+                    Some(true) => continue,             // Status code matched
+                    Some(false) | None => return false, // Status code didn't match or wasn't found
+                }
+            } else {
+                // Logic for other tags:
+                // First, try to match directly with the provided tag key
+                let direct_match = span
+                    .attributes()
+                    .find(|attr| attr.key() == rule_tag_key_str)
+                    .and_then(|attr| self.match_attribute_value(attr.value(), matcher));
+
+                if direct_match.unwrap_or(false) {
+                    continue;
+                }
+
+                // If no direct match, try to find the corresponding OpenTelemetry attribute that
+                // maps to the Datadog tag key This handles cases where the rule key
+                // is a Datadog key (e.g., "http.method") and the attribute is an
+                // OTel key (e.g., "http.request.method")
+                if rule_tag_key_str.starts_with("http.") {
+                    let tag_match = span.attributes().any(|attr| {
+                        if let Some(alternate_key) = span.get_alternate_key(attr.key()) {
+                            if alternate_key == rule_tag_key_str {
+                                return self
+                                    .match_attribute_value(attr.value(), matcher)
+                                    .unwrap_or(false);
+                            }
+                        }
+                        false
+                    });
+
+                    if !tag_match {
+                        return false; // Mapped attribute not found or did not match
+                    }
+                    // If tag_match is true, loop continues to next rule_tag_key.
+                } else {
+                    // For non-HTTP attributes, if we don't have a direct match, the rule doesn't
+                    // match
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Helper method to specifically match a rule against an HTTP status code extracted from
+    /// attributes. Returns Some(true) if status code found and matches, Some(false) if found
+    /// but not matched, None if not found.
+    fn match_http_status_code_rule(
+        &self,
+        matcher: &GlobMatcher,
+        span: &impl SpanProperties,
+    ) -> Option<bool> {
+        span.status_code().and_then(|status_code| {
+            let status_value = ValueI64(i64::from(status_code));
+            self.match_attribute_value(&status_value, matcher)
+        })
+    }
+
+    // Helper method to match attribute values considering different value types
+    fn match_attribute_value(&self, value: &impl ValueLike, matcher: &GlobMatcher) -> Option<bool> {
+        // Floating point values are handled with special rules
+        if let Some(float_val) = value.extract_float() {
+            // Check if the float has a non-zero decimal part
+            let has_decimal = float_val != (float_val as i64) as f64;
+
+            // For non-integer floats, only match if it's a wildcard pattern
+            if has_decimal {
+                // All '*' pattern returns true, any other pattern returns false
+                return Some(matcher.pattern().chars().all(|c| c == '*'));
+            }
+
+            // For integer floats, convert to string for matching
+            return Some(matcher.matches(&float_val.to_string()));
+        }
+
+        // For non-float values, use normal matching
+        value
+            .extract_string()
+            .map(|string_value| matcher.matches(&string_value))
+    }
+
+    /// Samples a trace ID using this rule's sample rate
+    pub fn sample(&self, trace_id: &impl TraceIdLike) -> bool {
+        // Delegate to the internal rate sampler's new sample method
+        self.rate_sampler.sample(trace_id)
+    }
+}
+
+/// Represents a priority for sampling rules
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RuleProvenance {
+    Customer = 0,
+    Dynamic = 1,
+    Default = 2,
+}
+
+impl From<&str> for RuleProvenance {
+    fn from(s: &str) -> Self {
+        match s {
+            "customer" => RuleProvenance::Customer,
+            "dynamic" => RuleProvenance::Dynamic,
+            _ => RuleProvenance::Default,
+        }
+    }
+}
+
+/// Helper struct for representing i64 values as ValueLike
+struct ValueI64(i64);
+
+impl ValueLike for ValueI64 {
+    fn extract_float(&self) -> Option<f64> {
+        Some(self.0 as f64)
+    }
+
+    fn extract_string(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Owned(self.0.to_string()))
+    }
+}

--- a/datadog-opentelemetry/src/sampling/types.rs
+++ b/datadog-opentelemetry/src/sampling/types.rs
@@ -12,16 +12,15 @@ use std::borrow::Cow;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use opentelemetry::trace::TraceId;
+/// ```
 /// use datadog_opentelemetry::sampling::TraceIdLike;
 ///
 /// #[derive(Clone, PartialEq, Eq)]
-/// struct MyTraceId(TraceId);
+/// struct MyTraceId(u128);
 ///
 /// impl TraceIdLike for MyTraceId {
 ///     fn to_u128(&self) -> u128 {
-///         u128::from_be_bytes(self.0.to_bytes())
+///         self.0
 ///     }
 /// }
 /// ```
@@ -61,28 +60,6 @@ pub trait ValueLike {
     ///
     /// Returns `Some(Cow<str>)` for types that can be converted to strings, `None` otherwise.
     fn extract_string(&self) -> Option<Cow<'_, str>>;
-}
-
-impl AttributeLike for opentelemetry::KeyValue {
-    type Value = opentelemetry::Value;
-
-    fn key(&self) -> &str {
-        self.key.as_str()
-    }
-
-    fn value(&self) -> &Self::Value {
-        &self.value
-    }
-}
-
-impl ValueLike for opentelemetry::Value {
-    fn extract_float(&self) -> Option<f64> {
-        crate::sampling::utils::extract_float_value(self)
-    }
-
-    fn extract_string(&self) -> Option<Cow<'_, str>> {
-        crate::sampling::utils::extract_string_value(self)
-    }
 }
 
 /// A trait for creating sampling attributes.


### PR DESCRIPTION
# What does this PR do?

Moves out sampling rules and otel tests and types from the `datadog_sampler.rs` file.

