### PR TITLE
chore(msrv)!: update to rust 1.87 [APMSP-3034]

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ["1.84.1", "stable", "nightly-2026-04-07"]
+        rust_version: ["1.87.0", "stable", "nightly-2026-04-07"]
         platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           # shellcheck disable=SC2046
-          cargo hack --each-feature clippy -- -D warnings $([ ${{ matrix.rust_version }} = 1.84.1 ] || [ ${{ matrix.rust_version }} = stable ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
+          cargo hack --each-feature clippy -- -D warnings $([ ${{ matrix.rust_version }} = 1.87.0 ] || [ ${{ matrix.rust_version }} = stable ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
   instrumentation-clippy:
     name: "clippy #instrumentation ${{ matrix.rust_version }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+'
 env:
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.87.0
 
 jobs:
   publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
       - cron:  '00 03 * * *'
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.87.0
 
 jobs:
   test:
@@ -165,7 +165,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@173e2937029d6526610c4e050211993cef5b8be9  # main
     permissions:
       contents: read
       id-token: write
@@ -174,5 +174,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 23941ab6de4122b7d0ca2b0d4aa7818def68a0d5 # main
+      ref: 173e2937029d6526610c4e050211993cef5b8be9 # main
       push_to_test_optimization: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ options.
 
 ## Rust Toolchain
 
-- **MSRV**: 1.84.1 (set via `rust-version` in `Cargo.toml`)
+- **MSRV**: 1.87.0 (set via `rust-version` in `Cargo.toml`)
 - **Formatting**: pinned `nightly-2026-04-07` toolchain
 
 Install the required toolchains and components:
@@ -25,8 +25,8 @@ Install the required toolchains and components:
 rustup install nightly-2026-04-07
 rustup component add rustfmt --toolchain nightly-2026-04-07
 rustup component add clippy --toolchain nightly-2026-04-07
-rustup install 1.84.1
-rustup component add clippy --toolchain 1.84.1
+rustup install 1.87.0
+rustup component add clippy --toolchain 1.87.0
 ```
 
 ## Formatting and Linting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.84.1"
+rust-version = "1.87.0"
 edition = "2021"
 version = "0.3.3"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ datadog_opentelemetry::tracing()
 
 ## Support
 
-* MSRV: 1.84
+* MSRV: 1.87
 
 * [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) version: 0.31
 * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -219,7 +219,7 @@
 //!
 //! ## Support
 //!
-//! * MSRV: 1.84
+//! * MSRV: 1.87
 //!
 //! * [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) version: 0.31
 //! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -1,7 +1,7 @@
 # Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.84-slim
+FROM rust:1.87-slim
 
 # Keep in sync with: scripts/update_license_3rdparty.sh (TOOL_VERSION) and .github/workflows/lint.yaml (cache key + install step)
 ARG TOOL_VERSION=1.0.6


### PR DESCRIPTION
# What does this PR do?

Bump MSRV from 1.84.1 to 1.87.0.

# Motivation

Upstream dependencies in `libdatadog` now require at least `edition2024`

# Additional Notes

Anything else we should know when reviewing?
