### PR TITLE
chore: bump libdd-data-pipeline 3.0.0 -> 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,11 +467,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libc",
+ "libdd-capabilities-impl",
  "libdd-common 3.0.2",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-telemetry",
+ "libdd-telemetry 4.0.0",
  "libdd-tinybytes",
  "libdd-trace-utils",
  "log",
@@ -568,6 +575,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -707,8 +725,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1210,6 +1230,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdd-capabilities"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ce42b411956272ea0ff851dddbd8ea4dae251192ffdbc50e90e20737ffd600"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a6210d654b578a52ac4abe31f94b88f52740c8f2a62adc969cad240eae319d"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body-util",
+ "libdd-capabilities",
+ "libdd-common 4.1.0",
+ "tokio",
+]
+
+[[package]]
 name = "libdd-common"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,22 +1323,27 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "3.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358411451d99011f13c7628acee25dc144f2bbeade87acf10fa7d5ffce1053dc"
+checksum = "1f03752a6f29378a786c6d28121549e1e36dcb48fa2abc760504cdd0e126d83f"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bytes",
  "either",
+ "getrandom 0.2.17",
  "http",
  "http-body-util",
- "libdd-common 3.0.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
- "libdd-telemetry",
+ "libdd-shared-runtime",
+ "libdd-telemetry 5.0.0",
  "libdd-tinybytes",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1316,14 +1367,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8eca39d1e2ef6267cf77fc51eb7ebc7d4f44827e150b4d317c29d8c33bf87"
+checksum = "8f79afd4a3f84f80f6b631e4446d09131c156f1179295e390e9b4dc2bfa527cf"
 dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 3.0.2",
+ "libdd-common 4.1.0",
  "serde",
  "tracing",
 ]
@@ -1359,6 +1410,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-shared-runtime"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9c295f7b55ec78e261537627a75be4e926a94e2b0014e98392b3f98e1957aa"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "libdd-telemetry"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,10 +1453,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-tinybytes"
-version = "1.1.0"
+name = "libdd-telemetry"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47838e12ae2665250b4cdba4e3119230b79e3c522bb9f48dd0c87346f5a8f44"
+checksum = "1662c33b446eed81b610b5d567ddb9c45c5b7587c6c23c5f5545a98b451cc0ba"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "hashbrown 0.15.5",
+ "http",
+ "http-body-util",
+ "libc",
+ "libdd-common 4.1.0",
+ "libdd-ddsketch",
+ "libdd-shared-runtime",
+ "serde",
+ "serde_json",
+ "sys-info",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "winver",
+]
+
+[[package]]
+name = "libdd-tinybytes"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97db80e3f3f9d19643ac444d6267951a5dab622ad9828c51149d49150625cfe8"
 dependencies = [
  "serde",
 ]
@@ -1399,7 +1496,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
+]
+
+[[package]]
+name = "libdd-trace-obfuscation"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2feb45760f019fb70338b35e1341605b078c2e56a55e8fdbe3e66f256ad60d"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 4.1.0",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1415,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1809242895edc53ac51a21287829f42474e749dbc222ea7f414cb3f0d1f91d4e"
+checksum = "c67e3e9a09dab3f19d4f79006f3efb8b4bf8416551465edaeeb71816949e2197"
 dependencies = [
  "prost",
  "serde",
@@ -1426,37 +1540,55 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "2.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
+checksum = "4313c4ce9cd9ea55b46c980164fc41569909c8c2bb6e0320ad1237194bd25a58"
 dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
  "hashbrown 0.15.5",
+ "http",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-ddsketch",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-shared-runtime",
+ "libdd-trace-obfuscation",
+ "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870506e9bb79c93ce5bbfe9d715c53c7ea393a177c7299f0bf43745c0adea0c7"
+checksum = "166fa5c3998dbaa5412156289e8fb24fee35d9aaf2a4707a17c34e956b20b505"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bytes",
  "cargo-platform",
  "cargo_metadata",
  "futures",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
  "httpmock",
  "hyper",
  "indexmap",
- "libdd-common 3.0.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
  "prost",
  "rand 0.8.6",
  "rmp",
@@ -2034,6 +2166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2487,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
  "libdd-shared-runtime",
  "libdd-telemetry",
  "libdd-tinybytes",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1350,18 +1350,18 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33082726b20ce7cf364032f3f600f3c24db25928dcde5368f8e25e194c2bf47"
+checksum = "726e95f0f543da854a24999b16601afd2ca2c6b0c1bdc511bf52c5cd0635f7ad"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 2.0.0",
+ "libc",
+ "libdd-trace-protobuf",
  "memfd",
  "prost",
  "rand 0.8.6",
  "rmp",
  "rmp-serde",
- "rustix",
  "serde",
  "serde_yaml",
 ]
@@ -1440,7 +1440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
 ]
 
 [[package]]
@@ -1452,23 +1452,12 @@ dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-utils",
  "log",
  "percent-encoding",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
-dependencies = [
- "prost",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -1499,7 +1488,7 @@ dependencies = [
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-utils",
  "rmp-serde",
  "serde",
@@ -1532,7 +1521,7 @@ dependencies = [
  "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "prost",
  "rand 0.8.6",
  "rmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,11 +468,11 @@ dependencies = [
  "hyper-util",
  "libc",
  "libdd-capabilities-impl",
- "libdd-common 3.0.2",
+ "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-telemetry 4.0.0",
+ "libdd-telemetry",
  "libdd-tinybytes",
  "libdd-trace-utils",
  "log",
@@ -1251,39 +1251,8 @@ dependencies = [
  "http",
  "http-body-util",
  "libdd-capabilities",
- "libdd-common 4.1.0",
+ "libdd-common",
  "tokio",
-]
-
-[[package]]
-name = "libdd-common"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c779949577250487179d904508f18750070e9a01eb58dce378409ec5fa066f3b"
-dependencies = [
- "anyhow",
- "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "libc",
- "nix",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tower-service",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1337,11 +1306,11 @@ dependencies = [
  "http-body-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-shared-runtime",
- "libdd-telemetry 5.0.0",
+ "libdd-telemetry",
  "libdd-tinybytes",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats",
@@ -1374,7 +1343,7 @@ dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 4.1.0",
+ "libdd-common",
  "serde",
  "tracing",
 ]
@@ -1403,7 +1372,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae8728d9d717eb1b648223c4c1da53f77627fecd6045027ccb758a72815b300"
 dependencies = [
- "libdd-common 4.1.0",
+ "libdd-common",
  "lru",
  "serde",
  "serde_json",
@@ -1420,36 +1389,11 @@ dependencies = [
  "futures-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "tokio",
  "tokio-util",
  "tracing",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libdd-telemetry"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78774ffce79da677602829d7fe27468283e5349010e974257233edf4cd12b783"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "futures",
- "hashbrown 0.15.5",
- "http",
- "http-body-util",
- "libc",
- "libdd-common 3.0.2",
- "libdd-ddsketch",
- "serde",
- "serde_json",
- "sys-info",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "winver",
 ]
 
 [[package]]
@@ -1467,7 +1411,7 @@ dependencies = [
  "http",
  "http-body-util",
  "libc",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "serde",
@@ -1507,7 +1451,7 @@ checksum = "6b2feb45760f019fb70338b35e1341605b078c2e56a55e8fdbe3e66f256ad60d"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils",
  "log",
@@ -1551,7 +1495,7 @@ dependencies = [
  "http",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
@@ -1585,7 +1529,7 @@ dependencies = [
  "indexmap",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
  "libdd-trace-protobuf 3.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libdd-capabilities-impl = { version = "2.0.0", default-features = false }
 libdd-telemetry = { version = "5.0.0", default-features = false }
 libdd-common = { version = "4.1.0", default-features = false }
 libdd-tinybytes = { version = "1.1.1", default-features = false }
-libdd-library-config = { version = "1.1.0", default-features = false }
+libdd-library-config = { version = "2.0.0", default-features = false }
 libdd-sampling = { version = "1.0.0", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", features = [
     "trace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ libdd-data-pipeline = { version = "5.0.0",  features = [
 ], default-features = false }
 libdd-trace-utils = { version = "5.0.0", default-features = false }
 libdd-capabilities-impl = { version = "2.0.0", default-features = false }
-libdd-telemetry = { version = "4.0.0", default-features = false }
-libdd-common = { version = "3.0.1", default-features = false }
-libdd-tinybytes = { version = "1.1.0", default-features = false }
+libdd-telemetry = { version = "5.0.0", default-features = false }
+libdd-common = { version = "4.1.0", default-features = false }
+libdd-tinybytes = { version = "1.1.1", default-features = false }
 libdd-library-config = { version = "1.1.0", default-features = false }
 libdd-sampling = { version = "1.0.0", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 
 [workspace.dependencies]
 # Libdatadog dependencies - change to a stable version once we release
-libdd-data-pipeline = { version = "5.0.0",  features = [
+libdd-data-pipeline = { version = "5.0.0", features = [
     "telemetry",
 ], default-features = false }
 libdd-trace-utils = { version = "5.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,11 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 
 [workspace.dependencies]
 # Libdatadog dependencies - change to a stable version once we release
-libdd-data-pipeline = { version = "3.0.1", default-features = false }
-libdd-trace-utils = { version = "3.0.0", default-features = false }
+libdd-data-pipeline = { version = "5.0.0",  features = [
+    "telemetry",
+], default-features = false }
+libdd-trace-utils = { version = "5.0.0", default-features = false }
+libdd-capabilities-impl = { version = "2.0.0", default-features = false }
 libdd-telemetry = { version = "4.0.0", default-features = false }
 libdd-common = { version = "3.0.1", default-features = false }
 libdd-tinybytes = { version = "1.1.0", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -15,6 +15,7 @@ base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Ma
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+borrow-or-share,https://github.com/yescallop/borrow-or-share,MIT-0,Scallop Ye <yescallop@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 byteorder,https://github.com/BurntSushi/byteorder,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
@@ -55,6 +56,7 @@ errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <
 event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>"
 event-listener-strategy,https://github.com/smol-rs/event-listener-strategy,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
 find-msvc-tools,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,The find-msvc-tools Authors
+fluent-uri,https://github.com/yescallop/fluent-uri-rs,MIT,Scallop Ye <yescallop@gmail.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
 form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
@@ -110,15 +112,19 @@ konst_macro_rules,https://github.com/rodrimati1992/konst,Zlib,rodrimati1992 <rod
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-capabilities,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities,Apache-2.0,The libdd-capabilities Authors
+libdd-capabilities-impl,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl,Apache-2.0,The libdd-capabilities-impl Authors
 libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apache-2.0,The libdd-common Authors
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
 libdd-dogstatsd-client,https://github.com/DataDog/libdatadog/tree/main/libdd-dogstatsd-client,Apache-2.0,The libdd-dogstatsd-client Authors
 libdd-library-config,https://github.com/DataDog/libdatadog/tree/main/libdd-library-config,Apache-2.0,The libdd-library-config Authors
 libdd-sampling,https://github.com/DataDog/libdatadog/tree/main/libdd-sampling,Apache-2.0,Datadog Inc. <info@datadoghq.com>
+libdd-shared-runtime,https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime,Apache-2.0,The libdd-shared-runtime Authors
 libdd-telemetry,https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry,Apache-2.0,The libdd-telemetry Authors
 libdd-tinybytes,https://github.com/DataDog/libdatadog/tree/main/libdd-tinybytes,Apache-2.0,The libdd-tinybytes Authors
 libdd-trace-normalization,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-normalization,Apache-2.0,David Lee <david.lee@datadoghq.com>
+libdd-trace-obfuscation,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-obfuscation,Apache-2.0,Datadog Inc. <info@datadoghq.com>
 libdd-trace-protobuf,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-protobuf,Apache-2.0,The libdd-trace-protobuf Authors
 libdd-trace-stats,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-stats,Apache-2.0,The libdd-trace-stats Authors
 libdd-trace-utils,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-utils,Apache-2.0,The libdd-trace-utils Authors
@@ -173,6 +179,8 @@ rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Pr
 rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
 rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ref-cast-impl,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -59,6 +59,7 @@ criterion = { version = "0.5.1", optional = true }
 
 # Libdatadog dependencies
 libdd-data-pipeline = { workspace = true }
+libdd-capabilities-impl = { workspace = true }
 libdd-trace-utils = { workspace = true }
 libdd-telemetry = { workspace = true }
 libdd-common = { workspace = true }

--- a/datadog-opentelemetry/src/exporter/mod.rs
+++ b/datadog-opentelemetry/src/exporter/mod.rs
@@ -613,7 +613,7 @@ impl<T: Send + 'static> TraceExporterWorker<T> {
             let start = std::time::Instant::now();
             let timeout = Duration::from_secs(5);
             while libdd_data_pipeline::agent_info::get_agent_info().is_none() {
-                if std::time::Instant::now().duration_since(start) > timeout {
+                if start.elapsed() > timeout {
                     panic!("Timeout waiting for agent info to be ready");
                 }
                 thread::sleep(Duration::from_millis(10));

--- a/datadog-opentelemetry/src/exporter/mod.rs
+++ b/datadog-opentelemetry/src/exporter/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use crate::{dd_debug, dd_error};
+use libdd_capabilities_impl::NativeCapabilities;
 use libdd_data_pipeline::trace_exporter::{
     agent_response::AgentResponse,
     error::{self as trace_exporter_error, TraceExporterError},
@@ -553,12 +554,12 @@ pub trait Exporter<T> {
     fn trace_chunks(
         &mut self,
         trace_chunks: Vec<TraceChunk<T>>,
-        trace_exporter: &TraceExporter,
+        trace_exporter: &TraceExporter<NativeCapabilities>,
     ) -> Result<AgentResponse, TraceExporterError>;
 }
 
 struct TraceExporterWorker<T> {
-    trace_exporter: TraceExporter,
+    trace_exporter: TraceExporter<NativeCapabilities>,
     rx: Receiver<T>,
     exporter: Box<dyn Exporter<T>>,
     #[allow(clippy::type_complexity)]
@@ -609,9 +610,14 @@ impl<T: Send + 'static> TraceExporterWorker<T> {
         {
             // Wait for the agent info to be fetched to get deterministic output when deciding
             // to drop traces or not
-            self.trace_exporter
-                .wait_agent_info_ready(Duration::from_secs(5))
-                .unwrap();
+            let start = std::time::Instant::now();
+            let timeout = Duration::from_secs(5);
+            while libdd_data_pipeline::agent_info::get_agent_info().is_none() {
+                if std::time::Instant::now().duration_since(start) > timeout {
+                    panic!("Timeout waiting for agent info to be ready");
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
         }
         while let Ok((message, data)) = self.rx.receive(self.config.max_flush_interval) {
             if !data.is_empty() {

--- a/datadog-opentelemetry/src/mappings/transform/mod.rs
+++ b/datadog-opentelemetry/src/mappings/transform/mod.rs
@@ -511,6 +511,12 @@ impl<'a> CowStr<'a> {
     }
 }
 
+impl From<String> for CowStr<'_> {
+    fn from(s: String) -> Self {
+        Self::from_string(s)
+    }
+}
+
 impl std::borrow::Borrow<str> for CowStr<'_> {
     fn borrow(&self) -> &str {
         self.0.as_ref()

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -4,6 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use arc_swap::ArcSwap;
+use libdd_capabilities_impl::NativeCapabilities;
 use libdd_data_pipeline::trace_exporter::{
     agent_response::AgentResponse, error::TraceExporterError, TelemetryConfig, TraceExporter,
     TraceExporterOutputFormat,
@@ -120,7 +121,7 @@ impl Exporter<SpanData> for MapperExporter {
     fn trace_chunks(
         &mut self,
         trace_chunks: Vec<TraceChunk<SpanData>>,
-        trace_exporter: &TraceExporter,
+        trace_exporter: &TraceExporter<NativeCapabilities>,
     ) -> Result<AgentResponse, TraceExporterError> {
         let resource = self.otel_resource.load();
         let trace_chunks = trace_chunks

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
  "libdd-shared-runtime",
  "libdd-telemetry",
  "libdd-tinybytes",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1206,18 +1206,18 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33082726b20ce7cf364032f3f600f3c24db25928dcde5368f8e25e194c2bf47"
+checksum = "726e95f0f543da854a24999b16601afd2ca2c6b0c1bdc511bf52c5cd0635f7ad"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 2.0.0",
+ "libc",
+ "libdd-trace-protobuf",
  "memfd",
  "prost",
  "rand 0.8.6",
  "rmp",
  "rmp-serde",
- "rustix",
  "serde",
  "serde_yaml",
 ]
@@ -1296,7 +1296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
 ]
 
 [[package]]
@@ -1308,23 +1308,12 @@ dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-utils",
  "log",
  "percent-encoding",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
-dependencies = [
- "prost",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -1355,7 +1344,7 @@ dependencies = [
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "libdd-trace-utils",
  "rmp-serde",
  "serde",
@@ -1384,7 +1373,7 @@ dependencies = [
  "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf",
  "prost",
  "rand 0.8.6",
  "rmp",

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -384,11 +384,11 @@ dependencies = [
  "hyper-util",
  "libc",
  "libdd-capabilities-impl",
- "libdd-common 3.0.2",
+ "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-telemetry 4.0.0",
+ "libdd-telemetry",
  "libdd-tinybytes",
  "libdd-trace-utils",
  "lru",
@@ -1107,39 +1107,8 @@ dependencies = [
  "http",
  "http-body-util",
  "libdd-capabilities",
- "libdd-common 4.1.0",
+ "libdd-common",
  "tokio",
-]
-
-[[package]]
-name = "libdd-common"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c779949577250487179d904508f18750070e9a01eb58dce378409ec5fa066f3b"
-dependencies = [
- "anyhow",
- "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "libc",
- "nix",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tower-service",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1193,11 +1162,11 @@ dependencies = [
  "http-body-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-shared-runtime",
- "libdd-telemetry 5.0.0",
+ "libdd-telemetry",
  "libdd-tinybytes",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats",
@@ -1230,7 +1199,7 @@ dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 4.1.0",
+ "libdd-common",
  "serde",
  "tracing",
 ]
@@ -1259,7 +1228,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae8728d9d717eb1b648223c4c1da53f77627fecd6045027ccb758a72815b300"
 dependencies = [
- "libdd-common 4.1.0",
+ "libdd-common",
  "lru",
  "serde",
  "serde_json",
@@ -1276,36 +1245,11 @@ dependencies = [
  "futures-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "tokio",
  "tokio-util",
  "tracing",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libdd-telemetry"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78774ffce79da677602829d7fe27468283e5349010e974257233edf4cd12b783"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "futures",
- "hashbrown 0.15.5",
- "http",
- "http-body-util",
- "libc",
- "libdd-common 3.0.2",
- "libdd-ddsketch",
- "serde",
- "serde_json",
- "sys-info",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "winver",
 ]
 
 [[package]]
@@ -1323,7 +1267,7 @@ dependencies = [
  "http",
  "http-body-util",
  "libc",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "serde",
@@ -1363,7 +1307,7 @@ checksum = "6b2feb45760f019fb70338b35e1341605b078c2e56a55e8fdbe3e66f256ad60d"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils",
  "log",
@@ -1407,7 +1351,7 @@ dependencies = [
  "http",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
@@ -1437,7 +1381,7 @@ dependencies = [
  "indexmap",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.1.0",
+ "libdd-common",
  "libdd-tinybytes",
  "libdd-trace-normalization",
  "libdd-trace-protobuf 3.0.2",

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -117,6 +117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,11 +383,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libc",
+ "libdd-capabilities-impl",
  "libdd-common 3.0.2",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-telemetry",
+ "libdd-telemetry 4.0.0",
  "libdd-tinybytes",
  "libdd-trace-utils",
  "lru",
@@ -449,6 +456,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -582,8 +600,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1066,6 +1086,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdd-capabilities"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ce42b411956272ea0ff851dddbd8ea4dae251192ffdbc50e90e20737ffd600"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a6210d654b578a52ac4abe31f94b88f52740c8f2a62adc969cad240eae319d"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body-util",
+ "libdd-capabilities",
+ "libdd-common 4.1.0",
+ "tokio",
+]
+
+[[package]]
 name = "libdd-common"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,20 +1179,25 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "3.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358411451d99011f13c7628acee25dc144f2bbeade87acf10fa7d5ffce1053dc"
+checksum = "1f03752a6f29378a786c6d28121549e1e36dcb48fa2abc760504cdd0e126d83f"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bytes",
  "either",
+ "getrandom 0.2.17",
  "http",
  "http-body-util",
- "libdd-common 3.0.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
- "libdd-telemetry",
+ "libdd-shared-runtime",
+ "libdd-telemetry 5.0.0",
  "libdd-tinybytes",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats",
@@ -1172,14 +1223,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8eca39d1e2ef6267cf77fc51eb7ebc7d4f44827e150b4d317c29d8c33bf87"
+checksum = "8f79afd4a3f84f80f6b631e4446d09131c156f1179295e390e9b4dc2bfa527cf"
 dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 3.0.2",
+ "libdd-common 4.1.0",
  "serde",
  "tracing",
 ]
@@ -1215,6 +1266,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-shared-runtime"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9c295f7b55ec78e261537627a75be4e926a94e2b0014e98392b3f98e1957aa"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "libdd-telemetry"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1298,34 @@ dependencies = [
  "libc",
  "libdd-common 3.0.2",
  "libdd-ddsketch",
+ "serde",
+ "serde_json",
+ "sys-info",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "winver",
+]
+
+[[package]]
+name = "libdd-telemetry"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1662c33b446eed81b610b5d567ddb9c45c5b7587c6c23c5f5545a98b451cc0ba"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "hashbrown 0.15.5",
+ "http",
+ "http-body-util",
+ "libc",
+ "libdd-common 4.1.0",
+ "libdd-ddsketch",
+ "libdd-shared-runtime",
  "serde",
  "serde_json",
  "sys-info",
@@ -1259,6 +1356,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-trace-obfuscation"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2feb45760f019fb70338b35e1341605b078c2e56a55e8fdbe3e66f256ad60d"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 4.1.0",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "libdd-trace-protobuf"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,30 +1396,48 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "2.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
+checksum = "4313c4ce9cd9ea55b46c980164fc41569909c8c2bb6e0320ad1237194bd25a58"
 dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
  "hashbrown 0.15.5",
+ "http",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-ddsketch",
+ "libdd-shared-runtime",
+ "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870506e9bb79c93ce5bbfe9d715c53c7ea393a177c7299f0bf43745c0adea0c7"
+checksum = "166fa5c3998dbaa5412156289e8fb24fee35d9aaf2a4707a17c34e956b20b505"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
  "indexmap",
- "libdd-common 3.0.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.1.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
  "libdd-trace-protobuf 3.0.2",
@@ -1722,6 +1854,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2161,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",


### PR DESCRIPTION
# What does this PR do?
Update `libdd-data-pipeline` to its latest version and fix breakings.

# Motivation
[Another PR](https://github.com/DataDog/dd-trace-rs/pull/225) will follow this one to expose a new parameter for testing.

# Additional Notes
- Had to inline `wait_agent_info_ready()` because it's now async