### PR TITLE
feat(telemetry): add stable session identifier headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,8 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdd-common"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1182,8 +1181,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2704d0fcc9281cc844a63d15188aecc84d45725b77e489cc04ad30959b2000"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1212,8 +1210,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "prost",
 ]
@@ -1221,8 +1218,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a457381568835e7c3646f3f2d44ff4f3ebcda44d87332e2fdaeb20e6a8365dcd"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1235,8 +1231,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7bb67a865fe7e8a16aacc7bc43a805fb3b907c713e0b212e7a7abe6e0735cb"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1260,8 +1255,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47838e12ae2665250b4cdba4e3119230b79e3c522bb9f48dd0c87346f5a8f44"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "serde",
 ]
@@ -1269,8 +1263,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a737b43f01d6a0cbd1399c5b89863a5d2663fe7b19bf1d3ea28048abab396353"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1279,8 +1272,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "prost",
  "serde",
@@ -1290,8 +1282,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea447dc8a5d84c6b5eb6ea877c4fea4149fd29f6b45fcfc5cfd7edf82a18e056"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "hashbrown 0.15.5",
  "libdd-ddsketch",
@@ -1302,8 +1293,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59e9a0a41bb17d06fb85a70db3be04e53ddfb8f61a593939bb9677729214db"
+source = "git+https://github.com/DataDog/libdatadog?branch=ayan.khan%2Fstable-session-identifier-headers#fe2f6c72fd610eda69852c98721fdb7651300406"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,13 @@ description = "Reserved future DataDog package, contact info@datadoghq.com if yo
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 
 [workspace.dependencies]
-# Libdatadog dependencies - change to a stable version once we release
-libdd-data-pipeline = { version = "2.0.1", default-features = false }
-libdd-trace-utils = { version = "2.0.2", default-features = false }
-libdd-telemetry = { version = "3.0.0", default-features = false }
-libdd-common = { version = "2.0.1", default-features = false }
-libdd-tinybytes = { version = "1.1.0", default-features = false }
+# Libdatadog dependencies - pinned to branch with stable session identifier support.
+# TODO: revert to crates.io versions once DataDog/libdatadog#1782 is merged and published.
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", branch = "ayan.khan/stable-session-identifier-headers", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", branch = "ayan.khan/stable-session-identifier-headers", default-features = false }
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", branch = "ayan.khan/stable-session-identifier-headers", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", branch = "ayan.khan/stable-session-identifier-headers", default-features = false }
+libdd-tinybytes = { git = "https://github.com/DataDog/libdatadog", branch = "ayan.khan/stable-session-identifier-headers", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", features = [
     "trace",
     "metrics",

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -927,6 +927,7 @@ impl_config_value_provider!(option: String);
 pub struct Config {
     // # Global
     runtime_id: &'static str,
+    root_session_id: &'static str,
 
     // # Tracer
     tracer_version: &'static str,
@@ -1138,6 +1139,7 @@ impl Config {
 
         Self {
             runtime_id: default.runtime_id,
+            root_session_id: default.root_session_id,
             tracer_version: default.tracer_version,
             language_version: default.language_version,
             language: default.language,
@@ -1298,6 +1300,12 @@ impl Config {
         self.runtime_id
     }
 
+    /// Returns the root session ID for this process tree.
+    /// Equals `runtime_id` for the root process; inherited from the parent for child processes.
+    pub fn root_session_id(&self) -> &str {
+        self.root_session_id
+    }
+
     /// Returns the version of the Datadog tracer.
     pub fn tracer_version(&self) -> &str {
         self.tracer_version
@@ -1431,6 +1439,19 @@ impl Config {
         // TODO(paullgdc): Regenerate on fork? Would we even support forks?
         static RUNTIME_ID: OnceLock<String> = OnceLock::new();
         RUNTIME_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+    }
+
+    /// Root session ID for this process tree.
+    /// Reads `DD_ROOT_RS_SESSION_ID` if set (child process inheriting from parent),
+    /// otherwise falls back to `process_runtime_id()` (this process is the root).
+    fn process_root_session_id() -> &'static str {
+        static ROOT_SESSION_ID: OnceLock<String> = OnceLock::new();
+        ROOT_SESSION_ID.get_or_init(|| {
+            std::env::var("DD_ROOT_RS_SESSION_ID")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| Config::process_runtime_id().to_owned())
+        })
     }
 
     /// Returns whether telemetry collection is enabled.
@@ -1726,6 +1747,7 @@ impl std::fmt::Debug for Config {
 fn default_config() -> Config {
     Config {
         runtime_id: Config::process_runtime_id(),
+        root_session_id: Config::process_root_session_id(),
         env: ConfigItem::new(SupportedConfigurations::DD_ENV, None),
         // TODO(paullgdc): Default service naming detection, probably from arg0
         service: ConfigItemWithOverride::new_calculated(

--- a/datadog-opentelemetry/src/core/telemetry.rs
+++ b/datadog-opentelemetry/src/core/telemetry.rs
@@ -247,6 +247,7 @@ fn make_telemetry_worker(
             config.tracer_version().to_string(),
         );
         builder.runtime_id = Some(config.runtime_id().to_string());
+        builder.root_session_id = Some(config.root_session_id().to_string());
         builder.config = libdd_telemetry::config::Config::from_env();
         builder.config.telemetry_heartbeat_interval =
             Duration::from_secs_f64(config.telemetry_heartbeat_interval());


### PR DESCRIPTION
## Summary

Implements the [Stable Service Instance Identifier RFC](https://docs.google.com/document/d/1Fai2gZlkvfa_WQs_yJsmi3nUwiOsMtNu2LFBnbTHJRA) for dd-trace-rs.

- **`DD-Session-ID`**: present on every telemetry request (set to `runtime_id`)
- **`DD-Root-Session-ID`**: present only in child processes, inherited via `DD_ROOT_RS_SESSION_ID` env var
- `Config` gains a `root_session_id` field: reads `DD_ROOT_RS_SESSION_ID` at init, falls back to `runtime_id` for root processes

## Changes

- `src/core/configuration/configuration.rs`:
  - `Config`: add `root_session_id: &'static str` field
  - `process_root_session_id()`: reads `DD_ROOT_RS_SESSION_ID` env var or falls back to `runtime_id`
  - `root_session_id()`: public getter
- `src/core/telemetry.rs`: pass `root_session_id` to `TelemetryWorkerBuilder`

## Dependencies

**Blocked on**: DataDog/libdatadog#1782 — `TelemetryWorkerBuilder::root_session_id` field must be published before this can compile against the released crate.

CI will show a compile error on `builder.root_session_id` until the libdatadog PR is merged and published.

## Related

- System-tests PR: DataDog/system-tests#6510
- libdatadog PR: DataDog/libdatadog#1782
- Node.js PR: DataDog/dd-trace-js#7821
- Go PR: DataDog/dd-trace-go#4574

## Test plan

- [ ] Update `libdd-telemetry` version once DataDog/libdatadog#1782 is published
- [ ] Verify headers appear in telemetry requests in integration tests
- [ ] CI green