### PR TITLE
chore(config_inversion): fix tag naming for update_central_configurations_version_range_v2 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,13 @@ validate_supported_configurations_v2_local_file:
     LOCAL_JSON_PATH: "supported-configurations.json"
     BACKFILLED: "true"
 
-# Executed on release (branch with tag vx.y.z)
+# Executed on release tag datadog-opentelemetry-vx.y.z
 update_central_configurations_version_range_v2:
   stage: config-validation
   image: registry.ddbuild.io/ci/libdatadog-build/packaging:100425777
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^datadog-opentelemetry-v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: on_success
   extends: .update_central_configurations_version_range_v2
   variables:
     LOCAL_REPO_NAME: "dd-trace-rs"


### PR DESCRIPTION
# What does this PR do?

Fix release tag naming for update_central_configurations_version_range_v2 job do that the job is lauched during (or after) a release.

# Motivation

We realized that dd-trace-rs was not running this job and thus not updating their supported configs on the FPD

# Additional Notes

