### PR TITLE
feat: publish tracer metadata upon global init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "libc",
  "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "hyper-util",
  "libdd-common",
  "libdd-data-pipeline",
+ "libdd-library-config",
  "libdd-telemetry",
  "libdd-tinybytes",
  "libdd-trace-utils",
@@ -542,6 +543,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "event-listener"
@@ -1144,9 +1155,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdd-common"
@@ -1196,7 +1207,7 @@ dependencies = [
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 3.0.1",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1230,6 +1241,24 @@ dependencies = [
  "libdd-common",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "libdd-library-config"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33082726b20ce7cf364032f3f600f3c24db25928dcde5368f8e25e194c2bf47"
+dependencies = [
+ "anyhow",
+ "libdd-trace-protobuf 2.0.0",
+ "memfd",
+ "prost",
+ "rand 0.8.5",
+ "rmp",
+ "rmp-serde",
+ "rustix",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -1273,7 +1302,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 3.0.1",
+]
+
+[[package]]
+name = "libdd-trace-protobuf"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+dependencies = [
+ "prost",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -1295,7 +1335,7 @@ checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
 dependencies = [
  "hashbrown 0.15.5",
  "libdd-ddsketch",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 3.0.1",
  "libdd-trace-utils",
 ]
 
@@ -1319,7 +1359,7 @@ dependencies = [
  "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 3.0.1",
  "prost",
  "rand 0.8.5",
  "rmp",
@@ -1331,6 +1371,12 @@ dependencies = [
  "tracing",
  "urlencoding",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1377,6 +1423,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "mime"
@@ -2027,6 +2082,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2191,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2655,6 +2736,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libdd-trace-utils = { version = "3.0.0", default-features = false }
 libdd-telemetry = { version = "4.0.0", default-features = false }
 libdd-common = { version = "3.0.1", default-features = false }
 libdd-tinybytes = { version = "1.1.0", default-features = false }
+libdd-library-config = { version = "1.1.0", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", features = [
     "trace",
     "metrics",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -54,6 +54,7 @@ digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Develop
 displaydoc,https://github.com/yaahc/displaydoc,MIT OR Apache-2.0,Jane Lusby <jlusby@yaah.dev>
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
+errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
 event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>"
 event-listener-strategy,https://github.com/smol-rs/event-listener-strategy,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
@@ -111,18 +112,21 @@ libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apac
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
 libdd-dogstatsd-client,https://github.com/DataDog/libdatadog/tree/main/libdd-dogstatsd-client,Apache-2.0,The libdd-dogstatsd-client Authors
+libdd-library-config,https://github.com/DataDog/libdatadog/tree/main/libdd-library-config,Apache-2.0,The libdd-library-config Authors
 libdd-telemetry,https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry,Apache-2.0,The libdd-telemetry Authors
 libdd-tinybytes,https://github.com/DataDog/libdatadog/tree/main/libdd-tinybytes,Apache-2.0,The libdd-tinybytes Authors
 libdd-trace-normalization,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-normalization,Apache-2.0,David Lee <david.lee@datadoghq.com>
 libdd-trace-protobuf,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-protobuf,Apache-2.0,The libdd-trace-protobuf Authors
 libdd-trace-stats,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-stats,Apache-2.0,The libdd-trace-stats Authors
 libdd-trace-utils,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-utils,Apache-2.0,The libdd-trace-utils Authors
+linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+memfd,https://github.com/lucab/memfd-rs,MIT OR Apache-2.0,"Luca Bruno <lucab@lucabruno.net>, Simonas Kazlauskas <memfd@kazlauskas.me>"
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
@@ -180,6 +184,7 @@ rmpv,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmai
 rustc-demangle,https://github.com/rust-lang/rustc-demangle,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 rustc_version,https://github.com/djc/rustc-version-rs,MIT OR Apache-2.0,The rustc_version Authors
 rustc_version_runtime,https://github.com/seppo0010/rustc-version-runtime-rs,MIT,Sebastian Waisbrot <seppo0010@gmail.com>
+rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
 rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 same-file,https://github.com/BurntSushi/same-file,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
@@ -191,6 +196,7 @@ serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaa
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_regex,https://github.com/tailhook/serde-regex,MIT OR Apache-2.0,paul@colomiets.name
 serde_urlencoded,https://github.com/nox/serde_urlencoded,MIT OR Apache-2.0,Anthony Ramine <n.oxyde@gmail.com>
+serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
@@ -238,6 +244,7 @@ unarray,https://github.com/cameron1024/unarray,MIT OR Apache-2.0,The unarray Aut
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
 unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
+unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 urlencoding,https://github.com/kornelski/rust_urlencoding,MIT,"Kornel <kornel@geekhood.net>, Bertram Truong <b@bertramtruong.com>"
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -67,6 +67,7 @@ libdd-tinybytes = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
 libdd-library-config = { workspace = true }
+libc = "0.2"
 
 [dev-dependencies]
 assert_unordered = "0.3"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -26,7 +26,6 @@ opentelemetry-otlp = { workspace = true, features = [
     "metrics",
     "logs",
 ], default-features = false, optional = true }
-libdd-library-config = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true }
 
@@ -65,6 +64,9 @@ libdd-trace-utils = { workspace = true }
 libdd-telemetry = { workspace = true }
 libdd-common = { workspace = true }
 libdd-tinybytes = { workspace = true }
+
+[target.'cfg(target_os="linux")'.dependencies]
+libdd-library-config = { workspace = true }
 
 [dev-dependencies]
 assert_unordered = "0.3"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "metrics",
     "logs",
 ], default-features = false, optional = true }
+libdd-library-config = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true }
 

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1611,18 +1611,16 @@ impl Config {
 
     /// Generate tracer metadata from this config.
     pub(crate) fn to_tracer_metadata(&self) -> TracerMetadata {
-        let mut metadata = TracerMetadata::default();
-
-        metadata.runtime_id = Some(self.runtime_id.to_owned());
-        metadata.tracer_language = "rust".to_owned();
-        metadata.tracer_version = self.tracer_version.to_owned();
-        // What about metadata.hostname?
-        metadata.service_name = Some(self.service().to_owned());
-        metadata.service_env = self.env().map(str::to_owned);
-        metadata.service_version = self.version().map(str::to_owned);
-        // What about metadata.process_tags and metadata.container_id ?
-
-        metadata
+        TracerMetadata {
+            runtime_id: Some(self.runtime_id.to_owned()),
+            tracer_language: "rust".to_owned(),
+            tracer_version: self.tracer_version.to_owned(),
+            service_name: Some(self.service().to_owned()),
+            service_env: self.env().map(str::to_owned),
+            service_version: self.version().map(str::to_owned),
+            // What about hostname, process_tags and container_id ?
+            ..Default::default()
+        }
     }
 }
 

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1,7 +1,6 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use libdd_library_config::tracer_metadata::TracerMetadata;
 use libdd_telemetry::data::Configuration;
 use std::collections::{HashSet, VecDeque};
 use std::fmt::Display;
@@ -10,6 +9,9 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{borrow::Cow, sync::OnceLock};
+
+#[cfg(target_os = "linux")]
+use libdd_library_config::tracer_metadata::TracerMetadata;
 
 use rustc_version_runtime::version;
 
@@ -1610,6 +1612,7 @@ impl Config {
     }
 
     /// Generate tracer metadata from this config.
+    #[cfg(target_os = "linux")]
     pub(crate) fn to_tracer_metadata(&self) -> TracerMetadata {
         TracerMetadata {
             runtime_id: Some(self.runtime_id.to_owned()),

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1614,14 +1614,37 @@ impl Config {
     /// Generate tracer metadata from this config.
     #[cfg(target_os = "linux")]
     pub(crate) fn to_tracer_metadata(&self) -> TracerMetadata {
+        fn hostname() -> String {
+            let mut buf = Vec::with_capacity(256);
+
+            unsafe {
+                // Safety: buf is valid for writes for at most buf.len().
+                if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) == 0 {
+                    // Amusingly (so to speak), if the host name doesn't fit in `buf.len()`,
+                    // gethostname will put a truncated version in the buffer, which isn't
+                    // null-terminated. So the resulting buffer might or might not be a valid C
+                    // string...
+                    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+                    buf.truncate(len);
+                    // Note: use from_utf8_lossy_owned once it's stabilized
+                    String::from_utf8(buf)
+                        .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned())
+                } else {
+                    String::new()
+                }
+            }
+        }
+
         TracerMetadata {
             runtime_id: Some(self.runtime_id.to_owned()),
             tracer_language: "rust".to_owned(),
             tracer_version: self.tracer_version.to_owned(),
+            hostname: hostname(),
             service_name: Some(self.service().to_owned()),
             service_env: self.env().map(str::to_owned),
             service_version: self.version().map(str::to_owned),
-            // What about hostname, process_tags and container_id ?
+            container_id: libdd_common::entity_id::get_container_id().map(str::to_owned),
+            // TODO: add the process tags. For now, we can't easily get them.
             ..Default::default()
         }
     }

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1,6 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use libdd_library_config::tracer_metadata::TracerMetadata;
 use libdd_telemetry::data::Configuration;
 use std::collections::{HashSet, VecDeque};
 use std::fmt::Display;
@@ -1606,6 +1607,22 @@ impl Config {
     /// Return tags max length
     pub fn datadog_tags_max_length(&self) -> usize {
         *self.datadog_tags_max_length.value()
+    }
+
+    /// Generate tracer metadata from this config.
+    pub(crate) fn to_tracer_metadata(&self) -> TracerMetadata {
+        let mut metadata = TracerMetadata::default();
+
+        metadata.runtime_id = Some(self.runtime_id.to_owned());
+        metadata.tracer_language = "rust".to_owned();
+        metadata.tracer_version = self.tracer_version.to_owned();
+        // What about metadata.hostname?
+        metadata.service_name = Some(self.service().to_owned());
+        metadata.service_env = self.env().map(str::to_owned);
+        metadata.service_version = self.version().map(str::to_owned);
+        // What about metadata.process_tags and metadata.container_id ?
+
+        metadata
     }
 }
 

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1615,7 +1615,7 @@ impl Config {
     #[cfg(target_os = "linux")]
     pub(crate) fn to_tracer_metadata(&self) -> TracerMetadata {
         fn hostname() -> String {
-            let mut buf = Vec::with_capacity(256);
+            let mut buf = vec![0; 256];
 
             unsafe {
                 // Safety: buf is valid for writes for at most buf.len().

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -344,10 +344,54 @@ impl DatadogTracingBuilder {
     }
 
     /// Initializes the Tracer Provider, and the Text Map Propagator and install
-    /// them globally
+    /// them globally.
+    ///
+    /// On compatible platforms (currently Linux), [Self::init] (as opposed to [Self::init_local])
+    /// automatically publishes tracer metadata using both a Datadog-specific protocol and to the
+    /// [OTel process
+    /// context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4719-process-ctx.md).
+    /// Publication errors are logged but otherwise ignored.
     pub fn init(self) -> SdkTracerProvider {
-        let (tracer_provider, propagator) = self.init_local();
+        let config = self.config.unwrap_or_else(|| Config::builder().build());
 
+        // For now, both the datadog-specific and the otel publications are linux-specific and
+        // involves fd manipulations, so we gate it.
+        #[cfg(target_os = "linux")]
+        {
+            use libdd_library_config::tracer_metadata::{
+                store_tracer_metadata, AnonymousFileHandle,
+            };
+            use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+            use std::sync::atomic::{AtomicI32, Ordering};
+
+            // This stores the current file descriptor corresponding to the published tracer
+            // metadata, if any. If another tracer is set globally later, we swap the new fd in and
+            // close the previous descriptor.
+            //
+            // `RawFd` is defined as `i32` on almost all but exotic platforms, and -1 is never a
+            // valid descriptor (this is the error value returned by e.g. the `open` syscall).
+            static CURRENT_TRACER_METADATA_FD: AtomicI32 = AtomicI32::new(-1);
+            let tracer_metadata = config.to_tracer_metadata();
+
+            match store_tracer_metadata(&tracer_metadata) {
+                Ok(AnonymousFileHandle::Linux(fd)) => {
+                    let previous =
+                        CURRENT_TRACER_METADATA_FD.swap(fd.into_raw_fd(), Ordering::Relaxed);
+
+                    if previous != -1 {
+                        // Safety: we only ever store a fd coming from an owned fd in
+                        // TRACER_METADATA_FD.
+                        let _ = unsafe { OwnedFd::from_raw_fd(previous) };
+                    }
+                }
+                Err(e) => {
+                    dd_warn!("Couldn't publish the tracer metadata during global initialization. External readers such as an eBPF profiler won't be able to access the corresponding resource attributes: {e}");
+                }
+            }
+        }
+
+        let (tracer_provider, propagator) =
+            make_tracer(Arc::new(config), self.tracer_provider, self.resource);
         opentelemetry::global::set_text_map_propagator(propagator);
         opentelemetry::global::set_tracer_provider(tracer_provider.clone());
         tracer_provider

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -347,47 +347,18 @@ impl DatadogTracingBuilder {
     /// them globally.
     ///
     /// On compatible platforms (currently Linux), [Self::init] (as opposed to [Self::init_local])
-    /// automatically publishes tracer metadata using both a Datadog-specific protocol and to the
-    /// [OTel process
+    /// automatically publishes tracer metadata to the [OTel process
     /// context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4719-process-ctx.md).
     /// Publication errors are logged but otherwise ignored.
     pub fn init(self) -> SdkTracerProvider {
         let config = self.config.unwrap_or_else(|| Config::builder().build());
 
-        // For now, both the datadog-specific and the otel publications are linux-specific and
-        // involves fd manipulations, so we gate it.
+        // For now, otel process context spec is linux-specific.
         #[cfg(target_os = "linux")]
-        {
-            use libdd_library_config::tracer_metadata::{
-                store_tracer_metadata, AnonymousFileHandle,
-            };
-            use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
-            use std::sync::atomic::{AtomicI32, Ordering};
-
-            // This stores the current file descriptor corresponding to the published tracer
-            // metadata, if any. If another tracer is set globally later, we swap the new fd in and
-            // close the previous descriptor.
-            //
-            // `RawFd` is defined as `i32` on almost all but exotic platforms, and -1 is never a
-            // valid descriptor (this is the error value returned by e.g. the `open` syscall).
-            static CURRENT_TRACER_METADATA_FD: AtomicI32 = AtomicI32::new(-1);
-            let tracer_metadata = config.to_tracer_metadata();
-
-            match store_tracer_metadata(&tracer_metadata) {
-                Ok(AnonymousFileHandle::Linux(fd)) => {
-                    let previous =
-                        CURRENT_TRACER_METADATA_FD.swap(fd.into_raw_fd(), Ordering::Relaxed);
-
-                    if previous != -1 {
-                        // Safety: we only ever store a fd coming from an owned fd in
-                        // TRACER_METADATA_FD.
-                        let _ = unsafe { OwnedFd::from_raw_fd(previous) };
-                    }
-                }
-                Err(e) => {
-                    dd_warn!("Couldn't publish the tracer metadata during global initialization. External readers such as an eBPF profiler won't be able to access the corresponding resource attributes: {e}");
-                }
-            }
+        if let Err(e) = libdd_library_config::otel_process_ctx::linux::publish(
+            &config.to_tracer_metadata().to_otel_process_ctx(),
+        ) {
+            dd_warn!("Couldn't publish the tracer metadata during global initialization. External readers such as an eBPF profiler won't be able to access the corresponding resource attributes: {e}");
         }
 
         let (tracer_provider, propagator) =
@@ -402,6 +373,11 @@ impl DatadogTracingBuilder {
     ///
     /// You will need to set them up yourself, at a latter point if you want to use global tracing
     /// methods and library integrations
+    ///
+    /// # Process context
+    ///
+    /// As opposed as [Self::init], this method won't automatically publish tracer metadata to the
+    /// OTel process context.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# What does this PR do?

This PR hooks up `store_tracer_metadata` from `libdd-library-config` into tracer initialization. Without changing the API or anything else, this will automatically publish tracer metadata as resource attributes both through a pre-existing Datadog-specific protocol, and through the OTel process context.

# Motivation

This is a required step toward supporting ePBF profiling in dd-trace-rs.

# Additional Notes

- I couldn't find attributes for `hostname`, `process_tags` and `container_id` in the config. Happy to be pointed at which value we should use for those (or just let them initialized by default)
- While it's not really expected that people set up multiple tracers in a single app, it's permitted by the dd-trace-rs API. The process context is global to the whole process, hence we can ask when should we set or update this context. The answer of this PR is to do it automatically when a tracer is set globally through `init()`, which should be the common way of doing things, but do not do it for local initialization through `init_local`. This is somehow arbitrary and can be debated.