### PR TITLE
feat(trace-id): add DD_TRACE_SECURE_RANDOM option for guaranteed ID uniqueness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ opentelemetry-semantic-conventions = { version = "0.31.0", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1.44.1" }
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { version = "0.8", features = ["small_rng", "getrandom"] }
 
 serde = { version = "1.0.194" }
 serde_json = { version = "1.0.140" }

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -965,6 +965,9 @@ pub struct Config {
     trace_propagation_style_inject: ConfigItem<Option<Vec<TracePropagationStyle>>>,
     trace_propagation_extract_first: ConfigItem<bool>,
 
+    /// Whether to use cryptographically secure random for trace/span ID generation
+    trace_secure_random: ConfigItem<bool>,
+
     /// Whether remote configuration is enabled
     remote_config_enabled: ConfigItem<bool>,
 
@@ -1158,6 +1161,7 @@ impl Config {
             #[cfg(feature = "test-utils")]
             wait_agent_info_ready: default.wait_agent_info_ready,
             extra_services_tracker: ExtraServicesTracker::new(),
+            trace_secure_random: cisu.update_parsed(default.trace_secure_random),
             remote_config_enabled: cisu.update_parsed(default.remote_config_enabled),
             remote_config_poll_interval: cisu.update_parsed_with_transform(
                 default.remote_config_poll_interval,
@@ -1227,6 +1231,7 @@ impl Config {
             &self.trace_propagation_style_extract,
             &self.trace_propagation_style_inject,
             &self.trace_propagation_extract_first,
+            &self.trace_secure_random,
             &self.remote_config_enabled,
             &self.remote_config_poll_interval,
             &self.datadog_tags_max_length,
@@ -1622,6 +1627,11 @@ impl Config {
         self.extra_services_tracker.get_extra_services()
     }
 
+    /// Returns whether secure random is enabled for trace/span ID generation.
+    pub fn trace_secure_random(&self) -> bool {
+        *self.trace_secure_random.value()
+    }
+
     /// Check if remote configuration is enabled
     pub fn remote_config_enabled(&self) -> bool {
         *self.remote_config_enabled.value()
@@ -1825,6 +1835,10 @@ fn default_config() -> Config {
             false,
         ),
         extra_services_tracker: ExtraServicesTracker::new(),
+        trace_secure_random: ConfigItem::new(
+            SupportedConfigurations::DD_TRACE_SECURE_RANDOM,
+            false,
+        ),
         remote_config_enabled: ConfigItem::new(
             SupportedConfigurations::DD_REMOTE_CONFIGURATION_ENABLED,
             true,
@@ -3457,5 +3471,39 @@ mod tests {
             .build();
 
         assert_eq!(config.remote_config_poll_interval(), 0.2);
+    }
+
+    #[test]
+    fn test_trace_secure_random_default() {
+        let config = Config::builder().build();
+        assert!(!config.trace_secure_random());
+    }
+
+    #[test]
+    fn test_trace_secure_random_from_env() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_SECURE_RANDOM", "true")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        assert!(config.trace_secure_random());
+
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_SECURE_RANDOM", "false")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        assert!(!config.trace_secure_random());
+
+        // Invalid value falls back to the default (false)
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_SECURE_RANDOM", "yes")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        assert!(!config.trace_secure_random());
     }
 }

--- a/datadog-opentelemetry/src/core/configuration/supported_configurations.rs
+++ b/datadog-opentelemetry/src/core/configuration/supported_configurations.rs
@@ -34,6 +34,7 @@ pub(crate) enum SupportedConfigurations {
     DD_TRACE_PROPAGATION_STYLE_INJECT,
     DD_TRACE_RATE_LIMIT,
     DD_TRACE_SAMPLING_RULES,
+    DD_TRACE_SECURE_RANDOM,
     DD_TRACE_STATS_COMPUTATION_ENABLED,
     DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH,
     DD_VERSION,
@@ -120,6 +121,7 @@ impl SupportedConfigurations {
             }
             SupportedConfigurations::DD_TRACE_RATE_LIMIT => "DD_TRACE_RATE_LIMIT",
             SupportedConfigurations::DD_TRACE_SAMPLING_RULES => "DD_TRACE_SAMPLING_RULES",
+            SupportedConfigurations::DD_TRACE_SECURE_RANDOM => "DD_TRACE_SECURE_RANDOM",
             SupportedConfigurations::DD_TRACE_STATS_COMPUTATION_ENABLED => {
                 "DD_TRACE_STATS_COMPUTATION_ENABLED"
             }

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -553,7 +553,7 @@ fn make_tracer(
 
         let mut tracer_provider_builder = tracer_provider_builder
             .with_sampler(sampler) // Use the sampler created above
-            .with_id_generator(trace_id::TraceidGenerator);
+            .with_id_generator(trace_id::TraceidGenerator::new(config.trace_secure_random()));
         if config.enabled() {
             let span_processor = DatadogSpanProcessor::new(
                 config.clone(),

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -553,7 +553,9 @@ fn make_tracer(
 
         let mut tracer_provider_builder = tracer_provider_builder
             .with_sampler(sampler) // Use the sampler created above
-            .with_id_generator(trace_id::TraceidGenerator::new(config.trace_secure_random()));
+            .with_id_generator(trace_id::TraceidGenerator::new(
+                config.trace_secure_random(),
+            ));
         if config.enabled() {
             let span_processor = DatadogSpanProcessor::new(
                 config.clone(),

--- a/datadog-opentelemetry/src/trace_id.rs
+++ b/datadog-opentelemetry/src/trace_id.rs
@@ -2,20 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::sync::OnceLock;
 
 use rand::{rngs::OsRng, Rng, RngCore, SeedableRng};
 
-static SECURE_RANDOM: OnceLock<bool> = OnceLock::new();
-
-fn secure_random() -> bool {
-    *SECURE_RANDOM.get_or_init(|| {
-        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true")
-    })
+#[derive(Debug)]
+pub(crate) struct TraceidGenerator {
+    secure_random: bool,
 }
 
-#[derive(Debug)]
-pub(crate) struct TraceidGenerator;
+impl TraceidGenerator {
+    pub(crate) fn new(secure_random: bool) -> Self {
+        Self { secure_random }
+    }
+}
 
 thread_local! {
     // Used only when DD_TRACE_SECURE_RANDOM is not set.
@@ -29,7 +28,7 @@ impl opentelemetry_sdk::trace::IdGenerator for TraceidGenerator {
         // 32 bits timestamp | 32 bits of zeroes | 64 bits of random
         // The timestamp is the number of seconds since the UNIX epoch
 
-        let lower_half = if secure_random() {
+        let lower_half = if self.secure_random {
             OsRng.next_u64()
         } else {
             RNG.with(|rng| rng.borrow_mut().gen::<u64>())
@@ -47,7 +46,7 @@ impl opentelemetry_sdk::trace::IdGenerator for TraceidGenerator {
     }
 
     fn new_span_id(&self) -> opentelemetry::SpanId {
-        let id = if secure_random() {
+        let id = if self.secure_random {
             OsRng.next_u64()
         } else {
             RNG.with(|rng| rng.borrow_mut().gen::<u64>())
@@ -64,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_trace_id_generator() {
-        let generator = TraceidGenerator;
+        let generator = TraceidGenerator::new(false);
         let trace_id = u128::from_be_bytes(generator.new_trace_id().to_bytes());
         // Format should be 32 bits timestamp | 32 bits of zeroes | 64 bits of random
         assert!(trace_id & 0x0000_0000_FFFF_FFFF_0000_0000_0000_0000 == 0);
@@ -81,14 +80,14 @@ mod tests {
 
     #[test]
     fn test_new_trace_id_nonzero() {
-        let gen = TraceidGenerator;
+        let gen = TraceidGenerator::new(false);
         let id = gen.new_trace_id();
         assert_ne!(id, opentelemetry::TraceId::INVALID);
     }
 
     #[test]
     fn test_new_span_id_nonzero() {
-        let gen = TraceidGenerator;
+        let gen = TraceidGenerator::new(false);
         let id = gen.new_span_id();
         assert_ne!(id, opentelemetry::SpanId::INVALID);
     }
@@ -105,8 +104,34 @@ mod tests {
     }
 
     #[test]
-    fn test_secure_random_flag() {
-        // Just verify it returns a bool without panicking (OnceLock may already be init)
-        let _ = secure_random();
+    fn test_secure_random_trace_id_format() {
+        let gen = TraceidGenerator::new(true);
+        let trace_id = u128::from_be_bytes(gen.new_trace_id().to_bytes());
+        // Must still follow: 32 bits timestamp | 32 bits zeroes | 64 bits random
+        assert!(trace_id & 0x0000_0000_FFFF_FFFF_0000_0000_0000_0000 == 0);
+        let ts = (trace_id >> 96) as u64;
+        let now = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("negative timestamp")
+            .as_secs();
+        assert!(now - 120 < ts && ts < now + 120);
+        assert_ne!(trace_id & 0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, 0);
+    }
+
+    #[test]
+    fn test_secure_random_span_id_nonzero() {
+        let gen = TraceidGenerator::new(true);
+        let id = gen.new_span_id();
+        assert_ne!(id, opentelemetry::SpanId::INVALID);
+    }
+
+    #[test]
+    fn test_secure_random_produces_varied_values() {
+        use std::collections::HashSet;
+        let gen = TraceidGenerator::new(true);
+        let ids: HashSet<[u8; 8]> = (0..100)
+            .map(|_| gen.new_span_id().to_bytes())
+            .collect();
+        assert!(ids.len() > 90, "Expected diverse IDs, got {}", ids.len());
     }
 }

--- a/datadog-opentelemetry/src/trace_id.rs
+++ b/datadog-opentelemetry/src/trace_id.rs
@@ -2,14 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
+use std::sync::OnceLock;
 
-use rand::{Rng, SeedableRng};
+use rand::{rngs::OsRng, Rng, RngCore, SeedableRng};
+
+static SECURE_RANDOM: OnceLock<bool> = OnceLock::new();
+
+fn secure_random() -> bool {
+    *SECURE_RANDOM.get_or_init(|| {
+        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true")
+    })
+}
 
 #[derive(Debug)]
 pub(crate) struct TraceidGenerator;
 
 thread_local! {
-    /// TODO: Restart entropy in forked thread in case of fork
+    // Used only when DD_TRACE_SECURE_RANDOM is not set.
+    // TODO: Restart entropy in forked thread in case of fork
     static RNG: RefCell<rand::rngs::SmallRng> = RefCell::new(rand::rngs::SmallRng::from_entropy());
 }
 
@@ -19,7 +29,11 @@ impl opentelemetry_sdk::trace::IdGenerator for TraceidGenerator {
         // 32 bits timestamp | 32 bits of zeroes | 64 bits of random
         // The timestamp is the number of seconds since the UNIX epoch
 
-        let lower_half = RNG.with(|rng| rng.borrow_mut().gen::<u64>());
+        let lower_half = if secure_random() {
+            OsRng.next_u64()
+        } else {
+            RNG.with(|rng| rng.borrow_mut().gen::<u64>())
+        };
         let timestamp = std::time::UNIX_EPOCH
             .elapsed()
             .map(|d| d.as_secs())
@@ -33,7 +47,12 @@ impl opentelemetry_sdk::trace::IdGenerator for TraceidGenerator {
     }
 
     fn new_span_id(&self) -> opentelemetry::SpanId {
-        let span_id = RNG.with(|rng| rng.borrow_mut().gen::<u64>()).to_be_bytes();
+        let id = if secure_random() {
+            OsRng.next_u64()
+        } else {
+            RNG.with(|rng| rng.borrow_mut().gen::<u64>())
+        };
+        let span_id = id.to_be_bytes();
         opentelemetry::SpanId::from_bytes(span_id)
     }
 }
@@ -58,5 +77,36 @@ mod tests {
         assert!(now - 120 < ts && ts < now + 120);
         // Check that the lower half is not zero
         assert!(trace_id & 0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF != 0);
+    }
+
+    #[test]
+    fn test_new_trace_id_nonzero() {
+        let gen = TraceidGenerator;
+        let id = gen.new_trace_id();
+        assert_ne!(id, opentelemetry::TraceId::INVALID);
+    }
+
+    #[test]
+    fn test_new_span_id_nonzero() {
+        let gen = TraceidGenerator;
+        let id = gen.new_span_id();
+        assert_ne!(id, opentelemetry::SpanId::INVALID);
+    }
+
+    #[test]
+    fn test_osrng_produces_varied_values() {
+        use std::collections::HashSet;
+        let values: HashSet<u64> = (0..100).map(|_| OsRng.next_u64()).collect();
+        assert!(
+            values.len() > 90,
+            "Expected diverse OsRng values, got {}",
+            values.len()
+        );
+    }
+
+    #[test]
+    fn test_secure_random_flag() {
+        // Just verify it returns a bool without panicking (OnceLock may already be init)
+        let _ = secure_random();
     }
 }

--- a/datadog-opentelemetry/src/trace_id.rs
+++ b/datadog-opentelemetry/src/trace_id.rs
@@ -129,9 +129,7 @@ mod tests {
     fn test_secure_random_produces_varied_values() {
         use std::collections::HashSet;
         let gen = TraceidGenerator::new(true);
-        let ids: HashSet<[u8; 8]> = (0..100)
-            .map(|_| gen.new_span_id().to_bytes())
-            .collect();
+        let ids: HashSet<[u8; 8]> = (0..100).map(|_| gen.new_span_id().to_bytes()).collect();
         assert!(ids.len() > 90, "Expected diverse IDs, got {}", ids.len());
     }
 }

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -211,6 +211,14 @@
         "propertyKeys": ["trace_sampling_rules"]
       }
     ],
+    "DD_TRACE_SECURE_RANDOM": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "propertyKeys": ["trace_secure_random"]
+      }
+    ],
     "DD_TRACE_STATS_COMPUTATION_ENABLED": [
       {
         "version": "B",


### PR DESCRIPTION
[Tech Doc](https://docs.google.com/document/d/1s_nVu8eyR2BiIdHSQ8K1OZE5yji_lo5g7CuS5GmLFVg/edit?usp=sharing)

https://datadoghq.atlassian.net/browse/SVLS-9140

## Background

For Firecracker-based container technology, in order to reduce cold-start latency, the system snapshots the entire process memory of a warmed-up instance and reuses it to launch new ones. Every resumed instance starts from the same frozen memory image — including any userspace PRNG state that was initialized before the snapshot was taken.

## Motivation

Standard PRNGs seed once at startup and produce a deterministic sequence from that point forward. When Firecracker resumes thousands of instances from the same snapshot, every one of them begins at the same position in that sequence. Concurrent instances then generate identical trace IDs and span IDs, corrupting distributed traces and making sampled data statistically meaningless.

The fix cannot live inside each language tracer: from inside a resumed process, a cold start and a snapshot restore are indistinguishable. The process simply wakes up already initialized — no changed PID, no kernel signal, no env var that differs between the two cases.

## Issue
SmallRng thread-local (rand 0.8); not fork-safe and not snapshot-safe

## Solution  

With DD_TRACE_SECURE_RANDOM=true, we should switch OsRng (getrandom(2) per call). With no userspace PRNG state to freeze, every resumed instance generates an independent sequence — regardless of when the snapshot was taken.

## Summary

- `SmallRng` is seeded from OS entropy once at thread-local initialization; its state is deterministic thereafter. In environments where process memory is cloned, all copies share the same thread-local PRNG state and generate identical trace/span ID sequences. A fork-safety gap for this same reason is noted in the existing TODO comment.
- When `DD_TRACE_SECURE_RANDOM=true`, `new_trace_id` and `new_span_id` use `OsRng` (`getrandom(2)` per call) instead of the `SmallRng` thread-local. `OsRng` holds no userspace state, ensuring ID uniqueness regardless of how the process image was duplicated. This also addresses the fork-safety gap noted in the TODO.
- `DD_TRACE_SECURE_RANDOM` is registered in the config abstraction layer (`supported-configurations.json`, `SupportedConfigurations` enum, `Config` struct) so it is read through the same path as all other env vars, consistent with the `clippy::disallowed-methods` rule that bans direct `std::env::var` calls.
- `TraceidGenerator` now takes `secure_random: bool` at construction time (injected from `Config`) rather than reading the env var lazily via `OnceLock`.
- `Cargo.toml`: added `"getrandom"` to the `rand` features to make `OsRng` available.

## Test plan

- [x] `test_trace_id_generator`: trace ID follows `timestamp | zeroes | random` format, timestamp within bounds
- [x] `test_new_trace_id_nonzero`: generated trace ID is not `INVALID`
- [x] `test_new_span_id_nonzero`: generated span ID is not `INVALID`
- [x] `test_osrng_produces_varied_values`: 100 `OsRng` calls → >90 unique `u64` values
- [x] `test_secure_random_trace_id_format`: `secure_random=true` path still produces correct `timestamp | zeroes | random` format
- [x] `test_secure_random_span_id_nonzero`: `OsRng`-backed span ID is not `INVALID`
- [x] `test_secure_random_produces_varied_values`: 100 calls with `secure_random=true` → >90 unique span IDs
- [x] `test_trace_secure_random_default`: config defaults to `false` with no env var
- [x] `test_trace_secure_random_from_env`: `"true"` → `true`, `"false"` → `false`, invalid value → `false` (default)
- [x] Existing propagation/mapping tests unaffected (13 total pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)