### PR TITLE
fix(cargo): include resolver config in .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+[resolver]
+incompatible-rust-versions = "fallback"


### PR DESCRIPTION
# What does this PR do?

Change the cargo resolver behavior

It controls what happens when a dependency's latest version declares a rust-version higher than your workspace's MSRV.

Two modes:
  - "allow" (default): Cargo always picks the newest semver-compatible version, even if it requires a newer compiler than your MSRV. Build then fails with a confusing compiler error.
  - "fallback" (what's set here): Cargo prefers the newest version whose declared rust-version is ≤ your workspace MSRV. It falls back to an older release of that crate rather than picking one you can't compile.

# Motivation

`libdd-trace-utils` depends on `httpmock@^0.8.0-alpha.1`, and the latest `httpmock@0.8.3` version raised MSRV to 1.88. 
`cargo update` pulls 0.8.3 version breaking the build (of the tests) because the tracer's MSRV is 1.87.0 