### PR TITLE
chore(ci): update tools for generating 3rd party license file

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -121,51 +121,38 @@ jobs:
         # Exclude symbolizer-ffi from the checks (mostly imported code)
         run: '! find . \( -name "*.rs" -o -name "*.c" -o -name "*.sh" \) -print0 | xargs -0 licensecheck -c ".*" | grep -v "Apache License 2.0"'
 
-  license-3rdparty-csv:
+  license-3rdparty:
     runs-on: ubuntu-latest
     name: "Valid LICENSE-3rdparty.csv"
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: stat LICENSE-3rdparty.csv
-      - name: Cache
+      # Keep version in sync with: scripts/update_license_3rdparty.sh (TOOL_VERSION) and scripts/Dockerfile.license (ARG TOOL_VERSION)
+      - name: Cache dd-rust-license-tool
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry/
             ~/.cargo/git/db/
-            ~/.cargo/bin/
+            ~/.cargo/bin/dd-rust-license-tool
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          # cache key contains current version of dd-rust-license-tool
-          # when upstream version is updated we can bump the cache key version,
-          # to cache the latest version of the tool
-          key: "v1-dd-rust-license-tool-1.0.4"
-      - name: Cache
-        uses: ./.github/actions/cache
-      - name: Install dd-rust-license-tool
-        run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.4" || cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v1.0.4 dd-rust-license-tool
-      - name: "Generate new LICENSE-3rdparty.csv and check against the previous"
+          key: dd-rust-license-tool-1.0.6-v2
+      - run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.6" || cargo install dd-rust-license-tool --version "1.0.6" --locked
+      - name: Generate new LICENSE-3rdparty.csv and check against the previous
         run: |
-          # The LICENSE-3rdparty.csv file must match the output of the tool in the Linux CI environment.
-          # To update the file locally, run the './scripts/generate-licenses.sh' script.
-          echo "Running dd-rust-license-tool dump to generate CSV..."
           if ! dd-rust-license-tool dump > /tmp/CI.csv 2> /tmp/CI.error; then
             echo "ERROR: dd-rust-license-tool dump failed! See error output below:"
             cat /tmp/CI.error
             exit 1
           fi
-
-          # Compare the generated CSV with the current one. If they differ, diff will have a non-zero exit code.
           if ! diff /tmp/CI.csv LICENSE-3rdparty.csv; then
             echo "Differences detected in LICENSE-3rdparty.csv."
-            echo "Please run './scripts/generate-licenses.sh' to update the file and commit the changes."
+            echo "Please run './scripts/update_license_3rdparty.sh' to update the file and commit the changes."
             exit 1
           fi
-
           echo "No differences found."
-
-      - name: export the generated license file on failure
+      - name: Export generated license file on failure
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ find . -name '*.sh' -print0 | xargs -0 shellcheck
 rumdl check .
 
 # Update licence file if dependencies changed
-./scripts/generate-licenses.sh
+./scripts/update_license_3rdparty.sh
 ```
 
 ## Code Style
@@ -194,7 +194,7 @@ documented.
 
 To update the license file:
 
-1. Run `./scripts/generate-licenses.sh` (requires Docker)
+1. Run `./scripts/update_license_3rdparty.sh` (requires Docker or local tool install)
 2. Review the changes to `LICENSE-3rdparty.csv`
 3. Commit the updated file
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -47,7 +47,7 @@ crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,Th
 crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
 crossbeam-epoch,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-epoch Authors
 crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-utils Authors
-crunchy,https://github.com/eira-fransham/crunchy,MIT,Eira Fransham <jackefransham@gmail.com>
+crunchy,https://github.com/AtheMathmo/crunchy,MIT,Eira Fransham <jackefransham@gmail.com>
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 diff,https://github.com/utkarshkukreti/diff.rs,MIT OR Apache-2.0,Utkarsh Kukreti <utkarshkukreti@gmail.com>
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers

--- a/license-tool.toml
+++ b/license-tool.toml
@@ -1,4 +1,7 @@
 [overrides]
-# Tagged incorrectly by crates.io
+# This crate is missing a repository URL in its metadata.
+"crunchy" = { origin = "https://github.com/AtheMathmo/crunchy" }
+
+# This crate is tagged incorrectly in its metadata.
 # https://github.com/pluots/stringmetrics/blob/v2.2.2/LICENSE
-"stringmetrics-2.2.2" = { license = "Apache-2.0" }
+"stringmetrics" = { license = "Apache-2.0" }

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -1,21 +1,21 @@
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
 FROM rust:1.84-slim
 
-# Set up the workspace directory
-WORKDIR /usr/src/app
+# Keep in sync with: scripts/update_license_3rdparty.sh (TOOL_VERSION) and .github/workflows/lint.yaml (cache key + install step)
+ARG TOOL_VERSION=1.0.6
 
-# Install the license tool with cache mount
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v1.0.4 dd-rust-license-tool
+    cargo install dd-rust-license-tool --version "${TOOL_VERSION}" --locked
 
-# Copy the rest of the project files
+WORKDIR /build
+
 COPY . .
 
-# Generate the license file during build, with caching
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    dd-rust-license-tool dump > LICENSE-3rdparty.csv
+    dd-rust-license-tool dump > /licenses.csv
 
-# Simply output the pre-generated file at runtime
-ENTRYPOINT ["cat"]
-CMD ["./LICENSE-3rdparty.csv"] 
+ENTRYPOINT ["cat", "/licenses.csv"]

--- a/scripts/update_license_3rdparty.sh
+++ b/scripts/update_license_3rdparty.sh
@@ -1,19 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2024-present Datadog, Inc.
-#
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 # SPDX-License-Identifier: Apache-2.0
-
-# This script generates the LICENSE-3rdparty.csv file.
-# If dd-rust-license-tool v1.0.4 is installed locally it runs directly;
-# otherwise it offers to install the tool or fall back to Docker (Linux only).
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.4"
-INSTALL_CMD="cargo install --git https://github.com/DataDog/rust-license-tool.git --tag v${TOOL_VERSION} dd-rust-license-tool"
+# Keep in sync with: scripts/Dockerfile.license (ARG TOOL_VERSION) and .github/workflows/lint.yaml (cache key + install step)
+TOOL_VERSION="1.0.6"
+INSTALL_CMD="cargo install dd-rust-license-tool --version \"${TOOL_VERSION}\" --locked"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
 run_native() {
+    cd "${ROOT_DIR}"
     echo "Running dd-rust-license-tool dump..."
     dd-rust-license-tool dump > LICENSE-3rdparty.csv
 }
@@ -23,25 +21,24 @@ run_docker() {
         echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
         exit 1
     fi
-    # Ensure BuildKit is enabled for efficient caching
     export DOCKER_BUILDKIT=1
-    echo "Building license tool container with caching..."
+    echo "Building license tool container..."
     docker build \
         --progress=plain \
-        -t dd-license-tool \
-        -f scripts/Dockerfile.license \
-        .
+        -t dd-trace-rs-dd-license-tool \
+        -f "${ROOT_DIR}/scripts/Dockerfile.license" \
+        "${ROOT_DIR}"
     echo "Generating LICENSE-3rdparty.csv..."
-    docker run --rm dd-license-tool > LICENSE-3rdparty.csv
+    docker run --rm dd-trace-rs-dd-license-tool > "${ROOT_DIR}/LICENSE-3rdparty.csv"
 }
 
-if cargo install --list | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
+if cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
     run_native
 else
-    INSTALLED_VERSION=$(cargo install --list | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)
+    INSTALLED_VERSION=$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)
 
     echo "dd-rust-license-tool v${TOOL_VERSION} is not installed."
-    if [ -n "$INSTALLED_VERSION" ]; then
+    if [ -n "${INSTALLED_VERSION}" ]; then
         echo "Found installed version: ${INSTALLED_VERSION}"
     fi
     echo ""
@@ -51,23 +48,24 @@ else
     echo "How would you like to proceed?"
     echo "  1) Install dd-rust-license-tool v${TOOL_VERSION} locally and run"
     echo "  2) Use Docker (requires Docker daemon to be running)"
-    if [ -n "$INSTALLED_VERSION" ]; then
+    if [ -n "${INSTALLED_VERSION}" ]; then
         echo "  3) Run with the installed version (${INSTALLED_VERSION})"
         read -rp "Enter 1, 2, or 3: " choice
     else
         read -rp "Enter 1 or 2: " choice
     fi
-    case "$choice" in
+
+    case "${choice}" in
         1)
             echo "Installing dd-rust-license-tool v${TOOL_VERSION}..."
-            eval "$INSTALL_CMD"
+            eval "${INSTALL_CMD}"
             run_native
             ;;
         2)
             run_docker
             ;;
         3)
-            if [ -n "$INSTALLED_VERSION" ]; then
+            if [ -n "${INSTALLED_VERSION}" ]; then
                 run_native
             else
                 echo "Invalid choice. Exiting."
@@ -82,5 +80,5 @@ else
 fi
 
 echo ""
-echo "✅ Successfully generated LICENSE-3rdparty.csv."
+echo "Successfully generated LICENSE-3rdparty.csv."
 echo "Please review and commit the changes."


### PR DESCRIPTION
# What does this PR do?

Updates the tooling for generating third party license files and makes the scripts and workflows align with `libdatadog`.

# Motivation

Needs a newer version for newer `rust` and `cargo` versions.

# Additional Notes

Anything else we should know when reviewing?
