### PR TITLE
refactor(rc): wire libdatadog Remote Config client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -392,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -493,8 +493,8 @@ dependencies = [
  "hashbrown 0.15.5",
  "hyper",
  "libc",
- "libdd-common 3.0.2",
- "libdd-common 4.0.0",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-telemetry",
@@ -526,13 +526,14 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
  "base64",
  "futures-util",
  "http",
  "http-body-util",
- "libdd-common 4.0.0",
+ "libdd-common",
  "libdd-trace-protobuf 3.0.1",
  "manual_future",
  "serde",
@@ -776,8 +777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1266,15 +1269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,39 +1320,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libdd-common"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c779949577250487179d904508f18750070e9a01eb58dce378409ec5fa066f3b"
+name = "libdd-capabilities"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
  "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
  "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "libc",
- "nix",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
  "thiserror 1.0.69",
- "tokio",
- "tower-service",
- "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body-util",
+ "libdd-capabilities",
+ "libdd-common",
 ]
 
 [[package]]
 name = "libdd-common"
 version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1392,21 +1379,24 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358411451d99011f13c7628acee25dc144f2bbeade87acf10fa7d5ffce1053dc"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bytes",
  "either",
+ "getrandom 0.2.17",
  "http",
  "http-body-util",
- "libdd-common 3.0.2",
- "libdd-ddsketch",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "libdd-dogstatsd-client",
+ "libdd-shared-runtime",
  "libdd-telemetry",
  "libdd-tinybytes",
- "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 3.0.1",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1422,8 +1412,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "prost",
 ]
@@ -1431,13 +1420,12 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8eca39d1e2ef6267cf77fc51eb7ebc7d4f44827e150b4d317c29d8c33bf87"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 3.0.2",
+ "libdd-common",
  "serde",
  "tracing",
 ]
@@ -1461,20 +1449,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-shared-runtime"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
+dependencies = [
+ "async-trait",
+ "futures",
+ "libdd-capabilities",
+ "libdd-common",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "libdd-telemetry"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78774ffce79da677602829d7fe27468283e5349010e974257233edf4cd12b783"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
+ "bytes",
  "futures",
  "hashbrown 0.15.5",
  "http",
  "http-body-util",
  "libc",
- "libdd-common 3.0.2",
+ "libdd-common",
  "libdd-ddsketch",
+ "libdd-shared-runtime",
  "serde",
  "serde_json",
  "sys-info",
@@ -1488,8 +1492,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47838e12ae2665250b4cdba4e3119230b79e3c522bb9f48dd0c87346f5a8f44"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "serde",
 ]
@@ -1497,11 +1500,10 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 3.0.1",
 ]
 
 [[package]]
@@ -1518,17 +1520,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-dependencies = [
- "prost",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1809242895edc53ac51a21287829f42474e749dbc222ea7f414cb3f0d1f91d4e"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "prost",
  "serde",
@@ -1538,36 +1530,50 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "hashbrown 0.15.5",
+ "http",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "libdd-ddsketch",
- "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime",
+ "libdd-trace-protobuf 3.0.1",
  "libdd-trace-utils",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870506e9bb79c93ce5bbfe9d715c53c7ea393a177c7299f0bf43745c0adea0c7"
+source = "git+https://github.com/DataDog/libdatadog?branch=igor%2Frc%2Fdi-refactor-claude#9b0bd6bc0ff1b04e2f1cf71efd5311e84726a7de"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "cargo-platform",
  "cargo_metadata",
  "futures",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
  "httpmock",
  "hyper",
  "indexmap 2.14.0",
- "libdd-common 3.0.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 3.0.1",
  "prost",
  "rand 0.8.6",
  "rmp",
@@ -2035,7 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,10 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -31,6 +16,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anes"
@@ -49,21 +43,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -86,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -129,27 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,9 +133,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -172,15 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -193,20 +163,20 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075f133bee430b7644c54fb629b9b4420346ffa275a45c81a6babe8b09b4f51"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "camino"
-version = "1.1.12"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -240,18 +210,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -261,11 +232,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -297,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -316,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "concurrent-queue"
@@ -331,11 +305,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -354,6 +329,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -452,12 +437,46 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -467,16 +486,15 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "assert_unordered",
- "base64 0.21.7",
  "criterion",
  "datadog-opentelemetry",
+ "datadog-remote-config",
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
- "http-body-util",
  "hyper",
- "hyper-util",
  "libc",
- "libdd-common",
+ "libdd-common 3.0.2",
+ "libdd-common 4.0.0",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-telemetry",
@@ -491,11 +509,10 @@ dependencies = [
  "opentelemetry_sdk",
  "pretty_assertions",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version_runtime",
  "serde",
  "serde_json",
- "sha2",
  "test-case",
  "thiserror 1.0.69",
  "tokio",
@@ -504,6 +521,39 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "datadog-remote-config"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "base64",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "libdd-common 4.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "manual_future",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -534,6 +584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -575,6 +631,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -605,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -620,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -630,15 +692,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -647,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -664,15 +726,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -682,9 +744,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -694,7 +756,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -710,38 +771,45 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -749,7 +817,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -758,13 +826,20 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -779,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -789,12 +864,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
  "http",
@@ -813,6 +894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,12 +913,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -872,14 +958,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511f510e9b1888d67f10bab4397f8b019d2a9b249a2c10acbce2d705b1b32e26"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "crossbeam-utils",
  "form_urlencoded",
@@ -898,7 +984,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.14",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -906,13 +992,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -923,6 +1010,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -940,14 +1043,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -959,19 +1061,45 @@ dependencies = [
  "socket2",
  "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
  "windows-registry",
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
+name = "iana-time-zone"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -979,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -992,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1006,15 +1134,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1026,15 +1154,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1044,6 +1172,18 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1058,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1068,36 +1208,38 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "equivalent",
- "hashbrown 0.16.0",
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.9"
+name = "indexmap"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1105,13 +1247,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1134,19 +1276,36 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1155,10 +1314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.185"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdd-common"
@@ -1192,6 +1357,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-common"
+version = "4.0.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "libc",
+ "nix",
+ "pin-project",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "libdd-data-pipeline"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,12 +1401,12 @@ dependencies = [
  "either",
  "http",
  "http-body-util",
- "libdd-common",
+ "libdd-common 3.0.2",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1239,7 +1437,7 @@ dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common",
+ "libdd-common 3.0.2",
  "serde",
  "tracing",
 ]
@@ -1254,7 +1452,7 @@ dependencies = [
  "libdd-trace-protobuf 2.0.0",
  "memfd",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rmp",
  "rmp-serde",
  "rustix",
@@ -1269,13 +1467,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78774ffce79da677602829d7fe27468283e5349010e974257233edf4cd12b783"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "futures",
  "hashbrown 0.15.5",
  "http",
  "http-body-util",
  "libc",
- "libdd-common",
+ "libdd-common 3.0.2",
  "libdd-ddsketch",
  "serde",
  "serde_json",
@@ -1303,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1311,6 +1509,15 @@ name = "libdd-trace-protobuf"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+dependencies = [
+ "prost",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "libdd-trace-protobuf"
+version = "3.0.1"
 dependencies = [
  "prost",
  "serde",
@@ -1336,7 +1543,7 @@ checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
 dependencies = [
  "hashbrown 0.15.5",
  "libdd-ddsketch",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-utils",
 ]
 
@@ -1356,13 +1563,13 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "hyper",
- "indexmap",
- "libdd-common",
+ "indexmap 2.14.0",
+ "libdd-common 3.0.2",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rmp",
  "rmp-serde",
  "rmpv",
@@ -1381,49 +1588,57 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "manual_future"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c72f11f1d8e0c453cbd8042dfb83c2b50384f78a5a5d41019627c5f2062ece"
+dependencies = [
+ "futures-util",
 ]
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memfd"
@@ -1441,23 +1656,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1474,13 +1680,18 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1492,25 +1703,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
@@ -1522,7 +1730,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.14",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1563,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1574,7 +1782,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.14",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
 ]
@@ -1620,15 +1828,9 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
- "thiserror 2.0.14",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1638,9 +1840,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1648,22 +1850,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-tree"
@@ -1676,24 +1872,24 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1702,15 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1742,12 +1932,18 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1769,10 +1965,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.97"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1799,24 +2005,24 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "unarray",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1824,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1837,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1851,10 +2057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1863,12 +2075,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1888,7 +2100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1897,16 +2109,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1915,14 +2127,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1940,56 +2152,61 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1997,7 +2214,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2026,42 +2243,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.14"
+name = "ring"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
- "byteorder",
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]
 
 [[package]]
 name = "rmpv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
 dependencies = [
- "num-traits",
  "rmp",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -2092,7 +2313,53 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2103,9 +2370,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2117,43 +2384,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.26"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2162,14 +2497,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2195,12 +2531,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2246,10 +2613,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -2269,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2281,12 +2649,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2308,10 +2676,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
-name = "syn"
-version = "2.0.105"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2350,12 +2730,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2422,11 +2802,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.14",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2442,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2461,10 +2841,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
+name = "time"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2482,29 +2893,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2512,10 +2920,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.17"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2524,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2537,12 +2955,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "http",
  "http-body",
@@ -2563,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -2574,13 +2992,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -2623,9 +3041,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2635,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2646,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2667,16 +3085,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
- "opentelemetry_sdk",
- "rustversion",
  "smallvec",
- "thiserror 2.0.14",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -2686,14 +3101,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -2710,9 +3125,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -2722,9 +3137,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -2745,14 +3160,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "url"
-version = "2.5.4"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2769,11 +3191,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2816,58 +3238,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2875,31 +3290,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2933,11 +3382,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2956,16 +3405,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.1.3"
+name = "windows-core"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -2974,18 +3458,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3001,11 +3485,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -3139,19 +3623,104 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -3161,9 +3730,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3172,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3184,18 +3753,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3204,18 +3773,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3224,10 +3793,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerotrie"
-version = "0.2.3"
+name = "zeroize"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3236,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3247,11 +3822,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libdd-telemetry = { version = "4.0.0", default-features = false }
 libdd-common = { version = "3.0.1", default-features = false }
 libdd-tinybytes = { version = "1.1.0", default-features = false }
 libdd-library-config = { version = "1.1.0", default-features = false }
+datadog-remote-config = { path = "../libdatadog/datadog-remote-config", default-features = false, features = ["client"] }
 opentelemetry_sdk = { version = "0.31.0", features = [
     "trace",
     "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,13 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 libdd-data-pipeline = { version = "3.0.1", default-features = false }
 libdd-trace-utils = { version = "3.0.0", default-features = false }
 libdd-telemetry = { version = "4.0.0", default-features = false }
-libdd-common = { version = "3.0.1", default-features = false }
+libdd-common = { version = "4.0.0", default-features = false }
 libdd-tinybytes = { version = "1.1.0", default-features = false }
 libdd-library-config = { version = "1.1.0", default-features = false }
-datadog-remote-config = { path = "../libdatadog/datadog-remote-config", default-features = false, features = ["client"] }
+libdd-capabilities-impl = { version = "1.0.0", default-features = false }
+
+# TODO: replace with published crate
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude", default-features = false, features = ["client"] }
 opentelemetry_sdk = { version = "0.31.0", features = [
     "trace",
     "metrics",
@@ -55,6 +58,20 @@ serde_json = { version = "1.0.140" }
 
 hashbrown = { version = "0.15.5" }
 foldhash = { version = "0.1.5" }
+
+
+# Override crates.io libdd-* sources with the sibling libdatadog checkout so that
+# every libdd-common reference (workspace direct + transitive through datadog-remote-config)
+# resolves to a single crate instance. Drop this section once libdatadog publishes
+# the matching versions to crates.io.
+# TODO: remove!
+[patch.crates-io]
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
+libdd-tinybytes = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", branch = "igor/rc/di-refactor-claude" }
 
 
 [profile.dev]

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -41,17 +41,8 @@ thiserror = { version = "1.0", default-features = false }
 anyhow = "1.0.97"
 rustc_version_runtime = "0.3.0"
 hyper = { version = "1.6", features = ["client", "http1"] }
-hyper-util = { version = "0.1.16", features = [
-    "client",
-    "client-legacy",
-    "http1",
-    "tokio",
-] }
-http-body-util = "0.1"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tokio-util = "0.7"
-base64 = "0.21"
-sha2 = "0.10"
 uuid = { version = "1.11.0", features = ["v4"] }
 arc-swap = "1.7.1"
 
@@ -64,6 +55,11 @@ libdd-trace-utils = { workspace = true }
 libdd-telemetry = { workspace = true }
 libdd-common = { workspace = true }
 libdd-tinybytes = { workspace = true }
+datadog-remote-config = { workspace = true }
+# Renamed alias for libdd-common from the same libdatadog path datadog-remote-config uses,
+# so we can construct `Tag` / `Endpoint` for `Target` / `ConfigInvariants`. The workspace
+# `libdd-common` (v3.x from crates.io) is a separate major used elsewhere — Cargo keeps both.
+libdd-common-rc = { package = "libdd-common", path = "../../libdatadog/libdd-common", default-features = false }
 
 [target.'cfg(target_os="linux")'.dependencies]
 libdd-library-config = { workspace = true }

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -50,16 +50,13 @@ arc-swap = "1.7.1"
 criterion = { version = "0.5.1", optional = true }
 
 # Libdatadog dependencies
-libdd-data-pipeline = { workspace = true }
+libdd-data-pipeline = { workspace = true, features = ["https", "telemetry"] }
 libdd-trace-utils = { workspace = true }
 libdd-telemetry = { workspace = true }
 libdd-common = { workspace = true }
 libdd-tinybytes = { workspace = true }
+libdd-capabilities-impl = { workspace = true }
 datadog-remote-config = { workspace = true }
-# Renamed alias for libdd-common from the same libdatadog path datadog-remote-config uses,
-# so we can construct `Tag` / `Endpoint` for `Target` / `ConfigInvariants`. The workspace
-# `libdd-common` (v3.x from crates.io) is a separate major used elsewhere — Cargo keeps both.
-libdd-common-rc = { package = "libdd-common", path = "../../libdatadog/libdd-common", default-features = false }
 
 [target.'cfg(target_os="linux")'.dependencies]
 libdd-library-config = { workspace = true }

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -632,7 +632,7 @@ type SamplingRulesConfigItem = ConfigItemWithOverride<ParsedSamplingRules>;
 /// This is used to track services beyond the main service for remote configuration
 #[derive(Debug, Clone)]
 struct ExtraServicesTracker {
-    /// Services that have been discovered
+    /// Services that have been discovered.
     extra_services: Arc<Mutex<HashSet<String>>>,
     /// Services that have already been sent to the agent
     extra_services_sent: Arc<Mutex<HashSet<String>>>,
@@ -681,7 +681,7 @@ impl ExtraServicesTracker {
         }
     }
 
-    /// Get all extra services, updating from the queue
+    /// Get all extra services, updating from the queue.
     fn get_extra_services(&self) -> Vec<String> {
         let mut queue = match self.extra_services_queue.lock() {
             Ok(q) => q,
@@ -1614,7 +1614,7 @@ impl Config {
             .add_extra_services(service_names, self.service().deref());
     }
 
-    /// Get all extra services discovered at runtime
+    /// Get all extra services discovered at runtime.
     pub(crate) fn get_extra_services(&self) -> Vec<String> {
         if !self.remote_config_enabled() {
             return Vec::new();

--- a/datadog-opentelemetry/src/core/configuration/remote_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/remote_config.rs
@@ -15,7 +15,7 @@ use datadog_remote_config::{
     ParserRegistry, RemoteConfigCapabilities, RemoteConfigContent, RemoteConfigParsedData,
     RemoteConfigProduct, Target,
 };
-use libdd_common_rc::Endpoint;
+use libdd_common::Endpoint;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::thread;
@@ -208,7 +208,7 @@ impl RemoteConfigClientWorker {
 
 fn build_agent_endpoint(config: &Config) -> Result<Endpoint, RemoteConfigClientError> {
     // Reject obviously-broken URIs early so callers get a typed error before the worker spawns.
-    libdd_common_rc::parse_uri(&config.trace_agent_url())
+    libdd_common::parse_uri(&config.trace_agent_url())
         .map_err(|_| RemoteConfigClientError::InvalidAgentUri)?;
 
     let url = format!(
@@ -226,10 +226,6 @@ fn build_fetcher(
     let registry = ParserRegistry::new().with::<ApmTracingConfig>();
     let storage = ParsedFileStorage::with_registry(Arc::new(registry));
 
-    // Tags are intentionally left empty for now: the workspace's `libdd-common` (v3.x from
-    // crates.io) and `libdd-common-rc` (v4.x from libdatadog path) are two distinct crates,
-    // so we cannot translate `Config::global_tags()` into v4 `Tag`s without a converter.
-    // The agent's tag-based RC routing still works via `service` / `env` / `app_version`.
     let target = Target {
         service: config.service().to_string(),
         env: config.env().map(str::to_owned).unwrap_or_default(),

--- a/datadog-opentelemetry/src/core/configuration/remote_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/remote_config.rs
@@ -12,12 +12,11 @@ use datadog_remote_config::fetch::{
 use datadog_remote_config::file_change_tracker::Change;
 use datadog_remote_config::file_storage::ParsedFileStorage;
 use datadog_remote_config::{
-    ParserRegistry, ProductParser, RemoteConfigCapabilities, RemoteConfigParsedData,
+    ParserRegistry, RemoteConfigCapabilities, RemoteConfigContent, RemoteConfigParsedData,
     RemoteConfigProduct, Target,
 };
 use libdd_common_rc::Endpoint;
 use serde::Deserialize;
-use std::any::Any;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -57,20 +56,12 @@ where
     Ok(Some(serde_json::Value::deserialize(deserializer)?))
 }
 
-impl RemoteConfigParsedData for ApmTracingConfig {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn product(&self) -> RemoteConfigProduct {
-        RemoteConfigProduct::ApmTracing
-    }
-}
+impl RemoteConfigContent for ApmTracingConfig {
+    const PRODUCT: RemoteConfigProduct = RemoteConfigProduct::ApmTracing;
 
-fn apm_tracing_parser() -> ProductParser {
-    Box::new(|data: &[u8]| {
-        let parsed: ApmTracingConfig = serde_json::from_slice(data)?;
-        Ok(Box::new(parsed) as Box<dyn RemoteConfigParsedData>)
-    })
+    fn parse(data: &[u8]) -> anyhow::Result<Self> {
+        Ok(serde_json::from_slice(data)?)
+    }
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -232,8 +223,7 @@ fn build_fetcher(
 ) -> Result<SingleChangesFetcher<ParsedFileStorage>, RemoteConfigClientError> {
     let endpoint = build_agent_endpoint(config)?;
 
-    let mut registry = ParserRegistry::new();
-    registry.register(RemoteConfigProduct::ApmTracing, apm_tracing_parser());
+    let registry = ParserRegistry::new().with::<ApmTracingConfig>();
     let storage = ParsedFileStorage::with_registry(Arc::new(registry));
 
     // Tags are intentionally left empty for now: the workspace's `libdd-common` (v3.x from
@@ -267,7 +257,7 @@ fn build_fetcher(
 }
 
 type StoredFile = <ParsedFileStorage as datadog_remote_config::fetch::FileStorage>::StoredFile;
-type Updated = anyhow::Result<Box<dyn RemoteConfigParsedData>>;
+type Updated = anyhow::Result<Option<Box<dyn RemoteConfigParsedData>>>;
 
 fn apply_changes(
     config: &Arc<Config>,
@@ -295,9 +285,12 @@ fn apply_changes(
 fn apply_file(config: &Arc<Config>, file: &Arc<StoredFile>) -> Result<(), String> {
     let contents = file.contents();
     let parsed = contents.as_ref().map_err(|e| format!("parse error: {e}"))?;
+    // `None` means no parser is registered for this product, so treat as a no-op success so the
+    // agent doesn't keep retrying.
+    let Some(parsed) = parsed.as_ref() else {
+        return Ok(());
+    };
     let Some(apm) = parsed.as_any().downcast_ref::<ApmTracingConfig>() else {
-        // Unregistered product (e.g. IgnoredProduct sentinel) — treat as a no-op success so the
-        // agent doesn't keep retrying.
         return Ok(());
     };
     apply_apm_tracing(config, apm)
@@ -311,6 +304,9 @@ fn apply_remove(config: &Arc<Config>, file: &Arc<StoredFile>) {
             crate::dd_debug!("RemoteConfigClient: skipping remove for unparseable config: {e}");
             return;
         }
+    };
+    let Some(parsed) = parsed.as_ref() else {
+        return;
     };
     let Some(apm) = parsed.as_any().downcast_ref::<ApmTracingConfig>() else {
         return;
@@ -420,15 +416,10 @@ mod tests {
 
     #[test]
     fn test_apm_tracing_parser_round_trip() {
-        let parser = apm_tracing_parser();
         let json =
             br#"{"id":"42","lib_config":{"tracing_sampling_rules":[{"sample_rate":1.0,"service":"x"}]}}"#;
-        let parsed = parser(json).expect("parser should accept valid JSON");
-        let apm = parsed
-            .as_any()
-            .downcast_ref::<ApmTracingConfig>()
-            .expect("downcast to ApmTracingConfig");
+        let apm = ApmTracingConfig::parse(json).expect("parser should accept valid JSON");
         assert_eq!(apm.id, "42");
-        assert_eq!(apm.product(), RemoteConfigProduct::ApmTracing);
+        assert_eq!(ApmTracingConfig::PRODUCT, RemoteConfigProduct::ApmTracing);
     }
 }

--- a/datadog-opentelemetry/src/core/configuration/remote_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/remote_config.rs
@@ -6,192 +6,34 @@ use crate::core::utils::{ShutdownSignaler, WorkerHandle};
 
 use anyhow::Result;
 use core::fmt;
-use libdd_common::http_common::{self};
-use libdd_common::{connector::Connector::Http, Endpoint, HttpClient};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::thread::{self};
+use datadog_remote_config::fetch::{
+    ConfigApplyState, ConfigInvariants, ConfigOptions, SingleChangesFetcher,
+};
+use datadog_remote_config::file_change_tracker::Change;
+use datadog_remote_config::file_storage::ParsedFileStorage;
+use datadog_remote_config::{
+    ParserRegistry, ProductParser, RemoteConfigCapabilities, RemoteConfigParsedData,
+    RemoteConfigProduct, Target,
+};
+use libdd_common_rc::Endpoint;
+use serde::Deserialize;
+use std::any::Any;
+use std::sync::Arc;
+use std::thread;
 use std::time::{Duration, Instant};
 
-// HTTP client imports
-use http_body_util::BodyExt;
-use hyper::Method;
-use hyper_util::client::legacy::{connect::HttpConnector, Client};
-use hyper_util::rt::TokioExecutor;
+/// Per-call timeout for the agent's `/v0.7/config` endpoint.
+const DEFAULT_TIMEOUT_MS: u64 = 3000;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3); // lowest timeout with no failures
+// ── Product parser ────────────────────────────────────────────────────────────
 
-/// Capabilities that the client supports
-#[derive(Debug, Clone)]
-struct ClientCapabilities(u64);
-
-impl ClientCapabilities {
-    /// APM_TRACING_SAMPLE_RULES capability bit position
-    const APM_TRACING_SAMPLE_RULES: u64 = 1 << 29;
-
-    fn new() -> Self {
-        Self(Self::APM_TRACING_SAMPLE_RULES)
-    }
-
-    /// Encode capabilities as base64 string
-    fn encode(&self) -> String {
-        use base64::Engine;
-        let bytes = self.0.to_be_bytes();
-        // Find first non-zero byte to minimize encoding size
-        let start = bytes
-            .iter()
-            .position(|&b| b != 0)
-            .unwrap_or(bytes.len() - 1);
-        base64::engine::general_purpose::STANDARD.encode(&bytes[start..])
-    }
-}
-
-/// Client state sent to the agent
-#[derive(Debug, Clone, Serialize)]
-struct ClientState {
-    /// Root version of the configuration
-    root_version: u64,
-    /// Versions of individual targets
-    targets_version: u64,
-    /// Configuration states
-    config_states: Vec<ConfigState>,
-    /// Whether the client has an error
-    has_error: bool,
-    /// Error message if any
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-    /// Backend client state (opaque string from server)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    backend_client_state: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ConfigState {
-    /// ID of the configuration
-    id: String,
-    /// Version of the configuration
-    version: u64,
-    /// Product that owns this config
-    product: String,
-    /// Hash of the applied config
-    apply_state: u64,
-    /// Error if any while applying
-    apply_error: Option<String>,
-}
-
-/// Request sent to get configuration
-#[derive(Debug, Serialize)]
-struct ConfigRequest {
-    /// Client information
-    client: ClientInfo,
-    /// Cached target files
-    cached_target_files: Vec<CachedTargetFile>,
-}
-
-#[derive(Debug, Serialize)]
-struct ClientInfo {
-    /// State of the client
-    #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<ClientState>,
-    /// Client ID (runtime ID)
-    id: String,
-    /// Products this client is interested in
-    products: Vec<String>,
-    /// Is this a tracer client
-    is_tracer: bool,
-    /// Tracer specific info
-    #[serde(skip_serializing_if = "Option::is_none")]
-    client_tracer: Option<ClientTracer>,
-    /// Client capabilities (base64 encoded)
-    capabilities: String,
-}
-
-#[derive(Debug, Serialize)]
-struct ClientTracer {
-    /// Runtime ID
-    runtime_id: String,
-    /// Language (rust)
-    language: String,
-    /// Tracer version
-    tracer_version: String,
-    /// Service name
-    service: String,
-    /// Additional services this tracer is monitoring
-    #[serde(default)]
-    extra_services: Vec<String>,
-    /// Environment
-    #[serde(skip_serializing_if = "Option::is_none")]
-    env: Option<String>,
-    /// App version
-    #[serde(skip_serializing_if = "Option::is_none")]
-    app_version: Option<String>,
-    /// Global tags
-    tags: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct CachedTargetFile {
-    /// Path of the target file
-    path: String,
-    /// Length of the file
-    length: u64,
-    /// Hashes of the file
-    hashes: Vec<Hash>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct Hash {
-    /// Algorithm used (e.g., "sha256")
-    algorithm: String,
-    /// Hash value
-    hash: String,
-}
-
-/// Response from the configuration endpoint
-#[derive(Debug, Deserialize)]
-struct ConfigResponse {
-    /// Root metadata (TUF roots) - base64 encoded
-    #[serde(default)]
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    roots: Option<Vec<String>>,
-    /// Targets metadata - base64 encoded JSON
-    #[serde(default)]
-    targets: Option<String>,
-    /// Target files containing actual config data
-    #[serde(default)]
-    target_files: Option<Vec<TargetFile>>,
-    /// Client configs to apply
-    #[serde(default)]
-    client_configs: Option<Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TargetFile {
-    /// Path of the file
-    path: String,
-    /// Raw content (base64 encoded in responses)
-    raw: String,
-}
-
-// Custom deserializer that preserves explicit null as Some(Value::Null)
-fn missing_field_and_null_value<'de, D>(
-    deserializer: D,
-) -> Result<Option<serde_json::Value>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    // Deserialize as Value directly, which preserves null
-    Ok(Some(serde_json::Value::deserialize(deserializer)?))
-}
-
-/// Configuration payload for APM tracing
-/// Based on the apm-tracing.json schema from dd-go
-/// See: https://github.com/DataDog/dd-go/blob/prod/remote-config/apps/rc-schema-validation/schemas/apm-tracing.json
+/// Configuration payload for APM tracing.
+/// Based on the apm-tracing.json schema from dd-go.
+/// See: <https://github.com/DataDog/dd-go/blob/prod/remote-config/apps/rc-schema-validation/schemas/apm-tracing.json>
 #[derive(Debug, Clone, Deserialize)]
 struct ApmTracingConfig {
     id: String,
-    lib_config: LibConfig, // lib_config is a required property
+    lib_config: LibConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -202,54 +44,36 @@ struct LibConfig {
         rename = "tracing_sampling_rules"
     )]
     tracing_sampling_rules: Option<serde_json::Value>,
-    // Add other APM tracing config fields as needed (e.g., tracing_header_tags, etc.)
 }
 
-/// TUF targets metadata
-/// This is just an alias for SignedTargets to match the JSON structure
-type TargetsMetadata = SignedTargets;
-
-#[derive(Debug, Deserialize, Serialize)]
-struct TargetDesc {
-    /// Length of the target file
-    length: u64,
-    /// Hashes of the target file (algorithm -> hash)
-    hashes: HashMap<String, String>,
-    /// Custom metadata for this target
-    custom: Option<serde_json::Value>,
+/// Custom deserializer that preserves explicit `null` as `Some(Value::Null)`,
+/// so the handler can distinguish "field absent" (no-op) from "field is null" (clear rules).
+fn missing_field_and_null_value<'de, D>(
+    deserializer: D,
+) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Some(serde_json::Value::deserialize(deserializer)?))
 }
 
-#[derive(Debug, Deserialize)]
-struct Targets {
-    /// Type of the targets (usually "targets")
-    #[serde(rename = "_type")]
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    target_type: String,
-    /// Custom metadata
-    custom: Option<serde_json::Value>,
-    /// Expiration time
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    expires: String,
-    /// Specification version
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    spec_version: String,
-    /// Target descriptions (path -> TargetDesc)
-    targets: HashMap<String, TargetDesc>,
-    /// Version of the targets
-    version: u64,
+impl RemoteConfigParsedData for ApmTracingConfig {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn product(&self) -> RemoteConfigProduct {
+        RemoteConfigProduct::ApmTracing
+    }
 }
 
-#[derive(Debug, Deserialize)]
-struct SignedTargets {
-    /// Signatures (we don't validate these currently)
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    signatures: Option<Vec<serde_json::Value>>,
-    /// The signed targets data
-    signed: Targets,
-    /// Version of the signed targets
-    #[allow(dead_code)] // Part of TUF specification but not used in current implementation
-    version: Option<u64>,
+fn apm_tracing_parser() -> ProductParser {
+    Box::new(|data: &[u8]| {
+        let parsed: ApmTracingConfig = serde_json::from_slice(data)?;
+        Ok(Box::new(parsed) as Box<dyn RemoteConfigParsedData>)
+    })
 }
+
+// ── Public API ────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
 pub enum RemoteConfigClientError {
@@ -264,7 +88,7 @@ impl fmt::Display for RemoteConfigClientError {
         match self {
             Self::InvalidAgentUri => write!(f, "invalid agent URI"),
             Self::HandleMutexPoisoned => write!(f, "handle mutex poisoned"),
-            Self::WorkerPanicked(msg) => write!(f, "remote config worker panicked: {}", msg),
+            Self::WorkerPanicked(msg) => write!(f, "remote config worker panicked: {msg}"),
             Self::ShutdownTimedOut => write!(f, "shutdown timed out"),
         }
     }
@@ -288,22 +112,16 @@ impl RemoteConfigClientHandle {
 
     pub fn wait_for_shutdown(&self, timeout: Duration) -> Result<(), RemoteConfigClientError> {
         use crate::core::utils::WorkerError::*;
-        if let Err(e) = self.worker_handle.wait_for_shutdown(timeout) {
-            Err(match e {
-                ShutdownTimedOut => RemoteConfigClientError::ShutdownTimedOut,
-                HandleMutexPoisoned => RemoteConfigClientError::HandleMutexPoisoned,
-                WorkerPanicked(p) => RemoteConfigClientError::WorkerPanicked(p),
-            })
-        } else {
-            Ok(())
+        match self.worker_handle.wait_for_shutdown(timeout) {
+            Ok(()) => Ok(()),
+            Err(ShutdownTimedOut) => Err(RemoteConfigClientError::ShutdownTimedOut),
+            Err(HandleMutexPoisoned) => Err(RemoteConfigClientError::HandleMutexPoisoned),
+            Err(WorkerPanicked(p)) => Err(RemoteConfigClientError::WorkerPanicked(p)),
         }
     }
 }
 
-/// Receiver for shutdown signals through the cancellation token
-///
-/// When this struct is dropped, it will signal that the shutdown is finished to the
-/// handle
+/// Receiver that signals shutdown completion when dropped.
 struct RemoteConfigClientShutdownReceiver {
     cancel_token: tokio_util::sync::CancellationToken,
     shutdown_finished: Arc<ShutdownSignaler>,
@@ -316,12 +134,16 @@ impl Drop for RemoteConfigClientShutdownReceiver {
 }
 
 pub struct RemoteConfigClientWorker {
-    client: RemoteConfigClient,
+    config: Arc<Config>,
     shutdown_receiver: RemoteConfigClientShutdownReceiver,
 }
 
 impl RemoteConfigClientWorker {
     pub fn start(config: Arc<Config>) -> Result<RemoteConfigClientHandle, RemoteConfigClientError> {
+        // Validate the agent URI eagerly so callers see configuration errors before the worker
+        // thread is spawned.
+        build_agent_endpoint(&config)?;
+
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let shutdown_finished = ShutdownSignaler::new();
         let shutdown_receiver = RemoteConfigClientShutdownReceiver {
@@ -329,7 +151,7 @@ impl RemoteConfigClientWorker {
             shutdown_finished: shutdown_finished.clone(),
         };
         let worker = Self {
-            client: RemoteConfigClient::new(config)?,
+            config,
             shutdown_receiver,
         };
         let join_handle = thread::spawn(move || worker.run());
@@ -339,51 +161,44 @@ impl RemoteConfigClientWorker {
         })
     }
 
-    fn run(mut self) {
+    fn run(self) {
         crate::dd_debug!("RemoteConfigClient: started client worker");
 
-        // Create Tokio runtime in the background thread
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
         {
             Ok(rt) => rt,
             Err(e) => {
-                crate::dd_debug!("RemoteConfigClient: Failed to create Tokio runtime: {}", e);
+                crate::dd_debug!("RemoteConfigClient: Failed to create Tokio runtime: {e}");
                 return;
             }
         };
 
+        let mut fetcher = match build_fetcher(&self.config) {
+            Ok(f) => f,
+            Err(e) => {
+                crate::dd_debug!("RemoteConfigClient: Failed to build fetcher: {e}");
+                return;
+            }
+        };
+
+        let poll_interval = Duration::from_secs_f64(self.config.remote_config_poll_interval());
+
         let run_loop = async {
             let mut last_poll = Instant::now();
-
             loop {
-                // Fetch and apply configuration
-                match self.client.fetch_and_apply_config().await {
-                    Ok(()) => {
-                        crate::dd_debug!(
-                            "RemoteConfigClient: Successfully fetched and applied config"
-                        );
-                        // Clear any previous errors
-                        if let Ok(mut state) = self.client.state.lock() {
-                            state.has_error = false;
-                            state.error = None;
-                        }
-                    }
+                fetcher.set_extra_services(self.config.get_extra_services());
+                match fetcher.fetch_changes().await {
+                    Ok(changes) => apply_changes(&self.config, &fetcher, changes),
                     Err(e) => {
-                        crate::dd_debug!("RemoteConfigClient: Failed to fetch config: {}", e);
-                        // Record error in state
-                        if let Ok(mut state) = self.client.state.lock() {
-                            state.has_error = true;
-                            state.error = Some(format!("{e}"));
-                        }
+                        crate::dd_debug!("RemoteConfigClient: fetch failed: {e}");
                     }
                 }
 
-                // Wait for next poll interval
                 let elapsed = last_poll.elapsed();
-                if elapsed < self.client.poll_interval {
-                    tokio::time::sleep(self.client.poll_interval - elapsed).await
+                if elapsed < poll_interval {
+                    tokio::time::sleep(poll_interval - elapsed).await;
                 }
                 last_poll = Instant::now();
             }
@@ -398,1727 +213,222 @@ impl RemoteConfigClientWorker {
     }
 }
 
-/// Remote configuration client that polls the Datadog Agent for configuration updates.
-///
-/// This client is responsible for:
-/// - Fetching remote configuration from the Datadog Agent
-/// - Processing APM_TRACING product updates (specifically sampling rules)
-/// - Maintaining client state and capabilities
-/// - Providing a callback mechanism for configuration updates
-///
-/// The client currently handles a single product type (APM_TRACING)
-/// that defines sampling rules.
-struct RemoteConfigClient {
-    /// Unique identifier for this client instance
-    /// Different from runtime_id - each RemoteConfigClient gets its own UUID
-    client_id: String,
-    config: Arc<Config>,
-    agent_endpoint: Endpoint,
-    state: Arc<Mutex<ClientState>>,
-    capabilities: ClientCapabilities,
-    poll_interval: Duration,
-    // Cache of successfully applied configurations
-    cached_target_files: Vec<CachedTargetFile>,
-    // Registry of product handlers for processing different config types
-    product_registry: ProductRegistry,
-    // default http client
-    http_client: HttpClient,
-}
+// ── Wiring helpers ────────────────────────────────────────────────────────────
 
-impl RemoteConfigClient {
-    /// Creates a new remote configuration client
-    pub fn new(config: Arc<Config>) -> Result<Self, RemoteConfigClientError> {
-        let agent_url = libdd_common::parse_uri(&config.trace_agent_url())
-            .map_err(|_| RemoteConfigClientError::InvalidAgentUri)?;
-        let mut parts = agent_url.into_parts();
-        parts.path_and_query = Some(
-            "/v0.7/config"
-                .parse()
-                .map_err(|_| RemoteConfigClientError::InvalidAgentUri)?,
-        );
-        let agent_url =
-            hyper::Uri::from_parts(parts).map_err(|_| RemoteConfigClientError::InvalidAgentUri)?;
+fn build_agent_endpoint(config: &Config) -> Result<Endpoint, RemoteConfigClientError> {
+    // Reject obviously-broken URIs early so callers get a typed error before the worker spawns.
+    libdd_common_rc::parse_uri(&config.trace_agent_url())
+        .map_err(|_| RemoteConfigClientError::InvalidAgentUri)?;
 
-        let agent_endpoint = libdd_common::Endpoint::from_url(agent_url);
-
-        let state = Arc::new(Mutex::new(ClientState {
-            root_version: 1, // Agent requires >= 1 (base TUF director root)
-            targets_version: 0,
-            config_states: Vec::new(),
-            has_error: false,
-            error: None,
-            backend_client_state: None,
-        }));
-
-        let poll_interval = Duration::from_secs_f64(config.remote_config_poll_interval());
-
-        // Create HTTP connector with timeout configuration
-        let mut connector = HttpConnector::new();
-        connector.set_connect_timeout(Some(DEFAULT_TIMEOUT));
-
-        Ok(Self {
-            client_id: uuid::Uuid::new_v4().to_string(),
-            config,
-            agent_endpoint,
-            state,
-            capabilities: ClientCapabilities::new(),
-            poll_interval,
-            cached_target_files: Vec::new(),
-            product_registry: ProductRegistry::new(),
-            http_client: Client::builder(TokioExecutor::default()).build(Http(connector)),
-        })
-    }
-
-    /// Fetches configuration from the agent and applies it
-    async fn fetch_and_apply_config(&mut self) -> Result<()> {
-        let request_payload = self.build_request()?;
-        // Serialize the request to JSON
-        let json_body = serde_json::to_string(&request_payload)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize request: {}", e))?;
-
-        let req_builder = self
-            .agent_endpoint
-            .to_request_builder("dd-trace-rs")
-            .map_err(|e| anyhow::anyhow!("Failed to build request builder: {}", e))?;
-
-        let req = req_builder
-            .method(Method::POST)
-            .header("content-type", "application/json")
-            .body(http_common::Body::from(json_body))
-            .map_err(|e| anyhow::anyhow!("Failed to build request: {}", e))?;
-
-        // Send request to agent
-        let response = self
-            .http_client
-            .request(req)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to send request: {}", e))?;
-
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "Agent returned error status: {}",
-                response.status()
-            ));
-        }
-
-        // Collect the response body
-        let body_bytes = response
-            .into_body()
-            .collect()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to read response body: {}", e))?
-            .to_bytes();
-
-        // Parse JSON response
-        let config_response: ConfigResponse = serde_json::from_slice(&body_bytes)
-            .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
-
-        // Process the configuration response
-        self.process_response(config_response)?;
-
-        Ok(())
-    }
-
-    /// Builds the configuration request
-    fn build_request(&self) -> Result<ConfigRequest> {
-        let state = self
-            .state
-            .lock()
-            .map_err(|_| anyhow::anyhow!("Failed to lock state"))?;
-
-        let config = &self.config;
-
-        let client_info = ClientInfo {
-            state: Some(state.clone()),
-            id: self.client_id.clone(),
-            products: vec!["APM_TRACING".to_string()],
-            is_tracer: true,
-            client_tracer: Some(ClientTracer {
-                runtime_id: config.runtime_id().to_string(),
-                language: "rust".to_string(),
-                tracer_version: config.tracer_version().to_string(),
-                service: config.service().to_string(),
-                extra_services: config.get_extra_services(),
-                env: config.env().map(|s| s.to_string()),
-                app_version: config.version().map(|s| s.to_string()),
-                tags: config
-                    .global_tags()
-                    .map(|(key, value)| format!("{key}:{value}"))
-                    .collect(),
-            }),
-            capabilities: self.capabilities.encode(),
-        };
-
-        let cached_files = self.cached_target_files.clone();
-
-        Ok(ConfigRequest {
-            client: client_info,
-            cached_target_files: cached_files,
-        })
-    }
-
-    /// Processes the configuration response
-    fn process_response(&mut self, response: ConfigResponse) -> Result<()> {
-        // Process targets metadata to update backend state and version
-        let mut path_to_custom: HashMap<String, (Option<String>, Option<u64>)> = HashMap::new();
-        let mut signed_targets: Option<serde_json::Value> = None;
-
-        if let Some(targets_str) = response.targets {
-            use base64::Engine;
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(&targets_str)
-                .map_err(|e| anyhow::anyhow!("Failed to decode targets: {}", e))?;
-
-            let targets_json = String::from_utf8(decoded)
-                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in targets: {}", e))?;
-
-            let targets: TargetsMetadata = serde_json::from_str(&targets_json)
-                .map_err(|e| anyhow::anyhow!("Failed to parse targets metadata: {}", e))?;
-
-            // Store signed targets for validation
-            let targets_map = targets
-                .signed
-                .targets
-                .iter()
-                .map(|(k, v)| (k.clone(), serde_json::to_value(v).unwrap()))
-                .collect();
-            signed_targets = Some(serde_json::Value::Object(targets_map));
-
-            // Build lookup for per-path id and version from targets.signed.targets[*].custom
-            for (path, desc) in &targets.signed.targets {
-                let custom = &desc.custom;
-                let id = custom
-                    .as_ref()
-                    .and_then(|c| Some(c.get("id")?.as_str()?.to_owned()));
-                // Datadog RC uses custom.v (int). Fallback to custom.version if needed
-                let version: Option<u64> = custom
-                    .as_ref()
-                    .and_then(|c| c.get("v").or_else(|| c.get("version"))?.as_u64());
-                path_to_custom.insert(path.clone(), (id, version));
-            }
-
-            // Update state with backend state and version
-            if let Ok(mut state) = self.state.lock() {
-                state.targets_version = targets.signed.version;
-
-                if let Some(custom) = &targets.signed.custom {
-                    if let Some(backend_state) =
-                        custom.get("opaque_backend_state").and_then(|v| v.as_str())
-                    {
-                        state.backend_client_state = Some(backend_state.to_string());
-                    }
-                }
-            }
-        }
-
-        // Validate target files against signed targets and client configs
-        if let Some(target_files) = &response.target_files {
-            self.validate_signed_target_files(
-                target_files,
-                &signed_targets,
-                &response.client_configs,
-            )?;
-        }
-
-        // Parse target files if present
-        if let Some(target_files) = response.target_files {
-            // Build a new cache
-            let mut new_cache = Vec::new();
-            let mut any_failure = false;
-            let mut config_states_cleared = false;
-
-            for file in target_files {
-                // Extract product and config_id from path to determine which handler to use
-                // Path format is: ^(datadog/\d+|employee)/[^/]+/[^/]+/[^/]+$
-                // Where the three last groups represent product/config_id/name
-                let Some((product, config_id)) = extract_product_and_id_from_path(&file.path)
-                else {
-                    crate::dd_debug!(
-                        "RemoteConfigClient: Failed to extract product from path: {}",
-                        file.path
-                    );
-                    continue;
-                };
-
-                // Check if we have a handler for this product
-                let handler = match self.product_registry.get_handler(&product) {
-                    Some(h) => h,
-                    None => {
-                        continue;
-                    }
-                };
-
-                // Target files contain base64 encoded JSON configs
-                use base64::Engine;
-                let decoded = base64::engine::general_purpose::STANDARD
-                    .decode(&file.raw)
-                    .map_err(|e| anyhow::anyhow!("Failed to decode config: {}", e))?;
-
-                // Determine config id and version for state reporting (do this before applying)
-                let (_, meta_version) = path_to_custom
-                    .get(&file.path)
-                    .cloned()
-                    .unwrap_or((None, None));
-                let config_version = meta_version.unwrap_or(1);
-
-                // Apply the config and record success or failure state
-                // Right now we only support APM_TRACING handler, but in the future we will support
-                // other products
-                match handler.process_config(&decoded, &self.config) {
-                    Ok(_) => {
-                        // Calculate SHA256 hash of the decoded file
-                        use sha2::{Digest, Sha256};
-                        let mut hasher = Sha256::new();
-                        hasher.update(&decoded);
-                        let hash_result = hasher.finalize();
-                        let hash_hex = format!("{hash_result:x}");
-
-                        new_cache.push(CachedTargetFile {
-                            path: file.path.clone(),
-                            length: decoded.len() as u64,
-                            hashes: vec![Hash {
-                                algorithm: "sha256".to_string(),
-                                hash: hash_hex,
-                            }],
-                        });
-
-                        // Update state to reflect successful application with accurate id/version
-                        if let Ok(mut state) = self.state.lock() {
-                            if !config_states_cleared {
-                                state.config_states.clear();
-                                config_states_cleared = true;
-                            }
-                            state.config_states.push(ConfigState {
-                                id: config_id,
-                                version: config_version,
-                                product: product.clone(),
-                                apply_state: 2, // 2 denotes success
-                                apply_error: None,
-                            });
-                        }
-                    }
-                    Err(e) => {
-                        any_failure = true;
-                        crate::dd_debug!(
-                            "RemoteConfigClient: Failed to apply {} config {}: {}",
-                            product,
-                            config_id,
-                            e
-                        );
-                        if let Ok(mut state) = self.state.lock() {
-                            if !config_states_cleared {
-                                state.config_states.clear();
-                                config_states_cleared = true;
-                            }
-                            // 3 denotes error
-                            state.config_states.push(ConfigState {
-                                id: config_id,
-                                version: config_version,
-                                product,
-                                apply_state: 3, // 3 denotes error
-                                apply_error: Some(format!("{e}")),
-                            });
-                        }
-                        // Do not add to cache on failure
-                        continue;
-                    }
-                }
-            }
-
-            // Only update the cache if we successfully processed all configs
-            // This ensures we don't lose our previous cache state on errors
-            if !any_failure {
-                self.cached_target_files = new_cache;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Validates that target files exist in either signed targets or client configs
-    fn validate_signed_target_files(
-        &self,
-        payload_target_files: &[TargetFile],
-        payload_targets_signed: &Option<serde_json::Value>,
-        client_configs: &Option<Vec<String>>,
-    ) -> Result<()> {
-        for target in payload_target_files {
-            let exists_in_signed_targets = payload_targets_signed
-                .as_ref()
-                .and_then(|targets| targets.get(&target.path))
-                .is_some();
-
-            let exists_in_client_configs = client_configs
-                .as_ref()
-                .map(|configs| configs.contains(&target.path))
-                .unwrap_or(false);
-
-            if !exists_in_signed_targets && !exists_in_client_configs {
-                return Err(anyhow::anyhow!(
-                    "target file {} not exists in client_config and signed targets",
-                    target.path
-                ));
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// Product handler trait for processing different remote config products
-/// Each product (APM_TRACING, AGENT_CONFIG, etc.) implements this trait to handle their specific
-/// configuration format
-trait ProductHandler {
-    /// Process the configuration for this product
-    fn process_config(&self, config_json: &[u8], config: &Arc<Config>) -> Result<()>;
-
-    /// Get the product name this handler supports
-    fn product_name(&self) -> &'static str;
-}
-
-struct ApmTracingHandler;
-
-impl ProductHandler for ApmTracingHandler {
-    fn process_config(&self, config_json: &[u8], config: &Arc<Config>) -> Result<()> {
-        // Parse the config to extract sampling rules as raw JSON
-        let tracing_config: ApmTracingConfig = serde_json::from_slice(config_json)
-            .map_err(|e| anyhow::anyhow!("Failed to parse APM tracing config: {}", e))?;
-
-        // Extract sampling rules if present
-        if let Some(rules_value) = tracing_config.lib_config.tracing_sampling_rules {
-            if !rules_value.is_null() {
-                // Convert the raw JSON value to string for the config method
-                let rules_json = serde_json::to_string(&rules_value)
-                    .map_err(|e| anyhow::anyhow!("Failed to serialize sampling rules: {}", e))?;
-
-                match config.update_sampling_rules_from_remote(&rules_json, Some(tracing_config.id))
-                {
-                    Ok(()) => {
-                        crate::dd_debug!(
-                            "RemoteConfigClient: Applied sampling rules from remote config"
-                        );
-                    }
-                    Err(e) => {
-                        crate::dd_debug!(
-                            "RemoteConfigClient: Failed to update sampling rules: {}",
-                            e
-                        );
-                    }
-                }
-            } else {
-                crate::dd_debug!(
-                    "RemoteConfigClient: APM tracing config received but tracing_sampling_rules is null"
-                );
-                config.clear_remote_sampling_rules(Some(tracing_config.id));
-            }
-        } else {
-            crate::dd_debug!(
-                "RemoteConfigClient: APM tracing config received but no tracing_sampling_rules present"
-            );
-        }
-
-        Ok(())
-    }
-
-    fn product_name(&self) -> &'static str {
-        "APM_TRACING"
-    }
-}
-
-/// Product registry that maps product names to their handlers
-/// This makes it easy to add new products without modifying the main processing logic
-struct ProductRegistry {
-    handlers: HashMap<String, Box<dyn ProductHandler + Send + Sync>>,
-}
-
-impl ProductRegistry {
-    fn new() -> Self {
-        let mut registry = Self {
-            handlers: HashMap::new(),
-        };
-
-        // Register all supported products
-        registry.register(Box::new(ApmTracingHandler));
-
-        registry
-    }
-
-    fn register(&mut self, handler: Box<dyn ProductHandler + Send + Sync>) {
-        self.handlers
-            .insert(handler.product_name().to_string(), handler);
-    }
-
-    fn get_handler(&self, product: &str) -> Option<&(dyn ProductHandler + Send + Sync)> {
-        self.handlers.get(product).map(|handler| handler.as_ref())
-    }
-}
-
-/// Extract product and id from remote config path
-/// Path format is: ^(datadog/\d+|employee)/[^/]+/[^/]+/[^/]+$
-/// Where the three last groups represent product/config_id/name
-fn extract_product_and_id_from_path(path: &str) -> Option<(String, String)> {
-    let mut components = path
-        .strip_prefix("datadog/")
-        .map_or_else(
-            || path.strip_prefix("employee/"),
-            |rest| {
-                if !rest.starts_with(char::is_numeric) {
-                    None
-                } else {
-                    rest.trim_start_matches(char::is_numeric).strip_prefix("/")
-                }
-            },
-        )?
-        .split("/");
-
-    let (product, config_id) = (
-        components.next()?.to_string(),
-        components.next()?.to_string(),
+    let url = format!(
+        "{}/v0.7/config",
+        config.trace_agent_url().trim_end_matches('/')
     );
-    // Remove the last name part
-    let _ = components.next()?;
-    // Check if there are any remaining components after product, config_id, name
-    if components.next().is_some() || product.is_empty() || config_id.is_empty() {
-        return None;
+    Ok(Endpoint::from_slice(&url).with_timeout(DEFAULT_TIMEOUT_MS))
+}
+
+fn build_fetcher(
+    config: &Config,
+) -> Result<SingleChangesFetcher<ParsedFileStorage>, RemoteConfigClientError> {
+    let endpoint = build_agent_endpoint(config)?;
+
+    let mut registry = ParserRegistry::new();
+    registry.register(RemoteConfigProduct::ApmTracing, apm_tracing_parser());
+    let storage = ParsedFileStorage::with_registry(Arc::new(registry));
+
+    // Tags are intentionally left empty for now: the workspace's `libdd-common` (v3.x from
+    // crates.io) and `libdd-common-rc` (v4.x from libdatadog path) are two distinct crates,
+    // so we cannot translate `Config::global_tags()` into v4 `Tag`s without a converter.
+    // The agent's tag-based RC routing still works via `service` / `env` / `app_version`.
+    let target = Target {
+        service: config.service().to_string(),
+        env: config.env().map(str::to_owned).unwrap_or_default(),
+        app_version: config.version().map(str::to_owned).unwrap_or_default(),
+        tags: vec![],
+        process_tags: vec![],
+    };
+
+    let options = ConfigOptions {
+        invariants: ConfigInvariants {
+            language: config.language().to_string(),
+            tracer_version: config.tracer_version().to_string(),
+            endpoint,
+        },
+        products: vec![RemoteConfigProduct::ApmTracing],
+        capabilities: vec![RemoteConfigCapabilities::ApmTracingSampleRules],
+    };
+
+    Ok(SingleChangesFetcher::new(
+        storage,
+        target,
+        config.runtime_id().to_string(),
+        options,
+    ))
+}
+
+type StoredFile = <ParsedFileStorage as datadog_remote_config::fetch::FileStorage>::StoredFile;
+type Updated = anyhow::Result<Box<dyn RemoteConfigParsedData>>;
+
+fn apply_changes(
+    config: &Arc<Config>,
+    fetcher: &SingleChangesFetcher<ParsedFileStorage>,
+    changes: Vec<Change<Arc<StoredFile>, Updated>>,
+) {
+    for change in changes {
+        match change {
+            Change::Add(file) | Change::Update(file, _) => {
+                let state = match apply_file(config, &file) {
+                    Ok(()) => ConfigApplyState::Acknowledged,
+                    Err(e) => {
+                        crate::dd_debug!("RemoteConfigClient: failed to apply config: {e}");
+                        ConfigApplyState::Error(e)
+                    }
+                };
+                fetcher.set_config_state(&file, state);
+            }
+            // Remove events don't get an apply state: the file is gone from the fetcher's view.
+            Change::Remove(file) => apply_remove(config, &file),
+        }
     }
-    Some((product, config_id))
+}
+
+fn apply_file(config: &Arc<Config>, file: &Arc<StoredFile>) -> Result<(), String> {
+    let contents = file.contents();
+    let parsed = contents.as_ref().map_err(|e| format!("parse error: {e}"))?;
+    let Some(apm) = parsed.as_any().downcast_ref::<ApmTracingConfig>() else {
+        // Unregistered product (e.g. IgnoredProduct sentinel) — treat as a no-op success so the
+        // agent doesn't keep retrying.
+        return Ok(());
+    };
+    apply_apm_tracing(config, apm)
+}
+
+fn apply_remove(config: &Arc<Config>, file: &Arc<StoredFile>) {
+    let contents = file.contents();
+    let parsed = match contents.as_ref() {
+        Ok(p) => p,
+        Err(e) => {
+            crate::dd_debug!("RemoteConfigClient: skipping remove for unparseable config: {e}");
+            return;
+        }
+    };
+    let Some(apm) = parsed.as_any().downcast_ref::<ApmTracingConfig>() else {
+        return;
+    };
+    config.clear_remote_sampling_rules(Some(apm.id.clone()));
+}
+
+fn apply_apm_tracing(config: &Arc<Config>, apm: &ApmTracingConfig) -> Result<(), String> {
+    let Some(rules_value) = &apm.lib_config.tracing_sampling_rules else {
+        crate::dd_debug!(
+            "RemoteConfigClient: APM tracing config received but no tracing_sampling_rules present"
+        );
+        return Ok(());
+    };
+
+    if rules_value.is_null() {
+        crate::dd_debug!(
+            "RemoteConfigClient: APM tracing config received but tracing_sampling_rules is null"
+        );
+        config.clear_remote_sampling_rules(Some(apm.id.clone()));
+        return Ok(());
+    }
+
+    let rules_json = serde_json::to_string(rules_value)
+        .map_err(|e| format!("failed to serialize sampling rules: {e}"))?;
+
+    config.update_sampling_rules_from_remote(&rules_json, Some(apm.id.clone()))?;
+    crate::dd_debug!("RemoteConfigClient: Applied sampling rules from remote config");
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use proptest::prelude::*;
-    use test_case::test_case;
 
-    #[test]
-    fn test_client_capabilities() {
-        let caps = ClientCapabilities::new();
-        // Check that the encoded capabilities is a non-empty base64 string
-        let encoded = caps.encode();
-        assert!(!encoded.is_empty());
-
-        // The encoded value should decode to contain our capability bit
-        use base64::Engine;
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(&encoded)
-            .unwrap();
-
-        // Reconstruct the u64 from the variable-length big-endian bytes
-        let mut bytes = [0u8; 8];
-        let offset = 8 - decoded.len();
-        bytes[offset..].copy_from_slice(&decoded);
-        let value = u64::from_be_bytes(bytes);
-
-        // Verify the capability bit is set
-        assert_eq!(value, ClientCapabilities::APM_TRACING_SAMPLE_RULES);
-        assert_eq!(
-            value & ClientCapabilities::APM_TRACING_SAMPLE_RULES,
-            ClientCapabilities::APM_TRACING_SAMPLE_RULES
-        );
+    fn make_apm_config(id: &str, body: &str) -> ApmTracingConfig {
+        let json = format!(r#"{{"id":"{id}","lib_config":{body}}}"#);
+        serde_json::from_str(&json).expect("valid ApmTracingConfig")
     }
 
     #[test]
-    fn test_request_serialization() {
-        // Test that our request format matches the expected structure
-        let state = ClientState {
-            root_version: 1,
-            targets_version: 122282776,
-            config_states: vec![],
-            has_error: false,
-            error: None,
-            backend_client_state: Some("test_backend_state".to_string()),
-        };
-
-        let client_info = ClientInfo {
-            state: Some(state),
-            id: "test-client-id".to_string(),
-            products: vec!["APM_TRACING".to_string()],
-            is_tracer: true,
-            client_tracer: Some(ClientTracer {
-                runtime_id: "test-runtime-id".to_string(),
-                language: "rust".to_string(),
-                tracer_version: "0.0.1".to_string(),
-                service: "test-service".to_string(),
-                extra_services: vec![],
-                env: Some("test-env".to_string()),
-                app_version: Some("1.0.0".to_string()),
-                tags: vec![],
-            }),
-            capabilities: ClientCapabilities::new().encode(),
-        };
-
-        let request = ConfigRequest {
-            client: client_info,
-            cached_target_files: Vec::new(),
-        };
-
-        // Serialize and verify the structure
-        let json = serde_json::to_value(&request).unwrap();
-
-        // Check top-level structure
-        assert!(json.get("client").is_some());
-        // cached_target_files should be an empty array when empty
-        assert_eq!(
-            json.get("cached_target_files"),
-            Some(&serde_json::json!([]))
+    fn test_apm_tracing_config_parses_with_rules() {
+        let cfg = make_apm_config(
+            "42",
+            r#"{"tracing_sampling_rules":[{"sample_rate":0.5,"service":"svc","provenance":"dynamic"}]}"#,
         );
-
-        let client = &json["client"];
-
-        // Check client structure
-        assert_eq!(client["id"], "test-client-id");
-        assert_eq!(client["products"], serde_json::json!(["APM_TRACING"]));
-        assert_eq!(client["is_tracer"], true);
-
-        // Check client_tracer structure
-        let client_tracer = &client["client_tracer"];
-        assert_eq!(client_tracer["runtime_id"], "test-runtime-id");
-        assert_eq!(client_tracer["language"], "rust");
-        assert_eq!(client_tracer["service"], "test-service");
-        assert_eq!(client_tracer["extra_services"], serde_json::json!([]));
-        assert_eq!(client_tracer["env"], "test-env");
-        assert_eq!(client_tracer["app_version"], "1.0.0");
-
-        // Check state structure
-        let state = &client["state"];
-        assert_eq!(state["root_version"], 1);
-        assert_eq!(state["targets_version"], 122282776);
-        assert_eq!(state["has_error"], false);
-        assert_eq!(state["backend_client_state"], "test_backend_state");
-
-        // Check capabilities is a base64 encoded string
-        let capabilities = &client["capabilities"];
-        assert!(capabilities.is_string());
-        assert!(!capabilities.as_str().unwrap().is_empty());
-    }
-
-    #[test]
-    fn test_request_serialization_with_error() {
-        // Test that error field is included when has_error is true
-        let state = ClientState {
-            root_version: 1,
-            targets_version: 1,
-            config_states: vec![],
-            has_error: true,
-            error: Some("Test error message".to_string()),
-            backend_client_state: None,
-        };
-
-        let client_info = ClientInfo {
-            state: Some(state),
-            id: "test-client-id".to_string(),
-            products: vec!["APM_TRACING".to_string()],
-            is_tracer: true,
-            client_tracer: Some(ClientTracer {
-                runtime_id: "test-runtime-id".to_string(),
-                language: "rust".to_string(),
-                tracer_version: "0.0.1".to_string(),
-                service: "test-service".to_string(),
-                extra_services: vec!["service1".to_string(), "service2".to_string()],
-                env: None,
-                app_version: None,
-                tags: vec![],
-            }),
-            capabilities: ClientCapabilities::new().encode(),
-        };
-
-        let request = ConfigRequest {
-            client: client_info,
-            cached_target_files: Vec::new(),
-        };
-
-        let json = serde_json::to_value(&request).unwrap();
-        let state = &json["client"]["state"];
-
-        // Verify error field is present when has_error is true
-        assert_eq!(state["has_error"], true);
-        assert_eq!(state["error"], "Test error message");
-
-        // Verify extra_services is populated
-        let client_tracer = &json["client"]["client_tracer"];
-        assert_eq!(
-            client_tracer["extra_services"],
-            serde_json::json!(["service1", "service2"])
-        );
-
-        // Verify None values are not included in JSON
-        assert!(client_tracer.get("env").is_none());
-        assert!(client_tracer.get("app_version").is_none());
-        assert!(state.get("backend_client_state").is_none());
-    }
-
-    #[test]
-    fn test_apm_tracing_config_parsing() {
-        let json = r#"{
-            "id": "42",
-            "lib_config": {
-                "tracing_sampling_rules": [
-                    {
-                        "sample_rate": 0.5,
-                        "service": "test-service",
-                        "provenance": "dynamic"
-                    }
-                ]
-            }
-        }"#;
-
-        let config: ApmTracingConfig = serde_json::from_str(json).unwrap();
-        assert!(config.lib_config.tracing_sampling_rules.is_some());
-        let rules_value = config.lib_config.tracing_sampling_rules.unwrap();
-
-        // Parse the raw JSON value to verify the content
-        let rules: Vec<serde_json::Value> = serde_json::from_value(rules_value).unwrap();
-        assert_eq!(rules.len(), 1);
+        assert!(cfg.lib_config.tracing_sampling_rules.is_some());
+        let rules = cfg.lib_config.tracing_sampling_rules.unwrap();
+        assert!(rules.is_array());
         assert_eq!(rules[0]["sample_rate"], 0.5);
-        assert_eq!(rules[0]["service"], "test-service");
-        assert_eq!(rules[0]["provenance"], "dynamic");
+        assert_eq!(rules[0]["service"], "svc");
     }
 
     #[test]
-    fn test_apm_tracing_config_full_schema() {
-        // Test parsing a more complete configuration
-        let json = r#"{
-            "id": "42",
-            "lib_config": {
-                "tracing_sampling_rules": [
-                    {
-                        "sample_rate": 0.3,
-                        "service": "web-api",
-                        "name": "GET /users/*",
-                        "resource": "UserController.list",
-                        "tags": {
-                            "environment": "production",
-                            "region": "us-east-1"
-                        },
-                        "provenance": "customer"
-                    },
-                    {
-                        "sample_rate": 1.0,
-                        "service": "auth-service",
-                        "provenance": "dynamic"
-                    }
-                ]
-            }
-        }"#;
-
-        let config: ApmTracingConfig = serde_json::from_str(json).unwrap();
-        assert!(config.lib_config.tracing_sampling_rules.is_some());
-        let rules_value = config.lib_config.tracing_sampling_rules.unwrap();
-
-        // Parse the raw JSON value to verify the content
-        let rules: Vec<serde_json::Value> = serde_json::from_value(rules_value).unwrap();
-        assert_eq!(rules.len(), 2);
-
-        // Check first rule
-        assert_eq!(rules[0]["sample_rate"], 0.3);
-        assert_eq!(rules[0]["service"], "web-api");
-        assert_eq!(rules[0]["name"], "GET /users/*");
-        assert_eq!(rules[0]["resource"], "UserController.list");
-        assert_eq!(rules[0]["tags"].as_object().unwrap().len(), 2);
-        assert_eq!(rules[0]["tags"]["environment"], "production");
-        assert_eq!(rules[0]["tags"]["region"], "us-east-1");
-        assert_eq!(rules[0]["provenance"], "customer");
-
-        // Check second rule
-        assert_eq!(rules[1]["sample_rate"], 1.0);
-        assert_eq!(rules[1]["service"], "auth-service");
-        assert_eq!(rules[1]["provenance"], "dynamic");
-    }
-
-    #[test]
-    fn test_apm_tracing_config_empty() {
-        let json = r#"{}"#;
-
-        let config: LibConfig = serde_json::from_str(json).unwrap();
-        assert!(config.tracing_sampling_rules.is_none());
-    }
-
-    #[test]
-    fn test_cached_target_files() {
-        // Test that cached_target_files is properly serialized
-        let cached_file = CachedTargetFile {
-            path: "datadog/2/APM_TRACING/config123/config".to_string(),
-            length: 256,
-            hashes: vec![Hash {
-                algorithm: "sha256".to_string(),
-                hash: "abc123def456".to_string(),
-            }],
-        };
-
-        let request = ConfigRequest {
-            client: ClientInfo {
-                state: None,
-                id: "test-id".to_string(),
-                products: vec!["APM_TRACING".to_string()],
-                is_tracer: true,
-                client_tracer: None,
-                capabilities: ClientCapabilities::new().encode(),
-            },
-            cached_target_files: vec![cached_file.clone()],
-        };
-
-        let json = serde_json::to_value(&request).unwrap();
-        let cached = &json["cached_target_files"][0];
-
-        assert_eq!(cached["path"], "datadog/2/APM_TRACING/config123/config");
-        assert_eq!(cached["length"], 256);
-        assert_eq!(cached["hashes"][0]["algorithm"], "sha256");
-        assert_eq!(cached["hashes"][0]["hash"], "abc123def456");
-    }
-
-    #[test]
-    fn test_validate_signed_target_files() {
-        // Create a mock RemoteConfigClient for testing
-        let config = Arc::new(Config::builder().build());
-        let client = RemoteConfigClient::new(config).unwrap();
-
-        // Test case 1: Target file exists in signed targets
-        let target_files = vec![TargetFile {
-            path: "datadog/2/APM_TRACING/config123/config".to_string(),
-            raw: "base64_encoded_content".to_string(),
-        }];
-
-        let signed_targets = serde_json::json!({
-            "datadog/2/APM_TRACING/config123/config": {
-                "custom": {"id": "config123", "v": 1}
-            }
-        });
-
-        let client_configs = None;
-
-        // Should pass validation
-        assert!(client
-            .validate_signed_target_files(&target_files, &Some(signed_targets), &client_configs)
-            .is_ok());
-
-        // Test case 2: Target file exists in client configs
-        let target_files = vec![TargetFile {
-            path: "datadog/2/APM_TRACING/config456/config".to_string(),
-            raw: "base64_encoded_content".to_string(),
-        }];
-
-        let signed_targets = None;
-        let client_configs = Some(vec!["datadog/2/APM_TRACING/config456/config".to_string()]);
-
-        // Should pass validation
-        assert!(client
-            .validate_signed_target_files(&target_files, &signed_targets, &client_configs)
-            .is_ok());
-
-        // Test case 3: Target file exists in both signed targets and client configs
-        let target_files = vec![TargetFile {
-            path: "datadog/2/APM_TRACING/config789/config".to_string(),
-            raw: "base64_encoded_content".to_string(),
-        }];
-
-        let signed_targets = serde_json::json!({
-            "datadog/2/APM_TRACING/config789/config": {
-                "custom": {"id": "config789", "v": 1}
-            }
-        });
-        let client_configs = Some(vec!["datadog/2/APM_TRACING/config789/config".to_string()]);
-
-        // Should pass validation
-        assert!(client
-            .validate_signed_target_files(&target_files, &Some(signed_targets), &client_configs)
-            .is_ok());
-
-        // Test case 4: Target file exists in neither signed targets nor client configs
-        let target_files = vec![TargetFile {
-            path: "datadog/2/APM_TRACING/invalid_config/config".to_string(),
-            raw: "base64_encoded_content".to_string(),
-        }];
-
-        let signed_targets = serde_json::json!({
-            "datadog/2/APM_TRACING/other_config/config": {
-                "custom": {"id": "other_config", "v": 1}
-            }
-        });
-        let client_configs = Some(vec![
-            "datadog/2/APM_TRACING/another_config/config".to_string()
-        ]);
-
-        // Should fail validation
-        let result = client.validate_signed_target_files(
-            &target_files,
-            &Some(signed_targets),
-            &client_configs,
-        );
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("target file datadog/2/APM_TRACING/invalid_config/config not exists in client_config and signed targets"));
-
-        // Test case 5: Empty target files should pass validation
-        let target_files = vec![];
-        let signed_targets = None;
-        let client_configs = None;
-
-        // Should pass validation
-        assert!(client
-            .validate_signed_target_files(&target_files, &signed_targets, &client_configs)
-            .is_ok());
-    }
-
-    #[test]
-    fn test_parse_example_response() {
-        // Create a ConfigResponse object that represents the example response
-        let config_response = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogM319Cg==".to_string()), // base64 encoded targets with proper structure
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/apm-tracing-sampling/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJ0cmFjaW5nX3NhbXBsaW5nX3J1bGVzIjogW3sic2FtcGxlX3JhdGUiOiAwLjUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZSJ9XX19".to_string(), // base64 encoded APM config
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/apm-tracing-sampling/config".to_string(),
-            ]),
-        };
-
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // For testing purposes, we'll verify the config was updated by checking the rules
-
-        // Process the response - this should update the client's state and process APM_TRACING
-        // configs
-        let result = client.process_response(config_response);
-        assert!(result.is_ok(), "process_response should succeed");
-
-        // Verify that the client's state was updated correctly
-        let state = client.state.lock().unwrap();
-        assert_eq!(state.targets_version, 3);
-        assert_eq!(
-            state.backend_client_state,
-            Some("eyJfooIOiAiYmFoIn0=".to_string())
-        );
-        assert!(!state.has_error);
-
-        // Verify that APM_TRACING config states were added
-        assert_eq!(state.config_states.len(), 1);
-        let config_state = &state.config_states[0];
-        assert_eq!(config_state.product, "APM_TRACING");
-        assert_eq!(config_state.apply_state, 2); // success
-
-        // Verify that APM_TRACING cached files were added
-        let cached_files = client.cached_target_files;
-        assert_eq!(cached_files.len(), 1);
-        assert_eq!(
-            cached_files[0].path,
-            "datadog/2/APM_TRACING/apm-tracing-sampling/config"
-        );
-        // Cached file length is the decoded bytes length (not base64 string length)
-        assert_eq!(cached_files[0].length, 105);
-        assert_eq!(cached_files[0].hashes.len(), 1);
-        assert_eq!(cached_files[0].hashes[0].algorithm, "sha256");
-
-        // Verify that the config was updated with the processed rules
-        let config = client.config;
-        let rules = config.trace_sampling_rules();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].sample_rate, 0.5);
-        assert_eq!(rules[0].service, Some("test-service".to_string()));
-    }
-
-    #[test]
-    fn test_parse_multi_product_response() {
-        // This test verifies that our implementation correctly skips non-APM_TRACING
-        // configs and only processes APM_TRACING configs. The multi-product response contains
-        // ASM_FEATURES and LIVE_DEBUGGING configs which should be ignored.
-
-        // Create a ConfigResponse object that represents a multi-product response
-        let config_response = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogMn19Cg==".to_string()), // base64 encoded targets with proper structure
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config".to_string(),
-                    raw: "eyJhc20tZmVhdHVyZXMiOiB7ImVuYWJsZWQiOiB0cnVlfX0=".to_string(), // base64 encoded config
-                },
-                TargetFile {
-                    path: "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config".to_string(),
-                    raw: "eyJsaXZlLWRlYnVnZ2luZyI6IHsiZW5hYmxlZCI6IGZhbHNlfX0=".to_string(), // base64 encoded config
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config".to_string(),
-                "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config".to_string(),
-            ]),
-        };
-
-        // Create a RemoteConfigClient and process the response
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // Process the response - this should update the client's state
-        let result = client.process_response(config_response);
-        assert!(result.is_ok(), "process_response should succeed");
-
-        // Verify that the client's state was updated correctly
-        let state = client.state.lock().unwrap();
-        assert_eq!(state.targets_version, 2);
-        assert_eq!(
-            state.backend_client_state,
-            Some("eyJfooIOiAiYmFoIn0=".to_string())
-        );
-        assert!(!state.has_error);
-
-        // Verify that no config states were added since we don't process non-APM_TRACING products
-        assert_eq!(state.config_states.len(), 0);
-
-        // Verify that cached target files were not added since they're not APM_TRACING
-        let cached_files = client.cached_target_files;
-        assert_eq!(cached_files.len(), 0);
-    }
-
-    #[test]
-    fn test_config_update_from_remote() {
-        // Test that the config is updated when sampling rules are received
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // Process a config response with sampling rules
-        let config_response = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogM319Cg==".to_string()),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/test-config/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJ0cmFjaW5nX3NhbXBsaW5nX3J1bGVzIjogW3sic2FtcGxlX3JhdGUiOiAwLjUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZSJ9XX19".to_string(),
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/test-config/config".to_string(),
-            ]),
-        };
-
-        let result = client.process_response(config_response);
-        assert!(result.is_ok(), "process_response should succeed");
-
-        // Verify that the config was updated with the sampling rules
-        let config = client.config;
-        let rules = config.trace_sampling_rules();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].sample_rate, 0.5);
-        assert_eq!(rules[0].service, Some("test-service".to_string()));
-    }
-
-    #[test]
-    fn test_tuf_targets_parsing() {
-        // Test parsing of a realistic TUF targets file structure
-        // Based on the example provided in the user query
-        let tuf_targets_json = r#"{
-   "signatures": [
-       {
-           "keyid": "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd",
-           "sig": "4dd483db8b4aff81a9afd2ed4eaeb23fe3aca9a148a7a8942e24e8c5ef911e2692f94492b882727b257dacfbf6bcea09d6e26ea28ac145fcb4254ea046be3b03"
-       }
-   ],
-   "signed": {
-       "_type": "targets",
-       "custom": {
-           "opaque_backend_state": "eyJ2ZXJzaW9uIjoxLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6WyJGZXJOT1FyMStmTThKWk9TY0crZllucnhXMWpKN0w0ZlB5aGtxUWVCT3dJPSIsInd1aW9BVm1Qcy9oNEpXMDh1dnI1bi9meERLQ3lKdG1sQmRjaDNOcFdLZDg9IiwiOGFDYVJFc3hIV3R3SFNFWm5SV0pJYmtENXVBNUtETENoZG8vZ0RNdnJJMD0iXX19"
-       },
-       "expires": "2022-09-22T09:01:04Z",
-       "spec_version": "1.0.0",
-       "targets": {
-           "datadog/2/APM_SAMPLING/dynamic_rates/config": {
-               "custom": {
-                   "v": 27423
-               },
-               "hashes": {
-                   "sha256": "c2e8a801598fb3f878256d3cbafaf99ff7f10ca0b226d9a505d721dcda5629df"
-               },
-               "length": 58409
-           },
-           "employee/ASM_DD/1.recommended.json/config": {
-               "custom": {
-                   "v": 1
-               },
-               "hashes": {
-                   "sha256": "15eacd390af5f9f33c259392706f9f627af15b58c9ecbe1f3f2864a907813b02"
-               },
-               "length": 235228
-           },
-           "employee/CWS_DD/4.default.policy/config": {
-               "custom": {
-                   "v": 1
-               },
-               "hashes": {
-                   "sha256": "f1a09a444b311d6b701d21199d158921b903e6e0392832c285da3f80332fac8d"
-               },
-               "length": 34777
-           }
-       },
-       "version": 23755701
-   }
-}"#;
-
-        // Parse the TUF targets structure
-        let targets: SignedTargets = serde_json::from_str(tuf_targets_json)
-            .expect("Should successfully parse TUF targets JSON");
-
-        // Verify signatures array is parsed correctly
-        assert!(targets.signatures.is_some());
-        let signatures = targets.signatures.unwrap();
-        assert_eq!(signatures.len(), 1);
-
-        // Verify the signed targets structure
-        assert_eq!(targets.signed.target_type, "targets");
-        assert_eq!(targets.signed.expires, "2022-09-22T09:01:04Z");
-        assert_eq!(targets.signed.spec_version, "1.0.0");
-        assert_eq!(targets.signed.version, 23755701);
-
-        // Verify custom metadata with opaque_backend_state
-        assert!(targets.signed.custom.is_some());
-        let custom = targets.signed.custom.unwrap();
-        let backend_state = custom
-            .get("opaque_backend_state")
-            .and_then(|v| v.as_str())
-            .expect("Should have opaque_backend_state");
-        assert_eq!(backend_state, "eyJ2ZXJzaW9uIjoxLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6WyJGZXJOT1FyMStmTThKWk9TY0crZllucnhXMWpKN0w0ZlB5aGtxUWVCT3dJPSIsInd1aW9BVm1Qcy9oNEpXMDh1dnI1bi9meERLQ3lKdG1sQmRjaDNOcFdLZDg9IiwiOGFDYVJFc3hIV3R3SFNFWm5SV0pJYmtENXVBNUtETENoZG8vZ0RNdnJJMD0iXX19");
-
-        // Verify targets parsing
-        assert_eq!(targets.signed.targets.len(), 3);
-
-        // Test APM_SAMPLING target
-        let apm_sampling = targets
-            .signed
-            .targets
-            .get("datadog/2/APM_SAMPLING/dynamic_rates/config")
-            .expect("Should have APM_SAMPLING target");
-        assert_eq!(apm_sampling.length, 58409);
-        assert_eq!(
-            apm_sampling.hashes.get("sha256").unwrap(),
-            "c2e8a801598fb3f878256d3cbafaf99ff7f10ca0b226d9a505d721dcda5629df"
-        );
-        let apm_custom = apm_sampling.custom.as_ref().unwrap();
-        assert_eq!(apm_custom.get("v").unwrap().as_u64().unwrap(), 27423);
-
-        // Test ASM_DD target
-        let asm_dd = targets
-            .signed
-            .targets
-            .get("employee/ASM_DD/1.recommended.json/config")
-            .expect("Should have ASM_DD target");
-        assert_eq!(asm_dd.length, 235228);
-        assert_eq!(
-            asm_dd.hashes.get("sha256").unwrap(),
-            "15eacd390af5f9f33c259392706f9f627af15b58c9ecbe1f3f2864a907813b02"
-        );
-        let asm_custom = asm_dd.custom.as_ref().unwrap();
-        assert_eq!(asm_custom.get("v").unwrap().as_u64().unwrap(), 1);
-
-        // Test CWS_DD target
-        let cws_dd = targets
-            .signed
-            .targets
-            .get("employee/CWS_DD/4.default.policy/config")
-            .expect("Should have CWS_DD target");
-        assert_eq!(cws_dd.length, 34777);
-        assert_eq!(
-            cws_dd.hashes.get("sha256").unwrap(),
-            "f1a09a444b311d6b701d21199d158921b903e6e0392832c285da3f80332fac8d"
-        );
-        let cws_custom = cws_dd.custom.as_ref().unwrap();
-        assert_eq!(cws_custom.get("v").unwrap().as_u64().unwrap(), 1);
-    }
-
-    // ===== Valid Path Tests =====
-
-    #[test_case("datadog/2/APM_TRACING/config123/config", "APM_TRACING", "config123")]
-    #[test_case(
-        "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
-        "LIVE_DEBUGGING",
-        "LIVE_DEBUGGING-base"
-    )]
-    #[test_case(
-        "datadog/2/AGENT_CONFIG/dynamic_rates/config",
-        "AGENT_CONFIG",
-        "dynamic_rates"
-    )]
-    #[test_case(
-        "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config",
-        "ASM_FEATURES",
-        "ASM_FEATURES-base"
-    )]
-    #[test_case(
-        "datadog/2/APM_SAMPLING/dynamic_rates/config",
-        "APM_SAMPLING",
-        "dynamic_rates"
-    )]
-    fn test_valid_datadog_paths(path: &str, expected_product: &str, expected_id: &str) {
-        let result = extract_product_and_id_from_path(path);
-        assert_eq!(
-            result,
-            Some((expected_product.to_string(), expected_id.to_string()))
-        );
-    }
-
-    #[test_case(
-        "employee/ASM_DD/1.recommended.json/config",
-        "ASM_DD",
-        "1.recommended.json"
-    )]
-    #[test_case(
-        "employee/CWS_DD/4.default.policy/config",
-        "CWS_DD",
-        "4.default.policy"
-    )]
-    #[test_case("employee/TEST_PRODUCT/test-id/some-name", "TEST_PRODUCT", "test-id")]
-    fn test_valid_employee_paths(path: &str, expected_product: &str, expected_id: &str) {
-        let result = extract_product_and_id_from_path(path);
-        assert_eq!(
-            result,
-            Some((expected_product.to_string(), expected_id.to_string()))
-        );
-    }
-
-    #[test_case("datadog/0/PRODUCT/id/name", "PRODUCT", "id")]
-    #[test_case("datadog/1/PRODUCT/id/name", "PRODUCT", "id")]
-    #[test_case("datadog/2/PRODUCT/id/name", "PRODUCT", "id")]
-    #[test_case("datadog/99/PRODUCT/id/name", "PRODUCT", "id")]
-    #[test_case("datadog/123/PRODUCT/id/name", "PRODUCT", "id")]
-    #[test_case("datadog/999999/PRODUCT/id/name", "PRODUCT", "id")]
-    fn test_various_numeric_versions(path: &str, expected_product: &str, expected_id: &str) {
-        let result = extract_product_and_id_from_path(path);
-        assert_eq!(
-            result,
-            Some((expected_product.to_string(), expected_id.to_string()))
-        );
-    }
-
-    #[test_case("datadog/2/PRODUCT-NAME/config-id-123/file.json", "PRODUCT-NAME", "config-id-123" ; "hyphens")]
-    #[test_case("datadog/2/PRODUCT_NAME/config_id_123/file_name", "PRODUCT_NAME", "config_id_123" ; "underscores")]
-    #[test_case("datadog/2/PRODUCT.NAME/config.id.123/file.name", "PRODUCT.NAME", "config.id.123" ; "dots")]
-    #[test_case("employee/PR0D-UCT_123/id-with.chars/name", "PR0D-UCT_123", "id-with.chars" ; "mixed special chars")]
-    fn test_special_characters_in_components(
-        path: &str,
-        expected_product: &str,
-        expected_id: &str,
-    ) {
-        let result = extract_product_and_id_from_path(path);
-        assert_eq!(
-            result,
-            Some((expected_product.to_string(), expected_id.to_string()))
-        );
-    }
-
-    // ===== Invalid Path Tests =====
-
-    #[test_case("" ; "empty string")]
-    #[test_case(" " ; "single space")]
-    #[test_case("   " ; "multiple spaces")]
-    fn test_empty_and_whitespace(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test_case("invalid/path" ; "invalid prefix")]
-    #[test_case("invalid/2/PRODUCT/id/name" ; "invalid prefix with components")]
-    #[test_case("datadogs/2/PRODUCT/id/name" ; "typo in datadog")]
-    #[test_case("employe/PRODUCT/id/name" ; "typo in employee")]
-    #[test_case("PRODUCT/id/name" ; "missing prefix entirely")]
-    #[test_case("2/PRODUCT/id/name" ; "numeric prefix only")]
-    fn test_missing_prefix(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test_case("datadog/2" ; "datadog only version")]
-    #[test_case("datadog/2/PRODUCT" ; "datadog missing id and name")]
-    #[test_case("datadog/2/PRODUCT/config" ; "datadog missing name")]
-    #[test_case("employee/PRODUCT" ; "employee missing id and name")]
-    #[test_case("employee/PRODUCT/id" ; "employee missing name")]
-    fn test_insufficient_components(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test_case("datadog/2/PRODUCT/id/name/extra" ; "datadog one extra")]
-    #[test_case("datadog/2/PRODUCT/id/name/extra/more" ; "datadog two extra")]
-    #[test_case("employee/PRODUCT/id/name/extra" ; "employee one extra")]
-    #[test_case("employee/PRODUCT/id/name/extra/and/more" ; "employee three extra")]
-    fn test_too_many_components(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test_case("datadog/2/PROD/UCT/id/name" ; "slash in product")]
-    #[test_case("datadog/2/PRODUCT/conf/ig/name" ; "slash in config_id")]
-    #[test_case("datadog/2/PRODUCT/id/na/me" ; "slash in name")]
-    fn test_slashes_in_components(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test_case("/datadog/2/PRODUCT/id/name" ; "leading slash datadog")]
-    #[test_case("datadog/2/PRODUCT/id/name/" ; "trailing slash datadog")]
-    #[test_case("/employee/PRODUCT/id/name" ; "leading slash employee")]
-    fn test_leading_trailing_slashes(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    // ===== Property-Based Tests =====
-
-    proptest! {
-        #[test]
-        fn test_valid_datadog_paths_property(
-            version in 0u32..1000000,
-            product in "[A-Z_]{1,20}",
-            config_id in "[a-zA-Z0-9_-]{1,30}",
-            name in "[a-zA-Z0-9_.-]{1,30}"
-        ) {
-            let path = format!("datadog/{}/{}/{}/{}", version, product, config_id, name);
-            let result = extract_product_and_id_from_path(&path);
-
-            prop_assert_eq!(
-                result,
-                Some((product.clone(), config_id.clone())),
-                "Valid datadog path should parse successfully: {}",
-                path
-            );
-        }
-
-        #[test]
-        fn test_valid_employee_paths_property(
-            product in "[A-Z_]{1,20}",
-            config_id in "[a-zA-Z0-9_.-]{1,30}",
-            name in "[a-zA-Z0-9_.-]{1,30}"
-        ) {
-            let path = format!("employee/{}/{}/{}", product, config_id, name);
-            let result = extract_product_and_id_from_path(&path);
-
-            prop_assert_eq!(
-                result,
-                Some((product.clone(), config_id.clone())),
-                "Valid employee path should parse successfully: {}",
-                path
-            );
-        }
-
-        #[test]
-        fn test_invalid_prefix_property(
-            prefix in "[a-z]{1,20}",
-            rest in "[a-zA-Z0-9/_-]{1,50}"
-        ) {
-            prop_assume!(prefix != "datadog" && prefix != "employee");
-            let path = format!("{}/{}", prefix, rest);
-            let result = extract_product_and_id_from_path(&path);
-
-            prop_assert_eq!(
-                result,
-                None,
-                "Path with invalid prefix should fail: {}",
-                path
-            );
-        }
-
-        #[test]
-        fn test_too_few_components_property(
-            version in 0u32..100,
-            component_count in 0usize..3
-        ) {
-            let mut components = vec![format!("datadog/{}", version)];
-            for i in 0..component_count {
-                components.push(format!("comp{}", i));
-            }
-            let path = components.join("/");
-            let result = extract_product_and_id_from_path(&path);
-
-            prop_assert_eq!(
-                result,
-                None,
-                "Path with {} components should fail: {}",
-                component_count,
-                path
-            );
-        }
-
-        #[test]
-        fn test_too_many_components_property(
-            version in 0u32..100,
-            product in "[A-Z_]{1,20}",
-            config_id in "[a-zA-Z0-9_-]{1,30}",
-            name in "[a-zA-Z0-9_.-]{1,30}",
-            extra_count in 1usize..5
-        ) {
-            let mut path = format!("datadog/{}/{}/{}/{}", version, product, config_id, name);
-            for i in 0..extra_count {
-                path.push_str(&format!("/extra{}", i));
-            }
-            let result = extract_product_and_id_from_path(&path);
-
-            prop_assert_eq!(
-                result,
-                None,
-                "Path with {} extra components should fail: {}",
-                extra_count,
-                path
-            );
-        }
-    }
-
-    // ===== Regression Tests for Real-World Paths =====
-
-    #[test_case(
-        "datadog/2/APM_SAMPLING/dynamic_rates/config",
-        "APM_SAMPLING",
-        "dynamic_rates"
-    )]
-    #[test_case(
-        "employee/ASM_DD/1.recommended.json/config",
-        "ASM_DD",
-        "1.recommended.json"
-    )]
-    #[test_case(
-        "employee/CWS_DD/4.default.policy/config",
-        "CWS_DD",
-        "4.default.policy"
-    )]
-    #[test_case(
-        "datadog/2/APM_TRACING/apm-tracing-sampling/config",
-        "APM_TRACING",
-        "apm-tracing-sampling"
-    )]
-    #[test_case(
-        "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config",
-        "ASM_FEATURES",
-        "ASM_FEATURES-base"
-    )]
-    #[test_case(
-        "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
-        "LIVE_DEBUGGING",
-        "LIVE_DEBUGGING-base"
-    )]
-    fn test_real_world_examples(path: &str, expected_product: &str, expected_id: &str) {
-        let result = extract_product_and_id_from_path(path);
-        assert_eq!(
-            result,
-            Some((expected_product.to_string(), expected_id.to_string()))
-        );
-    }
-
-    // ===== Edge Cases =====
-
-    #[test_case("datadog/2/PRODUCT/id-\u{00E9}/name" ; "unicode e with acute")]
-    #[test_case("employee/PRODUCT/id-\u{4E2D}/name" ; "unicode chinese character")]
-    fn test_unicode_in_components(path: &str) {
-        // These should parse successfully since unicode chars are valid in [^/]+
-        let result = extract_product_and_id_from_path(path);
-        assert!(result.is_some());
-    }
-
-    #[test_case("DATADOG/2/PRODUCT/id/name" ; "uppercase DATADOG")]
-    #[test_case("Datadog/2/PRODUCT/id/name" ; "capitalized Datadog")]
-    #[test_case("EMPLOYEE/PRODUCT/id/name" ; "uppercase EMPLOYEE")]
-    #[test_case("Employee/PRODUCT/id/name" ; "capitalized Employee")]
-    fn test_case_sensitivity(path: &str) {
-        assert_eq!(extract_product_and_id_from_path(path), None);
-    }
-
-    #[test]
-    fn test_product_registry() {
-        let registry = ProductRegistry::new();
-
-        // Should have APM_TRACING handler registered
-        assert!(registry.get_handler("APM_TRACING").is_some());
-
-        // Should not have unknown products
-        assert!(registry.get_handler("UNKNOWN_PRODUCT").is_none());
-    }
-
-    #[test]
-    fn test_apm_tracing_handler() {
-        let handler = ApmTracingHandler;
-        assert_eq!(handler.product_name(), "APM_TRACING");
-
-        // Test processing config - this should not panic for valid JSON
-        let config = Arc::new(Config::builder().build());
-        let config_json = r#"{"id": "42", "lib_config": {"tracing_sampling_rules": [{"sample_rate": 0.5, "service": "test"}]}}"#;
-
-        // This should succeed
-        let result = handler.process_config(config_json.as_bytes(), &config);
-        assert!(result.is_ok());
-
-        // Test invalid JSON
-        let invalid_json = "invalid json";
-        let result = handler.process_config(invalid_json.as_bytes(), &config);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_config_states_cleared_between_processing_cycles() {
-        // Test that config_states are cleared before adding new ones to prevent memory leak
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // First processing cycle - add one config
-        let config_response_1 = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogMX19Cg==".to_string()),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/config1/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJ0cmFjaW5nX3NhbXBsaW5nX3J1bGVzIjogW3sic2FtcGxlX3JhdGUiOiAwLjUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZS0xIn1dfX0=".to_string(),
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/config1/config".to_string(),
-            ]),
-        };
-
-        // Process first response
-        let result = client.process_response(config_response_1);
-        assert!(result.is_ok(), "First process_response should succeed");
-
-        // Verify first config state was added
-        {
-            let state = client.state.lock().unwrap();
-            assert_eq!(state.config_states.len(), 1);
-            assert_eq!(state.config_states[0].id, "config1");
-            assert_eq!(state.config_states[0].apply_state, 2); // success
-        }
-
-        // Second processing cycle - add different configs
-        let config_response_2 = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogMn19Cg==".to_string()),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/config2/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJpZCI6IjQyIiwgInRyYWNpbmdfc2FtcGxpbmdfcnVsZXMiOiBbeyJzYW1wbGVfcmF0ZSI6IDAuNzUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZS0yIn1dfX0=".to_string(),
-                },
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/config3/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJpZCI6IjQyIiwgInRyYWNpbmdfc2FtcGxpbmdfcnVsZXMiOiBbeyJzYW1wbGVfcmF0ZSI6IDAuMjUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZS0yIn1dfX0=".to_string(),
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/config2/config".to_string(),
-                "datadog/2/APM_TRACING/config3/config".to_string(),
-            ]),
-        };
-
-        // Process second response
-        let result = client.process_response(config_response_2);
-        assert!(result.is_ok(), "Second process_response should succeed");
-
-        // Verify config_states were cleared and only contains the new configs
-        {
-            let state = client.state.lock().unwrap();
-            // Should have exactly 2 configs (config2 and config3), not 3 (which would include
-            // config1)
-            assert_eq!(state.config_states.len(), 2);
-
-            // Check that we only have the new config IDs, not the old one
-            let config_ids: Vec<String> =
-                state.config_states.iter().map(|cs| cs.id.clone()).collect();
-            assert!(config_ids.contains(&"config2".to_string()));
-            assert!(config_ids.contains(&"config3".to_string()));
-            assert!(!config_ids.contains(&"config1".to_string())); // Should not contain old config
-
-            // All should be successful
-            for config_state in &state.config_states {
-                assert_eq!(config_state.apply_state, 2); // success
-                assert_eq!(config_state.product, "APM_TRACING");
-            }
-        }
-
-        // Third processing cycle - empty target files
-        let config_response_3 = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogM319Cg==".to_string()),
-            target_files: Some(vec![]), // Empty target files
-            client_configs: Some(vec![]),
-        };
-
-        // Process third response
-        let result = client.process_response(config_response_3);
-        assert!(result.is_ok(), "Third process_response should succeed");
-
-        // Verify config_states remain unchanged when no configs are processed
-        // (since clearing only happens when we're about to add new config states)
-        {
-            let state = client.state.lock().unwrap();
-            assert_eq!(state.config_states.len(), 2); // Should still have config2 and config3
-
-            let config_ids: Vec<String> =
-                state.config_states.iter().map(|cs| cs.id.clone()).collect();
-            assert!(config_ids.contains(&"config2".to_string()));
-            assert!(config_ids.contains(&"config3".to_string()));
-        }
-    }
-
-    #[test]
-    fn test_config_states_cleared_on_error_configs() {
-        // Test that config_states are cleared even when processing results in errors
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // First processing cycle - add successful config
-        let config_response_1 = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogMX19Cg==".to_string()),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/good_config/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJ0cmFjaW5nX3NhbXBsaW5nX3J1bGVzIjogW3sic2FtcGxlX3JhdGUiOiAwLjUsICJzZXJ2aWNlIjogInRlc3Qtc2VydmljZSJ9XX19".to_string(),
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/good_config/config".to_string(),
-            ]),
-        };
-
-        // Process first response
-        let result = client.process_response(config_response_1);
-        assert!(result.is_ok(), "First process_response should succeed");
-
-        // Verify first config state was added
-        {
-            let state = client.state.lock().unwrap();
-            assert_eq!(state.config_states.len(), 1);
-            assert_eq!(state.config_states[0].id, "good_config");
-            assert_eq!(state.config_states[0].apply_state, 2); // success
-        }
-
-        // Second processing cycle - add config with invalid JSON (will cause error)
-        let config_response_2 = ConfigResponse {
-            roots: None,
-            targets: Some("eyJzaWduZWQiOiB7Il90eXBlIjogInRhcmdldHMiLCAiY3VzdG9tIjogeyJvcGFxdWVfYmFja2VuZF9zdGF0ZSI6ICJleUpmb29JT2lBaVltRm9JbjA9In0sICJleHBpcmVzIjogIjIwMjQtMTItMzFUMjM6NTk6NTlaIiwgInNwZWNfdmVyc2lvbiI6ICIxLjAuMCIsICJ0YXJnZXRzIjoge30sICJ2ZXJzaW9uIjogMn19Cg==".to_string()),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/bad_config/config".to_string(),
-                    raw: "aW52YWxpZCBqc29u".to_string(), // "invalid json" in base64
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/bad_config/config".to_string(),
-            ]),
-        };
-
-        // Process second response
-        let result = client.process_response(config_response_2);
-        assert!(
-            result.is_ok(),
-            "Second process_response should succeed (even with config errors)"
-        );
-
-        // Verify config_states were cleared and only contains the new error config
-        {
-            let state = client.state.lock().unwrap();
-            assert_eq!(state.config_states.len(), 1); // Should have only the error config
-            assert_eq!(state.config_states[0].id, "bad_config");
-            assert_eq!(state.config_states[0].apply_state, 3); // error
-            assert!(state.config_states[0].apply_error.is_some());
-
-            // Should not contain the previous successful config
-            assert_ne!(state.config_states[0].id, "good_config");
-        }
-    }
-
-    #[test]
-    fn test_tuf_targets_integration_with_remote_config() {
-        // Test that we can process a TUF targets response through the remote config system
-        let config = Arc::new(Config::builder().build());
-        let mut client = RemoteConfigClient::new(config).unwrap();
-
-        // Create a realistic TUF targets JSON and base64 encode it
-        let tuf_targets_json = r#"{
-   "signatures": [
-       {
-           "keyid": "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd",
-           "sig": "4dd483db8b4aff81a9afd2ed4eaeb23fe3aca9a148a7a8942e24e8c5ef911e2692f94492b882727b257dacfbf6bcea09d6e26ea28ac145fcb4254ea046be3b03"
-       }
-   ],
-   "signed": {
-       "_type": "targets",
-       "custom": {
-           "opaque_backend_state": "eyJ2ZXJzaW9uIjoxLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6WyJGZXJOT1FyMStmTThKWk9TY0crZllucnhXMWpKN0w0ZlB5aGtxUWVCT3dJPSIsInd1aW9BVm1Qcy9oNEpXMDh1dnI1bi9meERLQ3lKdG1sQmRjaDNOcFdLZDg9IiwiOGFDYVJFc3hIV3R3SFNFWm5SV0pJYmtENXVBNUtETENoZG8vZ0RNdnJJMD0iXX19"
-       },
-       "expires": "2022-09-22T09:01:04Z",
-       "spec_version": "1.0.0",
-       "targets": {
-           "datadog/2/APM_TRACING/test-sampling/config": {
-               "custom": {
-                   "v": 100
-               },
-               "hashes": {
-                   "sha256": "c2e8a801598fb3f878256d3cbafaf99ff7f10ca0b226d9a505d721dcda5629df"
-               },
-               "length": 58409
-           }
-       },
-       "version": 23755701
-   }
-}"#;
-
-        use base64::Engine;
-        let encoded_targets =
-            base64::engine::general_purpose::STANDARD.encode(tuf_targets_json.as_bytes());
-
-        // Create a config response with the TUF targets and a corresponding target file
-        let config_response = ConfigResponse {
-            roots: None,
-            targets: Some(encoded_targets),
-            target_files: Some(vec![
-                TargetFile {
-                    path: "datadog/2/APM_TRACING/test-sampling/config".to_string(),
-                    raw: "eyJpZCI6ICI0MiIsICJsaWJfY29uZmlnIjogeyJ0cmFjaW5nX3NhbXBsaW5nX3J1bGVzIjogW3sic2FtcGxlX3JhdGUiOiAwLjc1LCAic2VydmljZSI6ICJ0ZXN0LWFwcC1zZXJ2aWNlIn1dfX0=".to_string(), // base64 encoded sampling rules
-                },
-            ]),
-            client_configs: Some(vec![
-                "datadog/2/APM_TRACING/test-sampling/config".to_string()
-            ]),
-        };
-
-        // Process the response
-        let result = client.process_response(config_response);
-        assert!(
-            result.is_ok(),
-            "process_response should succeed: {result:?}"
-        );
-
-        // Verify state was updated with targets metadata
-        let state = client.state.lock().unwrap();
-        assert_eq!(state.targets_version, 23755701);
-        assert_eq!(
-            state.backend_client_state,
-            Some("eyJ2ZXJzaW9uIjoxLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6WyJGZXJOT1FyMStmTThKWk9TY0crZllucnhXMWpKN0w0ZlB5aGtxUWVCT3dJPSIsInd1aW9BVm1Qcy9oNEpXMDh1dnI1bi9meERLQ3lKdG1sQmRjaDNOcFdLZDg9IiwiOGFDYVJFc3hIV3R3SFNFWm5SV0pJYmtENXVBNUtETENoZG8vZ0RNdnJJMD0iXX19".to_string())
-        );
-
-        // Verify config states were updated with version from targets custom.v
-        assert_eq!(state.config_states.len(), 1);
-        let config_state = &state.config_states[0];
-        assert!(config_state.id == "test-sampling" || config_state.id == "apm-tracing-sampling");
-        assert_eq!(config_state.version, 100); // From custom.v in targets
-        assert_eq!(config_state.product, "APM_TRACING");
-
-        // Verify that the sampling rules were applied to the config
-        let config = client.config;
-        let rules = config.trace_sampling_rules();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].sample_rate, 0.75);
-        assert_eq!(rules[0].service, Some("test-app-service".to_string()));
-    }
-
-    #[test]
-    fn test_deserialize_tracing_sampling_rules_null() {
-        let config_json = r#"{"id": "42", "lib_config": {"tracing_sampling_rules": null}}"#;
-        let tracing_config: ApmTracingConfig =
-            serde_json::from_str(config_json).expect("Json should be parsed");
-
-        assert!(tracing_config.lib_config.tracing_sampling_rules.is_some());
-        assert!(tracing_config
+    fn test_apm_tracing_config_null_rules_preserved() {
+        let cfg = make_apm_config("42", r#"{"tracing_sampling_rules":null}"#);
+        let rules = cfg
             .lib_config
             .tracing_sampling_rules
-            .unwrap()
-            .is_null());
+            .expect("explicit null preserved as Some(Null)");
+        assert!(rules.is_null());
     }
 
     #[test]
-    fn test_deserialize_tracing_sampling_rules_missing() {
-        let config_json = r#"{"id": "42", "lib_config": {}}"#;
-        let tracing_config: ApmTracingConfig =
-            serde_json::from_str(config_json).expect("Json should be parsed");
+    fn test_apm_tracing_config_missing_rules() {
+        let cfg = make_apm_config("42", r#"{}"#);
+        assert!(cfg.lib_config.tracing_sampling_rules.is_none());
+    }
 
-        assert!(tracing_config.lib_config.tracing_sampling_rules.is_none());
+    #[test]
+    fn test_apply_apm_tracing_updates_rules() {
+        let config = Arc::new(Config::builder().build());
+        let apm = make_apm_config(
+            "config-id-1",
+            r#"{"tracing_sampling_rules":[{"sample_rate":0.25,"service":"svc"}]}"#,
+        );
+        apply_apm_tracing(&config, &apm).expect("apply should succeed");
+
+        let stored: Vec<_> = config.trace_sampling_rules().to_vec();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].sample_rate, 0.25);
+    }
+
+    #[test]
+    fn test_apply_apm_tracing_null_clears_rules() {
+        let config = Arc::new(Config::builder().build());
+        // Seed rules first.
+        apply_apm_tracing(
+            &config,
+            &make_apm_config(
+                "id-1",
+                r#"{"tracing_sampling_rules":[{"sample_rate":0.5,"service":"svc"}]}"#,
+            ),
+        )
+        .expect("apply should succeed");
+        assert_eq!(config.trace_sampling_rules().len(), 1);
+
+        // Null clears.
+        apply_apm_tracing(
+            &config,
+            &make_apm_config("id-1", r#"{"tracing_sampling_rules":null}"#),
+        )
+        .expect("clear should succeed");
+        assert!(config.trace_sampling_rules().is_empty());
+    }
+
+    #[test]
+    fn test_apm_tracing_parser_round_trip() {
+        let parser = apm_tracing_parser();
+        let json =
+            br#"{"id":"42","lib_config":{"tracing_sampling_rules":[{"sample_rate":1.0,"service":"x"}]}}"#;
+        let parsed = parser(json).expect("parser should accept valid JSON");
+        let apm = parsed
+            .as_any()
+            .downcast_ref::<ApmTracingConfig>()
+            .expect("downcast to ApmTracingConfig");
+        assert_eq!(apm.id, "42");
+        assert_eq!(apm.product(), RemoteConfigProduct::ApmTracing);
     }
 }

--- a/datadog-opentelemetry/src/exporter/mod.rs
+++ b/datadog-opentelemetry/src/exporter/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use crate::{dd_debug, dd_error};
+use libdd_capabilities_impl::NativeCapabilities;
 use libdd_data_pipeline::trace_exporter::{
     agent_response::AgentResponse,
     error::{self as trace_exporter_error, TraceExporterError},
@@ -553,12 +554,12 @@ pub trait Exporter<T> {
     fn trace_chunks(
         &mut self,
         trace_chunks: Vec<TraceChunk<T>>,
-        trace_exporter: &TraceExporter,
+        trace_exporter: &TraceExporter<NativeCapabilities>,
     ) -> Result<AgentResponse, TraceExporterError>;
 }
 
 struct TraceExporterWorker<T> {
-    trace_exporter: TraceExporter,
+    trace_exporter: TraceExporter<NativeCapabilities>,
     rx: Receiver<T>,
     exporter: Box<dyn Exporter<T>>,
     #[allow(clippy::type_complexity)]
@@ -583,7 +584,7 @@ impl<T: Send + 'static> TraceExporterWorker<T> {
     ) -> TraceExporterHandle {
         let handle = thread::spawn({
             move || {
-                let trace_exporter = match builder.build() {
+                let trace_exporter = match builder.build::<NativeCapabilities>() {
                     Ok(exporter) => exporter,
                     Err(e) => {
                         return Err(e);
@@ -608,9 +609,16 @@ impl<T: Send + 'static> TraceExporterWorker<T> {
         #[cfg(feature = "test-utils")]
         {
             // Wait for the agent info to be fetched to get deterministic output when deciding
-            // to drop traces or not
-            self.trace_exporter
-                .wait_agent_info_ready(Duration::from_secs(5))
+            // to drop traces or not. The upstream helper is async, so block on it from this
+            // worker thread via a fresh current-thread runtime.
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(
+                    self.trace_exporter
+                        .wait_agent_info_ready(Duration::from_secs(5)),
+                )
                 .unwrap();
         }
         while let Ok((message, data)) = self.rx.receive(self.config.max_flush_interval) {

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -4,6 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use arc_swap::ArcSwap;
+use libdd_capabilities_impl::NativeCapabilities;
 use libdd_data_pipeline::trace_exporter::{
     agent_response::AgentResponse, error::TraceExporterError, TelemetryConfig, TraceExporter,
     TraceExporterOutputFormat,
@@ -120,7 +121,7 @@ impl Exporter<SpanData> for MapperExporter {
     fn trace_chunks(
         &mut self,
         trace_chunks: Vec<TraceChunk<SpanData>>,
-        trace_exporter: &TraceExporter,
+        trace_exporter: &TraceExporter<NativeCapabilities>,
     ) -> Result<AgentResponse, TraceExporterError> {
         let resource = self.otel_resource.load();
         let trace_chunks = trace_chunks


### PR DESCRIPTION
## Summary

- Bring up an end-to-end Remote Config client driven by `datadog-remote-config` from libdatadog, replacing the prior placeholder.
- Adapt to the updated upstream API: typed `ParserRegistry`, `RemoteConfigContent` trait (with `const PRODUCT` and `fn parse`)

Currently tracks libdatadog branch `igor/rc/di-refactor-claude`. The `[patch.crates-io]` block is marked TODO and should be dropped once the matching libdatadog versions are published to crates.io.

## Notes
It is registering a custom parser for `ApmTracingConfig` but it could use the builtin RC parser for `DynamicConfigFile`. In that case we'll need to update config and sampler methods and types related with `trace_sampling_rules`. I have decided not to change it after the sampler migration is in place.


🤖 Generated with [Claude Code](https://claude.com/claude-code)