### PR TITLE
fix(ci): prevent shell expansion of publish tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,5 +31,6 @@ jobs:
         shell: bash
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          PUBLISH_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          ./scripts/publish-crate.sh --token "${CRATES_IO_TOKEN}" "${{ steps.tag.outputs.tag }}"
+          ./scripts/publish-crate.sh --token "${CRATES_IO_TOKEN}" "${PUBLISH_TAG}"


### PR DESCRIPTION
### Motivation
- Prevent command-injection via Git tag names in the `publish` workflow which could trigger shell command substitution and potentially exfiltrate the `CRATES_IO_TOKEN` secret.

### Description
- Update `.github/workflows/publish.yaml` to store `steps.tag.outputs.tag` in an environment variable `PUBLISH_TAG` and pass it to `./scripts/publish-crate.sh` as `"${PUBLISH_TAG}"` instead of interpolating the GitHub expression directly in the `run` block.

### Testing
- No automated tests were run for this minimal workflow-only change; the edit is limited to ` .github/workflows/publish.yaml` and does not change runtime release logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdfe85695c8322b9549ff48194acba)