### PR TITLE
feat(ci): add stable entry point for system-test source packaging [APMSP-3376]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,8 +154,10 @@ jobs:
     steps:
       - name: Checkout dd-trace-rs
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Pack dd-trace-rs
-        run: mkdir -p ./binaries/dd-trace-rs && cp -r datadog-opentelemetry Cargo.toml ./binaries/dd-trace-rs/
+      - name: Pack workspace source for system tests
+        # Reads [workspace] members from Cargo.toml and copies root dirs.
+        # New workspace crates are picked up automatically.
+        run: ./scripts/pack-system-tests-artifact.sh ./binaries/dd-trace-rs
       - name: Upload artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -19,7 +19,8 @@ dd-trace-rs/
 │   └── examples/
 │       ├── propagator/          # HTTP server example
 │       └── simple_tracing/      # Minimal tracing example
-├── scripts/                     # Release and license automation
+├── scripts/                     # Release, license, and build automation
+│   └── pack-system-tests-artifact.sh  # Stable entry point for system-test builds
 ├── docs/                        # Architecture documentation
 ├── .config/                     # Tool config (commitlint, nextest profiles)
 └── .github/                     # CI workflows and issue templates
@@ -35,6 +36,28 @@ are always public.
 - `logs-grpc` / `logs-http` — OTLP transport for logs (default: grpc)
 - `test-utils` — exposes internal helpers and pulls in test dependencies; never enable in production
   builds
+
+## System-test build entry point
+
+`scripts/pack-system-tests-artifact.sh` is the stable entry point for packaging workspace source
+for [DataDog/system-tests](https://github.com/DataDog/system-tests).
+
+System tests build `ddtrace-rs-client` inside Docker against a local copy of `datadog-opentelemetry`
+(path dependency, not a published crate). The script reads `[workspace] members` from `Cargo.toml`,
+expands any glob patterns, deduplicates nested paths, and copies the unique root directories along
+with the workspace-level files Cargo needs. New workspace crates are picked up automatically.
+
+```text
+# Pack source into ./binaries/dd-trace-rs (default)
+./scripts/pack-system-tests-artifact.sh
+
+# Specify a custom output directory
+./scripts/pack-system-tests-artifact.sh /path/to/output
+```
+
+CI runs this in the `build-artifacts` job and uploads the result as the `system_tests_binaries`
+artifact. The system-test Dockerfile copies the source into the container and compiles
+`ddtrace-rs-client` against it.
 
 ## datadog-opentelemetry
 

--- a/scripts/pack-system-tests-artifact.sh
+++ b/scripts/pack-system-tests-artifact.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pack [workspace] members → OUTPUT_DIR for system tests.
+# Stable entry point: reads members from Cargo.toml, copies root dirs.
+#
+# Usage: ./scripts/pack-system-tests-artifact.sh [OUTPUT_DIR]
+#   OUTPUT_DIR  defaults to ./binaries/dd-trace-rs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUTPUT_DIR="${1:-${REPO_ROOT}/binaries/dd-trace-rs}"
+
+cd "${REPO_ROOT}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# Read [workspace] members from Cargo.toml.
+# Glob patterns expanded; nested paths deduplicated — only unique root dirs
+# need to be copied (a root copy already includes nested members).
+# tomllib = Python stdlib (3.11+), no extra deps.
+mapfile -t ROOTS < <(python3 - <<'EOF'
+import glob, tomllib
+with open("Cargo.toml", "rb") as f:
+    patterns = tomllib.load(f)["workspace"]["members"]
+members = [p for pat in patterns for p in (sorted(glob.glob(pat)) or [pat])]
+# Drop member if another member is a strict path prefix of it.
+for m in members:
+    if not any(m.startswith(o + "/") for o in members if o != m):
+        print(m)
+EOF
+)
+
+for root in "${ROOTS[@]}"; do
+    # Ensure parent dir exists for multi-segment paths.
+    mkdir -p "${OUTPUT_DIR}/$(dirname "${root}")"
+    cp -r "${root}" "${OUTPUT_DIR}/${root}"
+done
+
+# Workspace-level files.
+cp Cargo.toml Cargo.lock "${OUTPUT_DIR}/"
+mkdir -p "${OUTPUT_DIR}/.cargo"
+cp .cargo/config.toml "${OUTPUT_DIR}/.cargo/config.toml"
+
+echo "packed ${#ROOTS[@]} workspace roots → ${OUTPUT_DIR}"
+ls -lA "${OUTPUT_DIR}"


### PR DESCRIPTION
# What does this PR do?

Add scripts/pack-system-tests-artifact.sh to replace the hardcoded `cp -r datadog-opentelemetry Cargo.toml` in the build-artifacts CI job.

The script reads [workspace] members from Cargo.toml, deduplicates nested paths, and copies the unique root directories. New workspace crates are included automatically.

# Motivation

The old approach broke when a new crate was added at the workspace root: Cargo.toml listed it as a member but its source was absent from the artifact, causing the system-test Docker build to fail.

# Additional Notes

Nope
