### PR TITLE
ci: include STS policy to allow reading from gitlab

### DIFF
--- a/.github/chainguard/self.gitlab.github-access.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.github-access.read.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-rs:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: read


### PR DESCRIPTION
# What does this PR do?

Include STS policy to allow reading from gitlab

# Motivation

Benchmarks