### PR TITLE
chore: bump to 0.3.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "propagator"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 dependencies = [
  "datadog-opentelemetry",
  "http-body-util",
@@ -2179,7 +2179,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_tracing"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 dependencies = [
  "datadog-opentelemetry",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/dd-trace-rs"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ opentelemetry-sdk.
 Add to you Cargo.toml
 
 ```toml
-datadog-opentelemetry = { version = "0.2.1" }
+datadog-opentelemetry = { version = "0.3.0" }
 ```
 
 ### Creating traces, metrics and logs
@@ -203,7 +203,7 @@ let logging_provider = datadog_opentelemetry::logs()
 
 For advanced usage and configuration information, check out [`DatadogTracingBuilder`],
 [`configuration::ConfigBuilder`] and the
-[library documentation](https://docs.rs/datadog-opentelemetry/0.2.1/datadog_opentelemetry/).
+[library documentation](https://docs.rs/datadog-opentelemetry/0.3.0-alpha.1/datadog_opentelemetry/).
 
 * Through env variables
 

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -16,7 +16,7 @@
 //! Add to you Cargo.toml
 //!
 //! ```toml
-//! datadog-opentelemetry = { version = "0.2.1" }
+//! datadog-opentelemetry = { version = "0.3.0" }
 //! ```
 //!
 //! ### Creating traces, metrics and logs


### PR DESCRIPTION
# Motivation

With the changes to the documentation that were made, we want to check that everything looks right on crates.io and doc.rs before releasing the main release/

So I'd like to release first in alpha, check, then release the actual 0.3.0

