### PR TITLE
feat(telemetry): exclude OTLP headers from configuration telemetry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -171,7 +171,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@173e2937029d6526610c4e050211993cef5b8be9  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@f2c6cc393bcd996357259ac991c8a6ba1f59177d  # main
     permissions:
       contents: read
       id-token: write
@@ -180,5 +180,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 173e2937029d6526610c4e050211993cef5b8be9 # main
+      ref: f2c6cc393bcd996357259ac991c8a6ba1f59177d # main
       push_to_test_optimization: true

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -309,6 +309,11 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
         self.source() == ConfigSourceOrigin::Default
     }
 
+    /// Whether this configuration's value is excluded from configuration telemetry.
+    fn is_sensitive(&self) -> bool {
+        self.name.is_sensitive()
+    }
+
     fn build_configurations_list(&self, calculated_value: Option<String>) -> Vec<Configuration> {
         let mut configurations = Vec::new();
         // Always include the default value
@@ -352,7 +357,13 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
 
 impl<T: Clone + ConfigurationValueProvider> ConfigurationProvider for ConfigItem<T> {
     /// Returns all configurations that were set for this configuration item.
+    ///
+    /// Configurations marked sensitive in the registry are excluded from
+    /// configuration telemetry, so this returns an empty list for them.
     fn get_all_configurations(&self) -> Vec<Configuration> {
+        if self.is_sensitive() {
+            return Vec::new();
+        }
         self.build_configurations_list(None)
     }
 }
@@ -488,7 +499,13 @@ impl<T: Clone + ConfigurationValueProvider + Deref> ConfigurationProvider
     for ConfigItemWithOverride<T>
 {
     /// Returns all configurations that were set for this configuration item.
+    ///
+    /// Configurations marked sensitive in the registry are excluded from
+    /// configuration telemetry, so this returns an empty list for them.
     fn get_all_configurations(&self) -> Vec<Configuration> {
+        if self.config_item.is_sensitive() {
+            return Vec::new();
+        }
         // Also add override value if set
         let override_value = self.override_value.load();
         let calculated_option = if self.source() == ConfigSourceOrigin::Calculated {
@@ -3968,5 +3985,115 @@ mod tests {
         let mut ok_builder = Config::builder();
         ok_builder.set_trace_sample_rate(0.3);
         assert_eq!(ok_builder.build().trace_sample_rate(), Some(0.3));
+    }
+
+    /// Collects every configuration entry reported via the telemetry
+    /// configuration list, mirroring the app-started reporting path.
+    fn collect_telemetry_configurations(config: &Config) -> Vec<Configuration> {
+        config
+            .get_telemetry_configuration()
+            .into_iter()
+            .flat_map(|provider| provider.get_all_configurations())
+            .collect()
+    }
+
+    #[test]
+    fn test_sensitive_otlp_headers_excluded_from_telemetry() {
+        const SENTINEL_OTLP_BASE: &str = "dd-api-key=SENTINEL_OTLP_BASE";
+        const SENTINEL_OTLP_METRICS: &str = "dd-api-key=SENTINEL_OTLP_METRICS";
+        const SENTINEL_OTLP_LOGS: &str = "dd-api-key=SENTINEL_OTLP_LOGS";
+
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [
+                // Sensitive configurations, each with a distinct sentinel value.
+                ("OTEL_EXPORTER_OTLP_HEADERS", SENTINEL_OTLP_BASE),
+                ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", SENTINEL_OTLP_METRICS),
+                ("OTEL_EXPORTER_OTLP_LOGS_HEADERS", SENTINEL_OTLP_LOGS),
+                // Non-sensitive exporter configurations that must still be reported.
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
+                ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
+                ("OTEL_EXPORTER_OTLP_TIMEOUT", "5000"),
+            ],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+
+        // The values are still parsed and usable; only their telemetry
+        // reporting is suppressed.
+        assert_eq!(config.otlp_headers(), SENTINEL_OTLP_BASE);
+        assert_eq!(config.otlp_metrics_headers(), SENTINEL_OTLP_METRICS);
+        assert_eq!(config.otlp_logs_headers(), SENTINEL_OTLP_LOGS);
+
+        let configurations = collect_telemetry_configurations(&config);
+
+        // No sentinel value may appear in any reported configuration value.
+        for sentinel in [
+            SENTINEL_OTLP_BASE,
+            SENTINEL_OTLP_METRICS,
+            SENTINEL_OTLP_LOGS,
+        ] {
+            assert!(
+                !configurations.iter().any(|c| c.value.contains(sentinel)),
+                "sentinel value {sentinel:?} must not appear in telemetry configuration"
+            );
+        }
+
+        // Sensitive header configurations are omitted entirely (omit idiom).
+        for name in [
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+            "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        ] {
+            assert!(
+                !configurations.iter().any(|c| c.name == name),
+                "expected {name} to be absent from configuration telemetry"
+            );
+        }
+
+        // Non-sensitive exporter configurations are still reported with their
+        // real values.
+        let value_for = |name: &str| {
+            configurations
+                .iter()
+                .filter(|c| c.name == name)
+                .max_by_key(|c| c.seq_id)
+                .map(|c| c.value.clone())
+        };
+        assert_eq!(
+            value_for("OTEL_EXPORTER_OTLP_ENDPOINT").as_deref(),
+            Some("http://localhost:4318")
+        );
+        assert_eq!(
+            value_for("OTEL_EXPORTER_OTLP_PROTOCOL").as_deref(),
+            Some("http/protobuf")
+        );
+        assert_eq!(
+            value_for("OTEL_EXPORTER_OTLP_TIMEOUT").as_deref(),
+            Some("5000")
+        );
+    }
+
+    #[test]
+    fn test_sensitive_config_item_get_all_configurations_is_empty() {
+        // The reusable mechanism applies at the ConfigItem level: a sensitive
+        // configuration reports no telemetry entries regardless of source.
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("OTEL_EXPORTER_OTLP_HEADERS", "dd-api-key=SENTINEL")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+
+        assert!(
+            config.otlp_headers.get_all_configurations().is_empty(),
+            "sensitive ConfigItem must not report any configuration entries"
+        );
+
+        // A non-sensitive ConfigItem continues to report entries.
+        assert!(
+            !config.otlp_endpoint.get_all_configurations().is_empty(),
+            "non-sensitive ConfigItem should still report configuration entries"
+        );
     }
 }

--- a/datadog-opentelemetry/src/core/configuration/supported_configurations.rs
+++ b/datadog-opentelemetry/src/core/configuration/supported_configurations.rs
@@ -159,6 +159,16 @@ impl SupportedConfigurations {
             _ => false,
         }
     }
+
+    /// Whether this configuration's value is excluded from configuration telemetry.
+    pub fn is_sensitive(&self) -> bool {
+        matches!(
+            self,
+            SupportedConfigurations::OTEL_EXPORTER_OTLP_HEADERS
+                | SupportedConfigurations::OTEL_EXPORTER_OTLP_LOGS_HEADERS
+                | SupportedConfigurations::OTEL_EXPORTER_OTLP_METRICS_HEADERS
+        )
+    }
 }
 
 pub(crate) fn is_alias_deprecated(name: &str) -> bool {

--- a/scripts/local_config_map_generate.py
+++ b/scripts/local_config_map_generate.py
@@ -30,6 +30,7 @@ as_str_block = ""
 aliases_block = []
 alias_deprecated_block = []
 deprecated_block = []
+sensitive_block = []
 for i, key in enumerate(supported_configurations["supportedConfigurations"].keys()):
     if i != 0:
         enum_block += "\n"
@@ -38,6 +39,7 @@ for i, key in enumerate(supported_configurations["supportedConfigurations"].keys
     as_str_block += f"            SupportedConfigurations::{key} => \"{key}\","
     aliases_accumulator = []
     deprecated = False
+    sensitive = False
     for version in supported_configurations["supportedConfigurations"][key]:
         if "aliases" in version:
             for alias in version["aliases"]:
@@ -46,10 +48,14 @@ for i, key in enumerate(supported_configurations["supportedConfigurations"].keys
                     alias_deprecated_block.append(f"\"{alias}\" => true,")
         if "deprecated" in version and version["deprecated"]:
             deprecated_block.append(f"SupportedConfigurations::{key} => true,")
+        if version.get("sensitive"):
+            sensitive = True
+    if sensitive:
+        sensitive_block.append(f"SupportedConfigurations::{key}")
     if len(aliases_accumulator) > 0:
         aliases_str = ', '.join(f'"{a}"' for a in aliases_accumulator)
         aliases_block.append(f"SupportedConfigurations::{key} => &[{aliases_str}],")
-        
+
 
 if len(undocumented_configurations) > 0:
     enum_block += "\n\n    /// Used for testing purposes only"
@@ -68,6 +74,12 @@ for i, key in enumerate(undocumented_configurations):
 aliases_join = "\n            ".join(aliases_block)
 deprecated_join = "\n            ".join(deprecated_block)
 alias_deprecated_join = "\n            ".join(alias_deprecated_block)
+
+if len(sensitive_block) > 0:
+    sensitive_pattern = "\n                | ".join(sensitive_block)
+    sensitive_body = f"matches!(\n            self,\n            {sensitive_pattern}\n        )"
+else:
+    sensitive_body = "false"
 
 result = f"""\
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
@@ -102,6 +114,11 @@ impl SupportedConfigurations {{
             {deprecated_join}
             _ => false,
         }}
+    }}
+
+    /// Whether this configuration's value is excluded from configuration telemetry.
+    pub fn is_sensitive(&self) -> bool {{
+        {sensitive_body}
     }}
 }}
 

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -264,7 +264,8 @@
         "version": "A",
         "type": "map",
         "default": "",
-        "propertyKeys": ["otlp_headers"]
+        "propertyKeys": ["otlp_headers"],
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": [
@@ -280,7 +281,8 @@
         "version": "A",
         "type": "string",
         "default": null,
-        "propertyKeys": ["otlp_logs_headers"]
+        "propertyKeys": ["otlp_logs_headers"],
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": [
@@ -312,7 +314,8 @@
         "version": "A",
         "type": "map",
         "default": null,
-        "propertyKeys": ["otlp_metrics_headers"]
+        "propertyKeys": ["otlp_metrics_headers"],
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": [


### PR DESCRIPTION
# What does this PR do?

Excludes the OTLP exporter header configurations (`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS`, `OTEL_EXPORTER_OTLP_LOGS_HEADERS`) from configuration telemetry. They are marked `sensitive: true` in `supported-configurations.json` and omitted when building configuration telemetry.

# Motivation

These configurations should not be included in configuration telemetry.

# Additional Notes

Unit tests added.
