### PR TITLE
chore(release): bump datadog-opentelemetry to 0.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Tracer Version(s)
       description: "Version(s) of the tracer affected by this bug"
-      placeholder: "0.3.1"
+      placeholder: "0.3.2"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "propagator"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "datadog-opentelemetry",
  "http-body-util",
@@ -2179,7 +2179,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_tracing"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "datadog-opentelemetry",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/dd-trace-rs"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ opentelemetry-sdk.
 Add to you Cargo.toml
 
 ```toml
-datadog-opentelemetry = { version = "0.3.1" }
+datadog-opentelemetry = { version = "0.3.2" }
 ```
 
 ### Creating traces, metrics and logs
@@ -203,7 +203,7 @@ let logging_provider = datadog_opentelemetry::logs()
 
 For advanced usage and configuration information, check out [`DatadogTracingBuilder`],
 [`configuration::ConfigBuilder`] and the
-[library documentation](https://docs.rs/datadog-opentelemetry/0.3.1/datadog_opentelemetry/).
+[library documentation](https://docs.rs/datadog-opentelemetry/0.3.2/datadog_opentelemetry/).
 
 * Through env variables
 

--- a/datadog-opentelemetry/CHANGELOG.md
+++ b/datadog-opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.2 (Mar 27, 2026)
+
+- Change telemetry.sdk.name to datadog and telemetry.sdk.version to our own version in https://github.com/DataDog/dd-trace-rs/pull/196
+- Fix rpc.grpc.status_code stats serialization in https://github.com/DataDog/libdatadog/pull/1780
+- Tag spans with sampling rate (_dd.p.ksr) in https://github.com/DataDog/dd-trace-rs/pull/180
+
+
 ## 0.3.1 (Mar 17, 2026)
 
 - Fix sampling effective rate reporting in spans, as it was being truncated in https://github.com/DataDog/dd-trace-rs/pull/183

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -16,7 +16,7 @@
 //! Add to you Cargo.toml
 //!
 //! ```toml
-//! datadog-opentelemetry = { version = "0.3.1" }
+//! datadog-opentelemetry = { version = "0.3.2" }
 //! ```
 //!
 //! ### Creating traces, metrics and logs

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
@@ -20,7 +20,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1"
+      "telemetry.sdk.version": "0.3.2"
     },
     "metrics": {
       "_sampling_priority_v1": 2.0,
@@ -48,7 +48,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.3.1"
+         "telemetry.sdk.version": "0.3.2"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
@@ -16,7 +16,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1"
+      "telemetry.sdk.version": "0.3.2"
     },
     "metrics": {
       "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
@@ -18,7 +18,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1"
+      "telemetry.sdk.version": "0.3.2"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
@@ -18,7 +18,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1"
+      "telemetry.sdk.version": "0.3.2"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,
@@ -46,7 +46,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.3.1"
+         "telemetry.sdk.version": "0.3.2"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
@@ -17,7 +17,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1"
+      "telemetry.sdk.version": "0.3.2"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
@@ -24,7 +24,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1",
+      "telemetry.sdk.version": "0.3.2",
       "thread.name": "integration_tests::tracing_api::test_instrument_error_reporting"
     },
     "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
@@ -21,7 +21,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1",
+      "telemetry.sdk.version": "0.3.2",
       "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
     },
     "metrics": {
@@ -56,7 +56,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.3.1",
+         "telemetry.sdk.version": "0.3.2",
          "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
        },
        "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
@@ -20,7 +20,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.3.1",
+      "telemetry.sdk.version": "0.3.2",
       "thread.name": "integration_tests::tracing_api::test_smoke"
     },
     "metrics": {
@@ -55,7 +55,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.3.1",
+         "telemetry.sdk.version": "0.3.2",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {
@@ -89,7 +89,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.3.1",
+         "telemetry.sdk.version": "0.3.2",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {


### PR DESCRIPTION
# What does this PR do?

bump workspace version to 0.3.2

