### PR TITLE
refactor(rc): drop in-tracer RC tags normalization shim [stacked on #227]

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/remote_config.rs
+++ b/datadog-opentelemetry/src/core/configuration/remote_config.rs
@@ -193,53 +193,6 @@ where
     Ok(Some(serde_json::Value::deserialize(deserializer)?))
 }
 
-/// Normalizes the `tags` field on each sampling rule from the RC wire shape
-/// (list of `{key, value_glob}` objects) into the shape `libdd-sampling`'s
-/// `SamplingRuleConfig` accepts (a `{key: value}` map). Map-shape tags are
-/// left untouched. Rules without `tags`, or with `tags` of an unexpected
-/// type, are left untouched (libdatadog's parse will reject if necessary).
-///
-/// If any list entry is malformed (missing `key`/`value_glob`, or non-string
-/// values), the rule's tags are left in their original (list) shape. This
-/// fails closed: libdatadog will reject the list-shape parse, the RC update
-/// is dropped, and the agent is informed via apply_state=3. We deliberately
-/// do not drop bad entries silently — doing so could broaden a tag-constrained
-/// rule into a less-constrained (or fully wildcard) rule.
-fn normalize_rc_tags(rules: &mut [serde_json::Value]) {
-    for rule in rules {
-        let Some(obj) = rule.as_object_mut() else {
-            continue;
-        };
-        let Some(tags) = obj.get("tags") else {
-            continue;
-        };
-        let serde_json::Value::Array(entries) = tags else {
-            // Map-shape (or null/etc.) — leave it for libdatadog to handle.
-            continue;
-        };
-        let mut map = serde_json::Map::with_capacity(entries.len());
-        let mut all_ok = true;
-        for entry in entries {
-            let (Some(key), Some(value)) = (
-                entry.get("key").and_then(|v| v.as_str()),
-                entry.get("value_glob").and_then(|v| v.as_str()),
-            ) else {
-                all_ok = false;
-                break;
-            };
-            map.insert(
-                key.to_string(),
-                serde_json::Value::String(value.to_string()),
-            );
-        }
-        if all_ok {
-            obj.insert("tags".to_string(), serde_json::Value::Object(map));
-        }
-        // else: leave the original list-shape tags in place; libdatadog's
-        // parse will reject and the RC update is rejected as a whole.
-    }
-}
-
 /// Configuration payload for APM tracing
 /// Based on the apm-tracing.json schema from dd-go
 /// See: https://github.com/DataDog/dd-go/blob/prod/remote-config/apps/rc-schema-validation/schemas/apm-tracing.json
@@ -920,9 +873,6 @@ impl ProductHandler for ApmTracingHandler {
                     }
                     None => Vec::new(),
                 };
-
-                // Normalize RC list-shape tags into the map shape libdd-sampling accepts.
-                normalize_rc_tags(&mut rules);
 
                 // Multi-source precedence:
                 // - If RC delivered explicit rules, env rules are replaced.
@@ -2446,8 +2396,16 @@ mod tests {
 
     #[test]
     fn test_handler_rc_rules_with_list_tags_applied() {
-        // Bug B regression guard: RC sends tags as list-of-objects; the handler
-        // must normalize to a map before passing to libdatadog.
+        // MERGE INTERLOCK — this test is intentionally RED on the current
+        // libdd-sampling and is the gate for this stacked PR. RC sends tags as a
+        // list-of-objects ([{key, value_glob}]); libdd-sampling must accept that
+        // wire shape directly now that the in-tracer normalization shim is removed.
+        // It fails today with "invalid type: sequence, expected a map". Do NOT merge
+        // this PR until the workspace libdd-sampling dependency is bumped to a
+        // release that parses list-shape tags natively — that bump turns this green.
+        // Leaving it red (rather than #[ignore]) is deliberate: it prevents merging
+        // the shim removal before the parser supports the wire shape, which would
+        // regress RC tag-qualified sampling in production.
         let config = build_config_for_handler();
         let payload = br#"{
             "id": "rc-list-tags",
@@ -2474,60 +2432,6 @@ mod tests {
             rules[0].tags.get("region").map(String::as_str),
             Some("us-east-1")
         );
-    }
-
-    #[test]
-    fn test_normalize_rc_tags_passes_through_map_shape() {
-        // Map-shape tags must be left untouched.
-        let mut rules: Vec<serde_json::Value> = vec![
-            serde_json::json!({"sample_rate": 0.5, "service": "svc", "tags": {"env": "prod"}}),
-        ];
-        normalize_rc_tags(&mut rules);
-        assert_eq!(
-            serde_json::Value::Array(rules),
-            serde_json::json!([
-                {"sample_rate": 0.5, "service": "svc", "tags": {"env": "prod"}}
-            ])
-        );
-    }
-
-    #[test]
-    fn test_normalize_rc_tags_converts_list_shape() {
-        let mut rules: Vec<serde_json::Value> = vec![serde_json::json!({
-            "sample_rate": 0.5,
-            "tags": [
-                {"key": "env", "value_glob": "prod"},
-                {"key": "region", "value_glob": "us-east-1"}
-            ]
-        })];
-        normalize_rc_tags(&mut rules);
-        let tags = rules[0]["tags"]
-            .as_object()
-            .expect("tags should be an object after normalization");
-        assert_eq!(tags.get("env").and_then(|v| v.as_str()), Some("prod"));
-        assert_eq!(
-            tags.get("region").and_then(|v| v.as_str()),
-            Some("us-east-1")
-        );
-    }
-
-    #[test]
-    fn test_normalize_rc_tags_leaves_malformed_list_untouched() {
-        // If any list entry is malformed (missing key/value_glob), the rule's
-        // tags are left in their original list shape — libdatadog's parse will
-        // then reject the update as a whole. We must not drop bad entries
-        // silently, which could broaden a tag-constrained rule.
-        let original = serde_json::json!({
-            "sample_rate": 0.5,
-            "tags": [
-                {"key": "env", "value_glob": "prod"},
-                {"key": "region"}
-            ]
-        });
-        let mut rules: Vec<serde_json::Value> = vec![original.clone()];
-        normalize_rc_tags(&mut rules);
-        // Tags remain in the original (rejected) list shape.
-        assert_eq!(rules[0], original);
     }
 
     #[test]


### PR DESCRIPTION
> 🚧 **DO NOT MERGE YET — intentionally premature, stacked on #227.**
> CI is **expected RED** until the workspace `libdd-sampling` dependency is bumped to a release that parses RC list-shape tags natively. See "Merge gate" below.

# What does this PR do?

Deletes `normalize_rc_tags` from `datadog-opentelemetry/src/core/configuration/remote_config.rs` — the temporary shim added in #227 that converts Remote Config's list-shape sampling-rule tags (`[{"key": "...", "value_glob": "..."}]`) into the map shape (`{"key": "value"}`) that `libdd-sampling`'s `SamplingRuleConfig` deserializer currently requires.

Also removes the shim's 3 direct unit tests (`test_normalize_rc_tags_*`) and its single call site. Net: **-106 / +10** in one file.

# Motivation

The shim only exists because `libdd-sampling` (currently pinned at `1.0.0`) deserializes rule `tags` as a `{key: value}` map and rejects the RC wire shape. Once a `libdd-sampling` release lands that parses the list shape `[{key, value_glob}]` natively, the in-tracer normalization is dead weight — the RC JSON can flow straight through. This PR stages that cleanup so it's ready to land the moment the dependency supports it.

# Merge gate — read before merging

This change is **only safe once `libdd-sampling` is bumped** to the release with native list-shape tag parsing. Merging the shim removal *alone* regresses production: the tracer would advertise RC sampling support but reject any rule carrying tags (`invalid type: sequence, expected a map`).

The interlock is the kept test **`test_handler_rc_rules_with_list_tags_applied`**:
- It is **RED today** on `libdd-sampling 1.0.0` (verified locally: `invalid type: sequence, expected a map at line 1 column 43`).
- It flips **green** once the workspace `libdd-sampling` is bumped to the release that accepts list-shape tags.
- Left red on purpose (not `#[ignore]`d) so CI cannot go green — and the PR cannot be cleanly merged — until the parser actually supports the wire shape.

**To land this PR:** in this branch (or a precursor), bump `libdd-sampling` (workspace `Cargo.toml` + `Cargo.lock`) to the release with native list-shape support, confirm the gate test goes green, then merge.

# Additional Notes

- **Stacked on #227** (base = `worktree-brian.marks+adaptive-sampling-fixes`). Rebase onto `main` once #227 merges.
- **Kept, with a post-bump caveat:** `test_handler_malformed_tags_rejects_update` still asserts that a rule with a malformed list-shape tag entry (missing `value_glob`) is rejected wholesale. Today that holds because libdd-sampling rejects *all* list-shape tags. Post-bump, the fail-closed invariant (don't silently drop a bad entry and broaden a tag-constrained rule) must be re-validated against the new parser, and that test's comment (which still attributes rejection to the removed shim) should be refreshed by the bump PR.
- **No CHANGELOG entry:** the changelog is release-sectioned with no "Unreleased" heading, and the net user-visible behavior at correct merge time (with the bump) is unchanged — list-tag rules still apply, just parsed by libdd-sampling instead of the shim. If the bump PR warrants a changelog line, add it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)