### PR TITLE
fix(ci): match devflow/merge.* checks in ensure-ci-success ignore pattern

### DIFF
--- a/.github/workflows/all-checks.yaml
+++ b/.github/workflows/all-checks.yaml
@@ -23,5 +23,5 @@ jobs:
           max-retries: 30
           polling-interval-seconds: 30
           ignored-name-patterns: |
-            devflow/merge
+            devflow/merge.*
             parametric.*


### PR DESCRIPTION
# What does this PR do?

Fixes the `ignored-name-patterns` in the `ensure-ci-success` workflow to correctly match the `devflow/mergegate` check.

# Motivation

The existing pattern `devflow/merge` does not match the actual check name `devflow/mergegate` (the action uses regex matching with implicit anchoring). This caused `ensure-ci-success` to block on `devflow/mergegate` — which is always `in_progress` on open PRs — until it exhausted its retries and failed. Every PR in this repo was hitting this failure.

Widening the pattern to `devflow/merge.*` covers `devflow/mergegate` and any future variants.

# Additional Notes

Confirmed by inspecting the logs of [run 27246972457](https://github.com/DataDog/dd-trace-rs/actions/runs/27246972457), which shows:
```
* ⏳ devflow/mergegate is still running (state: in_progress)
❌ Some checks are still running, but we are not retrying anymore.
```