### PR TITLE
chore(ci): bump nightly version used in CI to a newer version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache
         uses: ./.github/actions/cache
-      - name: Install nightly-2024-12-16 toolchain and rustfmt
-        run: rustup install nightly-2024-12-16 && rustup default nightly-2024-12-16 && rustup component add rustfmt
+      - name: Install nightly-2026-04-07 toolchain and rustfmt
+        run: rustup install nightly-2026-04-07 && rustup default nightly-2026-04-07 && rustup component add rustfmt
       - run: cargo fmt --all -- --check
   clippy:
     name: "clippy #${{ matrix.platform }} ${{ matrix.rust_version }}"
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ["1.84.1", "stable", "nightly-2024-12-16"]
+        rust_version: ["1.84.1", "stable", "nightly-2026-04-07"]
         platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,14 @@ options.
 ## Rust Toolchain
 
 - **MSRV**: 1.84.1 (set via `rust-version` in `Cargo.toml`)
-- **Formatting**: pinned `nightly-2024-12-16` toolchain
+- **Formatting**: pinned `nightly-2026-04-07` toolchain
 
 Install the required toolchains and components:
 
 ```bash
-rustup install nightly-2024-12-16
-rustup component add rustfmt --toolchain nightly-2024-12-16
-rustup component add clippy --toolchain nightly-2024-12-16
+rustup install nightly-2026-04-07
+rustup component add rustfmt --toolchain nightly-2026-04-07
+rustup component add clippy --toolchain nightly-2026-04-07
 rustup install 1.84.1
 rustup component add clippy --toolchain 1.84.1
 ```
@@ -33,17 +33,17 @@ rustup component add clippy --toolchain 1.84.1
 
 ### Rust formatting
 
-Formatting uses `cargo fmt` with the pinned `nightly-2024-12-16` toolchain to ensure consistent
+Formatting uses `cargo fmt` with the pinned `nightly-2026-04-07` toolchain to ensure consistent
 output across environments:
 
 ```bash
-rustup run nightly-2024-12-16 cargo fmt -p <modified crate>
+rustup run nightly-2026-04-07 cargo fmt -p <modified crate>
 ```
 
 To check without modifying files (as CI does):
 
 ```bash
-rustup run nightly-2024-12-16 cargo fmt --all -- --check
+rustup run nightly-2026-04-07 cargo fmt --all -- --check
 ```
 
 ### Rust linting (clippy)
@@ -86,7 +86,7 @@ cargo install rumdl@0.1.25
 
 ```bash
 # Format code
-rustup run nightly-2024-12-16 cargo fmt --all
+rustup run nightly-2026-04-07 cargo fmt --all
 
 # Lint Rust (all feature combinations)
 cargo hack --each-feature clippy -- -D warnings


### PR DESCRIPTION
# Motivation

The nightly version we use dates back from january 2024 and is a pre-release  for 1.85... Not really cutting edge

