### PR TITLE
fix(config): do not allow empty string values for some ConfigItems

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -552,7 +552,7 @@ impl ConfigItemSourceUpdater<'_> {
         self.apply_result(default, result, transform)
     }
 
-    /// Updates a ConfigItem from not empty sources string with transformation
+    /// Updates a ConfigItem from non empty sources string with transformation
     pub fn update_non_empty_string<ParsedConfig, ConfigItemType, F>(
         &self,
         default: ConfigItemType,

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -552,6 +552,25 @@ impl ConfigItemSourceUpdater<'_> {
         self.apply_result(default, result, transform)
     }
 
+    /// Updates a ConfigItem from not empty sources string with transformation
+    pub fn update_non_empty_string<ParsedConfig, ConfigItemType, F>(
+        &self,
+        default: ConfigItemType,
+        transform: F,
+    ) -> ConfigItemType
+    where
+        ParsedConfig: Clone + ConfigurationValueProvider,
+        ConfigItemType: ValueSourceUpdater<ParsedConfig>,
+        F: FnOnce(String) -> ParsedConfig,
+    {
+        let result = self.sources.get(default.name());
+        match result.value {
+            Some(ref config_key) if config_key.value.is_empty() => default,
+            Some(_) => self.apply_result(default, result, transform),
+            None => default,
+        }
+    }
+
     /// Updates a ConfigItem from sources with parsed value and transformation
     pub fn update_parsed_with_transform<ParsedConfig, RawConfig, ConfigItemType, F>(
         &self,
@@ -1068,7 +1087,7 @@ impl Config {
             tracer_version: default.tracer_version,
             language_version: default.language_version,
             language: default.language,
-            service: cisu.update_string(default.service, ServiceName::Configured),
+            service: cisu.update_non_empty_string(default.service, ServiceName::Configured),
             env: cisu.update_string(default.env, Some),
             version: cisu.update_string(default.version, Some),
             // TODO(paullgdc): tags should be merged, not replaced
@@ -1085,10 +1104,11 @@ impl Config {
             ),
             agent_host: cisu.update_string(default.agent_host, Cow::Owned),
             trace_agent_port: cisu.update_parsed(default.trace_agent_port),
-            trace_agent_url: cisu.update_string(default.trace_agent_url, Cow::Owned),
+            trace_agent_url: cisu.update_non_empty_string(default.trace_agent_url, Cow::Owned),
             dogstatsd_agent_host: cisu.update_string(default.dogstatsd_agent_host, Cow::Owned),
             dogstatsd_agent_port: cisu.update_parsed(default.dogstatsd_agent_port),
-            dogstatsd_agent_url: cisu.update_string(default.dogstatsd_agent_url, Cow::Owned),
+            dogstatsd_agent_url: cisu
+                .update_non_empty_string(default.dogstatsd_agent_url, Cow::Owned),
 
             trace_partial_flush_enabled: cisu.update_parsed(default.trace_partial_flush_enabled),
             trace_partial_flush_min_spans: cisu
@@ -3128,6 +3148,25 @@ mod tests {
     #[test]
     fn test_dd_agent_url_from_url_empty() {
         let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [
+                ("DD_AGENT_HOST", "agent-host"),
+                ("DD_TRACE_AGENT_PORT", "4242"),
+            ],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+
+        assert_eq!(&*config.trace_agent_url(), "http://agent-host:4242");
+    }
+
+    #[test]
+    fn test_dd_agent_url_from_url_set_to_empty_string() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_AGENT_URL", "")],
+            ConfigSourceOrigin::Calculated,
+        ));
         sources.add_source(HashMapSource::from_iter(
             [
                 ("DD_AGENT_HOST", "agent-host"),


### PR DESCRIPTION
# What does this PR do?

Add `ConfigItemSourceUpdater::update_non_empty_string` and use it for `service`, `trace_agent_url` and `dogstatsd_agent_url`

# Motivation

`ConfigItem`s track their value to know where it came from, and also, in some cases, it is possible to override their value.
`trace_agent_url` is one of those cases. 
As we take into account other config items to craft its final value, its source origin is set as calculated (`ConfigSourceOrigin::Calculated`) [when Config object is built](https://github.com/DataDog/dd-trace-rs/blob/main/datadog-opentelemetry/src/core/configuration/configuration.rs#L1848)

Problem: there is a ST setting `DD_TRACE_AGENT_URL=""`, so our config logic checks that `DD_TRACE_AGENT_URL` env var exists, and sets `trace_agent_url` as an empty value and `ConfigSourceOrigin::EnvVar` origin
Then when building Config object, the `trace_agent_url` is calculated and set but it doesn't have any effect because the source is taken into account when we get the `ConfigItem` value.

[Here](https://github.com/DataDog/dd-trace-rs/blob/main/datadog-opentelemetry/src/core/configuration/configuration.rs#L443) and [here](https://github.com/DataDog/dd-trace-rs/blob/main/datadog-opentelemetry/src/core/configuration/configuration.rs#L402) you can see that the priority of the `ConfigSourceOrigin` matters, so as the `trace_agent_url`'s original value (an empty string) came from an env var `DD_TRACE_AGENT_URL` and `ConfigSourceOrigin::EnvVar` > `ConfigSourceOrigin::Calculated` the final value is an empty string instead of the calculated value.

# Tests
Added `test_dd_agent_url_from_url_set_to_empty_string` to test the changes but existing [test_propagation_config_from_source](https://github.com/DataDog/dd-trace-rs/blob/main/datadog-opentelemetry/src/core/configuration/configuration.rs#L2500C8-L2500C43) probes that other origins have not been affected