### PR TITLE
ci: update system-tests pin to post-merge SHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -165,7 +165,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5  # main
     permissions:
       contents: read
       id-token: write
@@ -174,5 +174,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1 # main
+      ref: 23941ab6de4122b7d0ca2b0d4aa7818def68a0d5 # main
       push_to_test_optimization: true


### PR DESCRIPTION
Update system-tests pin from 1e5d6b7 to 23941ab (post-merge SHA) to activate dd-sts test optimization.