### PR TITLE
test(sampling): verify format_sampling_rate is locale-independent

### DIFF
--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -67,6 +67,7 @@ libdd-tinybytes = { workspace = true }
 
 [dev-dependencies]
 assert_unordered = "0.3"
+libc = "0.2"
 pretty_assertions = "1.4.1"
 proptest = { version = "1.9", features = ["std"], default-features = false }
 test-case = "3.3.1"

--- a/datadog-opentelemetry/src/sampling/datadog_sampler.rs
+++ b/datadog-opentelemetry/src/sampling/datadog_sampler.rs
@@ -1159,6 +1159,44 @@ mod tests {
     }
 
     #[test]
+    fn test_format_sampling_rate_locale_independent() {
+        use std::ffi::CString;
+
+        // Save original locale
+        let original_locale = unsafe {
+            let loc = libc::setlocale(libc::LC_ALL, std::ptr::null());
+            if loc.is_null() {
+                None
+            } else {
+                Some(CString::from(std::ffi::CStr::from_ptr(loc)))
+            }
+        };
+
+        // Set German locale (uses comma as decimal separator)
+        let german = CString::new("de_DE.UTF-8").unwrap();
+        let result = unsafe { libc::setlocale(libc::LC_ALL, german.as_ptr()) };
+
+        if result.is_null() {
+            eprintln!("de_DE.UTF-8 locale not available, skipping locale test");
+            return;
+        }
+
+        // Rust's format! macro is locale-independent by design.
+        // This test documents that contract.
+        assert_eq!(format_sampling_rate(0.3), Some("0.3".to_string()));
+        assert_eq!(format_sampling_rate(1.0), Some("1".to_string()));
+        assert_eq!(format_sampling_rate(0.5), Some("0.5".to_string()));
+        assert_eq!(format_sampling_rate(0.000001), Some("0.000001".to_string()));
+
+        // Restore original locale
+        if let Some(orig) = original_locale {
+            unsafe {
+                libc::setlocale(libc::LC_ALL, orig.as_ptr());
+            }
+        }
+    }
+
+    #[test]
     fn test_should_sample_parent_context() {
         let sampler = DatadogSampler::new(vec![], 100);
 


### PR DESCRIPTION
# What does this PR do?

Adds a unit test that verifies `format_sampling_rate` produces dot-delimited decimal output regardless of the process locale. The test sets `LC_ALL=de_DE.UTF-8` (which uses comma as decimal separator) and asserts that formatted rates still use periods.

# Motivation

Documents and guards the contract that Rust's `format!` macro is locale-independent, ensuring sampling rate strings sent over the wire always use the expected decimal format. This is a regression safety net for any future refactoring that might introduce locale-sensitive formatting (e.g., via C FFI).

# Additional Notes

- `libc = "0.2"` added as a dev-dependency for `setlocale` access.
- The test gracefully skips (early return with eprintln) if `de_DE.UTF-8` is not installed on the runner.