### PR TITLE
fix(datadog-opentelemetry): use workspace's rust-version

### DIFF
--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "datadog-opentelemetry"
 repository = "https://github.com/DataDog/dd-trace-rs/tree/main/datadog-opentelemetry"
 description = "A Datadog layer of compatibility for the opentelemetry SDK"
-# rust-version.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 version.workspace = true
 license.workspace = true


### PR DESCRIPTION
# What does this PR do?

