### PR TITLE
chore:  bump crate to 0.3.0 and add changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Tracer Version(s)
       description: "Version(s) of the tracer affected by this bug"
-      placeholder: "0.2.1"
+      placeholder: "0.3.0"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "propagator"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "datadog-opentelemetry",
  "http-body-util",
@@ -2179,7 +2179,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_tracing"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "datadog-opentelemetry",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/dd-trace-rs"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ let logging_provider = datadog_opentelemetry::logs()
 
 For advanced usage and configuration information, check out [`DatadogTracingBuilder`],
 [`configuration::ConfigBuilder`] and the
-[library documentation](https://docs.rs/datadog-opentelemetry/0.3.0-alpha.1/datadog_opentelemetry/).
+[library documentation](https://docs.rs/datadog-opentelemetry/0.3.0/datadog_opentelemetry/).
 
 * Through env variables
 

--- a/datadog-opentelemetry/CHANGELOG.md
+++ b/datadog-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0 (Feb 27, 2026)
+
+- Add OTEL metrics support in https://github.com/DataDog/dd-trace-rs/pull/127
+- add OTEL logs support in https://github.com/DataDog/dd-trace-rs/pull/144
+- Remove error logs on transient trace export issues in https://github.com/DataDog/dd-trace-rs/pull/148
+
 ## 0.2.1 (Dec 11, 2025)
 
 - Fix Remote Config path parsing


### PR DESCRIPTION
# What does this PR do?

Prepare v0.3.0 release