### PR TITLE
perf(ci): speed up 3rd party license check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -83,17 +83,11 @@ jobs:
           # cache key contains current version of dd-rust-license-tool
           # when upstream version is updated we can bump the cache key version,
           # to cache the latest version of the tool
-          key: "v1-dd-rust-license-tool"
+          key: "v1-dd-rust-license-tool-1.0.4"
       - name: Cache
         uses: ./.github/actions/cache
       - name: Install dd-rust-license-tool
-        run: which dd-rust-license-tool || cargo install --git https://github.com/DataDog/rust-license-tool.git dd-rust-license-tool
-      # To ensure the dependency tree is identical between the CI runner and the
-      # local license generation script (which also forces the 'git' protocol),
-      # we explicitly set the crates.io protocol. Cargo's default can vary
-      # between 'git' and 'sparse' depending on the environment, which can lead
-      # to different dependency resolutions. This guarantees consistency.
-      - run: mkdir -p .cargo && printf "[registries.crates-io]\nprotocol = \"git\"\n" > .cargo/config.toml
+        run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.4" || cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v1.0.4 dd-rust-license-tool
       - name: "Generate new LICENSE-3rdparty.csv and check against the previous"
         run: |
           # The LICENSE-3rdparty.csv file must match the output of the tool in the Linux CI environment.

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -3,13 +3,10 @@ FROM rust:1.84-slim
 # Set up the workspace directory
 WORKDIR /usr/src/app
 
-# Copy just the cargo config first - this rarely changes
-COPY .cargo/config.toml /usr/src/app/.cargo/config.toml
-
 # Install the license tool with cache mount
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --git https://github.com/DataDog/rust-license-tool.git dd-rust-license-tool
+    cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v1.0.4 dd-rust-license-tool
 
 # Copy the rest of the project files
 COPY . .

--- a/scripts/generate-licenses.sh
+++ b/scripts/generate-licenses.sh
@@ -4,38 +4,83 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# This script generates the LICENSE-3rdparty.csv file using a Docker container
-# to ensure the environment matches the CI runner (Linux). This avoids
-# platform-specific differences in the dependency tree.
+# This script generates the LICENSE-3rdparty.csv file.
+# If dd-rust-license-tool v1.0.4 is installed locally it runs directly;
+# otherwise it offers to install the tool or fall back to Docker (Linux only).
 
 set -euo pipefail
 
-# 1. Check if Docker is installed and the daemon is running.
-if ! command -v docker &> /dev/null || ! docker info &> /dev/null; then
-    echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
-    exit 1
+TOOL_VERSION="1.0.4"
+INSTALL_CMD="cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v${TOOL_VERSION} dd-rust-license-tool"
+
+run_native() {
+    echo "Running dd-rust-license-tool dump..."
+    dd-rust-license-tool dump > LICENSE-3rdparty.csv
+}
+
+run_docker() {
+    if ! command -v docker &> /dev/null || ! docker info &> /dev/null; then
+        echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
+        exit 1
+    fi
+    # Ensure BuildKit is enabled for efficient caching
+    export DOCKER_BUILDKIT=1
+    echo "Building license tool container with caching..."
+    docker build \
+        --progress=plain \
+        -t dd-license-tool \
+        -f scripts/Dockerfile.license \
+        .
+    echo "Generating LICENSE-3rdparty.csv..."
+    docker run --rm dd-license-tool > LICENSE-3rdparty.csv
+}
+
+if cargo install --list | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
+    run_native
+else
+    INSTALLED_VERSION=$(cargo install --list | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)
+
+    echo "dd-rust-license-tool v${TOOL_VERSION} is not installed."
+    if [ -n "$INSTALLED_VERSION" ]; then
+        echo "Found installed version: ${INSTALLED_VERSION}"
+    fi
+    echo ""
+    echo "To install v${TOOL_VERSION} locally, run:"
+    echo "  ${INSTALL_CMD}"
+    echo ""
+    echo "How would you like to proceed?"
+    echo "  1) Install dd-rust-license-tool v${TOOL_VERSION} locally and run"
+    echo "  2) Use Docker (requires Docker daemon to be running)"
+    if [ -n "$INSTALLED_VERSION" ]; then
+        echo "  3) Run with the installed version (${INSTALLED_VERSION})"
+        read -rp "Enter 1, 2, or 3: " choice
+    else
+        read -rp "Enter 1 or 2: " choice
+    fi
+    case "$choice" in
+        1)
+            echo "Installing dd-rust-license-tool v${TOOL_VERSION}..."
+            eval "$INSTALL_CMD"
+            run_native
+            ;;
+        2)
+            run_docker
+            ;;
+        3)
+            if [ -n "$INSTALLED_VERSION" ]; then
+                run_native
+            else
+                echo "Invalid choice. Exiting."
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Invalid choice. Exiting."
+            exit 1
+            ;;
+    esac
 fi
-
-# 2. Ensure BuildKit is enabled for efficient caching
-export DOCKER_BUILDKIT=1
-
-echo "Creating temporary cargo config..."
-mkdir -p .cargo
-printf "[registries.crates-io]\nprotocol = \"git\"\n" > .cargo/config.toml
-
-echo "Building license tool container with caching..."
-docker build \
-    --progress=plain \
-    -t dd-license-tool \
-    -f scripts/Dockerfile.license \
-    .
-
-echo "Generating LICENSE-3rdparty.csv..."
-docker run --rm dd-license-tool > LICENSE-3rdparty.csv
-
-echo "Cleaning up..."
-rm -rf .cargo/config.toml
 
 echo ""
 echo "✅ Successfully generated LICENSE-3rdparty.csv."
-echo "Please review and commit the changes." 
+echo "Please review and commit the changes."


### PR DESCRIPTION
# What does this PR do?

Cleans up and speeds up both CI and local checking of 3rd party dependencies.

# Motivation

The CI 3rd party license check was clobbering the cache and took rough 19 minutes 😱 

# Additional Notes

The changes were done by Claude, and reviewed by me. The 3rd party license check now takes around a minute tops.
