### PR TITLE
chore: regenerate instrumentation/Cargo.lock

### DIFF
--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "percent-encoding",
  "rand 0.8.5",
  "rustc_version_runtime",
  "serde",


### PR DESCRIPTION
# What does this PR do?

Regenerates `instrumentation/Cargo.lock` to add `percent-encoding` as a recorded transitive dependency. Without this, `cargo build --workspace --locked` and `cargo test --workspace --locked` fail in CI with:

```
error: cannot update the lock file instrumentation/Cargo.lock because --locked was passed to prevent this
```

# Motivation

This lock file drift has been causing the "Test (AWS integrations)" CI job to fail on every PR (including `main` since at least May 12). It is pre-existing infrastructure debt unrelated to any particular feature PR.

# Additional Notes

One-line change: adds `percent-encoding` to the lock file, reflecting a transitive dependency that was already present in the dependency graph but not recorded.