### PR TITLE
fix(ci): set a cron task on all days

### DIFF
--- a/.github/workflows/test-aws-integrations.yaml
+++ b/.github/workflows/test-aws-integrations.yaml
@@ -8,6 +8,8 @@ on:
       - "datadog-opentelemetry/**"
       - ".github/workflows/test-aws-integrations.yaml"
   workflow_dispatch:
+  schedule:
+    - cron:  '00 03 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
    push:
    workflow_dispatch:
    schedule:
-      - cron:  '00 03 * * 1-5'
+      - cron:  '00 03 * * *'
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.84.1


### PR DESCRIPTION
# What does this PR do?

* Add a cron task for `.github/workflows/test-aws-integrations.yaml`
* add runs on saturday/sunday for `.github/workflows/test.yaml`

# Motivation

At the beginning of the year, `dd-trace-java` accidentally dropped a significant portion of its CI coverage for two weeks. The same issue happened again twice shortly afterward. We realized that, with the increasing size and complexity of the CI, it has become quite easy to unintentionally drop part of it without noticing.

To address this, we added a Datadog monitor that alerts us whenever such an event occurs by tracking the cardinality of test names reported to Test Optimization each day. This monitor later caught a similar issue on `dd-trace-go` one month afterward.

However, due to a limitation in Datadog monitors, we need to either:

1. Ensure there is at least one run per day, including weekends
2. Or use a three-day time window

The second option would mean being notified three days after the drop instead of one day later. We therefore decided to go with the first option.


# Additional Notes

Anything else we should know when reviewing?
