### PR TITLE
feat(baggage): fix DatadogPropagator::fields

### DIFF
--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -72,7 +72,7 @@ pub struct DatadogCompositePropagator<C: PropagationConfig> {
     config: Arc<C>,
     extractors: Vec<TracePropagationStyle>,
     injectors: Vec<TracePropagationStyle>,
-    keys: Vec<String>,
+    fields: Vec<String>,
 }
 
 impl<C: PropagationConfig> DatadogCompositePropagator<C> {
@@ -101,18 +101,18 @@ impl<C: PropagationConfig> DatadogCompositePropagator<C> {
             .copied()
             .collect();
 
-        let keys = injectors.iter().fold(Vec::new(), |mut keys, injector| {
+        let fields = injectors.iter().fold(Vec::new(), |mut fields, injector| {
             <TracePropagationStyle as Propagator<C>>::keys(injector)
                 .iter()
-                .for_each(|key| keys.push(key.clone()));
-            keys
+                .for_each(|key| fields.push(key.clone()));
+            fields
         });
 
         Self {
             config,
             extractors,
             injectors,
-            keys,
+            fields,
         }
     }
 
@@ -138,8 +138,8 @@ impl<C: PropagationConfig> DatadogCompositePropagator<C> {
     }
 
     /// Returns the header keys used by the configured injectors.
-    pub fn keys(&self) -> &[String] {
-        &self.keys
+    pub fn fields(&self) -> &[String] {
+        &self.fields
     }
 
     fn extract_available_contexts(
@@ -1334,7 +1334,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_default_keys() {
+    fn test_default_fields() {
         let inject = Some(vec![
             TracePropagationStyle::Datadog,
             TracePropagationStyle::TraceContext,
@@ -1353,22 +1353,22 @@ pub(crate) mod tests {
                 "traceparent",
                 "tracestate"
             ],
-            propagator.keys()
+            propagator.fields()
         )
     }
 
     #[test]
-    fn test_tracecontext_keys() {
+    fn test_tracecontext_fields() {
         let inject = Some(vec![TracePropagationStyle::TraceContext]);
         let config = get_config(None, inject);
 
         let propagator = DatadogCompositePropagator::new(config);
 
-        assert_eq!(vec!["traceparent", "tracestate"], propagator.keys())
+        assert_eq!(vec!["traceparent", "tracestate"], propagator.fields())
     }
 
     #[test]
-    fn test_datadog_keys() {
+    fn test_datadog_fields() {
         let inject = Some(vec![TracePropagationStyle::Datadog]);
         let config = get_config(None, inject);
 
@@ -1382,7 +1382,7 @@ pub(crate) mod tests {
                 "x-datadog-sampling-priority",
                 "x-datadog-tags",
             ],
-            propagator.keys()
+            propagator.fields()
         )
     }
 }

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -101,8 +101,8 @@ impl<C: PropagationConfig> DatadogCompositePropagator<C> {
             .copied()
             .collect();
 
-        let keys = extractors.iter().fold(Vec::new(), |mut keys, extractor| {
-            <TracePropagationStyle as Propagator<C>>::keys(extractor)
+        let keys = injectors.iter().fold(Vec::new(), |mut keys, injector| {
+            <TracePropagationStyle as Propagator<C>>::keys(injector)
                 .iter()
                 .for_each(|key| keys.push(key.clone()));
             keys
@@ -929,10 +929,11 @@ pub(crate) mod tests {
 
     fn get_config(
         extract: Option<Vec<TracePropagationStyle>>,
-        _: Option<Vec<TracePropagationStyle>>,
+        inject: Option<Vec<TracePropagationStyle>>,
     ) -> Arc<Config> {
         let mut builder = Config::builder();
         builder.set_trace_propagation_style_extract(extract.unwrap_or_default());
+        builder.set_trace_propagation_style_inject(inject.unwrap_or_default());
         Arc::new(builder.build())
     }
 
@@ -1334,11 +1335,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_default_keys() {
-        let extract = Some(vec![
+        let inject = Some(vec![
             TracePropagationStyle::Datadog,
             TracePropagationStyle::TraceContext,
         ]);
-        let config = get_config(extract, None);
+        let config = get_config(None, inject);
 
         let propagator = DatadogCompositePropagator::new(config);
 
@@ -1358,8 +1359,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_tracecontext_keys() {
-        let extract = Some(vec![TracePropagationStyle::TraceContext]);
-        let config = get_config(extract, None);
+        let inject = Some(vec![TracePropagationStyle::TraceContext]);
+        let config = get_config(None, inject);
 
         let propagator = DatadogCompositePropagator::new(config);
 
@@ -1368,8 +1369,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_datadog_keys() {
-        let extract = Some(vec![TracePropagationStyle::Datadog]);
-        let config = get_config(extract, None);
+        let inject = Some(vec![TracePropagationStyle::Datadog]);
+        let config = get_config(None, inject);
 
         let propagator = DatadogCompositePropagator::new(config);
 

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -137,7 +137,7 @@ impl<C: PropagationConfig> DatadogCompositePropagator<C> {
             .for_each(|propagator| propagator.inject(context, carrier, self.config.as_ref()));
     }
 
-    /// Returns the header keys used by the configured extractors.
+    /// Returns the header keys used by the configured injectors.
     pub fn keys(&self) -> &[String] {
         &self.keys
     }

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -69,7 +69,6 @@ pub struct DatadogPropagator {
     baggage_propagator: BaggagePropagator,
     baggage_extract: bool,
     baggage_inject: bool,
-    fields: Vec<String>,
 }
 
 impl DatadogPropagator {
@@ -79,18 +78,6 @@ impl DatadogPropagator {
         let baggage_inject =
             get_injectors(config.as_ref()).contains(&TracePropagationStyle::Baggage);
         let inner = DatadogCompositePropagator::new(config.clone());
-        // Build fields() from injectors only (per OTel spec, fields() represents what the
-        // propagator *writes*). inner.keys() is extractor-derived, so we strip the baggage key
-        // from it and re-add it solely based on baggage_inject.
-        let mut fields: Vec<String> = inner
-            .keys()
-            .iter()
-            .filter(|k| k.as_str() != crate::propagation::baggage::BAGGAGE_KEY)
-            .cloned()
-            .collect();
-        if baggage_inject {
-            fields.push(crate::propagation::baggage::BAGGAGE_KEY.to_owned());
-        }
         DatadogPropagator {
             inner,
             registry,
@@ -98,7 +85,6 @@ impl DatadogPropagator {
             baggage_propagator: BaggagePropagator::new(),
             baggage_extract,
             baggage_inject,
-            fields,
         }
     }
 
@@ -238,7 +224,7 @@ impl TextMapPropagator for DatadogPropagator {
 
     fn fields(&self) -> opentelemetry::propagation::text_map_propagator::FieldIter<'_> {
         let fields: &[String] = if self.cfg.enabled() {
-            &self.fields
+            self.inner.keys()
         } else {
             &[]
         };

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -224,7 +224,7 @@ impl TextMapPropagator for DatadogPropagator {
 
     fn fields(&self) -> opentelemetry::propagation::text_map_propagator::FieldIter<'_> {
         let fields: &[String] = if self.cfg.enabled() {
-            self.inner.keys()
+            self.inner.fields()
         } else {
             &[]
         };


### PR DESCRIPTION
# What does this PR do?

- change `DatadogCompositePropagator` to obtain keys from injectors according to [Otel spec](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#fields-1).
- remove the not needed `DatadogPropagator::fields` property
