### PR TITLE
feat(propagation): implement B3 multi-header propagator

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -821,12 +821,8 @@ impl FromStr for TracePropagationStyle {
             "datadog" => Ok(TracePropagationStyle::Datadog),
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
-            // `b3multi` and `b3` are added to from_str alongside the b3multi and b3
-            // single-header propagator implementations. Accepting them here while their
-            // extractors are no-ops would regress users who set
-            // DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog with
-            // DD_TRACE_PROPAGATION_EXTRACT_FIRST=true — the no-op b3 propagator would be
-            // picked first and Datadog headers would never be tried.
+            "b3multi" => Ok(TracePropagationStyle::B3Multi),
+            // `b3` is added to from_str alongside the b3 single-header propagator.
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -3076,16 +3072,14 @@ mod tests {
 
     #[test]
     fn test_propagation_style_b3_display() {
-        // `b3multi` and `b3` round-trip via Display now that the variants exist;
-        // FromStr support is added when the respective propagators land.
         assert_eq!(TracePropagationStyle::B3Multi.to_string(), "b3multi");
         assert_eq!(TracePropagationStyle::B3SingleHeader.to_string(), "b3");
     }
 
     #[test]
-    fn test_propagation_style_b3_not_yet_parsed_from_env() {
-        // Until each B3 propagator lands, b3multi/b3 in the env var are dropped
-        // (FromStr returns Err, the env-var deserializer silently filters those).
+    fn test_propagation_style_b3multi_parsed_from_env() {
+        // b3multi parses (it has a working propagator now); b3 is still dropped
+        // until the b3 single-header propagator lands.
         let mut sources = CompositeSource::new();
         sources.add_source(HashMapSource::from_iter(
             [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
@@ -3095,7 +3089,15 @@ mod tests {
 
         assert_eq!(
             config.trace_propagation_style_extract(),
-            Some(vec![TracePropagationStyle::Datadog]).as_deref()
+            Some(vec![
+                TracePropagationStyle::B3Multi,
+                TracePropagationStyle::Datadog
+            ])
+            .as_deref()
+        );
+        assert_eq!(
+            TracePropagationStyle::from_str("B3Multi").unwrap(),
+            TracePropagationStyle::B3Multi
         );
     }
 

--- a/datadog-opentelemetry/src/propagation/b3multi.rs
+++ b/datadog-opentelemetry/src/propagation/b3multi.rs
@@ -1,0 +1,356 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! B3 multi-header trace context propagation.
+//!
+//! Implements the [B3 multiple-header propagation format] used by Zipkin and
+//! compatible tracers. Trace and span ids are exchanged via separate headers,
+//! with sampling expressed through `X-B3-Sampled` (accept/deny) or
+//! `X-B3-Flags` (debug ≡ keep).
+//!
+//! Behavior matches the Python tracer's `_B3MultiHeader` so that traces
+//! propagated through a Datadog-rust process keep the same wire-level
+//! semantics as the other Datadog tracers.
+//!
+//! [B3 multiple-header propagation format]: https://github.com/openzipkin/b3-propagation#multiple-headers
+
+use std::sync::LazyLock;
+
+use crate::core::sampling::{priority, SamplingPriority};
+use crate::dd_warn;
+use crate::propagation::{
+    carrier::{Extractor, Injector},
+    context::{InjectSpanContext, Sampling, SpanContext},
+};
+
+/// B3 trace ID header. Lower-hex, 16 or 32 chars.
+pub const B3_TRACE_ID_KEY: &str = "x-b3-traceid";
+/// B3 span ID header. Lower-hex, 16 chars.
+pub const B3_SPAN_ID_KEY: &str = "x-b3-spanid";
+/// B3 sampled header. `0` = deny, `1` = accept; any other value defers.
+pub const B3_SAMPLED_KEY: &str = "x-b3-sampled";
+/// B3 flags header. `1` = debug (treated as keep with highest priority).
+pub const B3_FLAGS_KEY: &str = "x-b3-flags";
+
+static B3_HEADER_KEYS: LazyLock<[String; 4]> = LazyLock::new(|| {
+    [
+        B3_TRACE_ID_KEY.to_owned(),
+        B3_SPAN_ID_KEY.to_owned(),
+        B3_SAMPLED_KEY.to_owned(),
+        B3_FLAGS_KEY.to_owned(),
+    ]
+});
+
+/// Extract trace context from a carrier using B3 multi-headers.
+///
+/// Returns `None` when the carrier lacks a `x-b3-traceid` header, the trace
+/// id cannot be parsed as a non-zero hex integer, or a present span id
+/// header is malformed. A missing or zero span id is accepted and recorded
+/// as `0`, matching how the Datadog propagator handles missing parent ids.
+pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
+    let trace_id_hex = carrier.get(B3_TRACE_ID_KEY)?;
+    let trace_id = parse_trace_id(trace_id_hex)?;
+
+    let span_id = match carrier.get(B3_SPAN_ID_KEY) {
+        Some(hex) => parse_span_id(hex)?,
+        None => 0,
+    };
+
+    let priority = extract_priority(carrier);
+
+    Some(SpanContext {
+        trace_id,
+        span_id,
+        sampling: Sampling {
+            priority,
+            mechanism: None,
+        },
+        origin: None,
+        tags: std::collections::HashMap::new(),
+        links: Vec::new(),
+        is_remote: true,
+        tracestate: None,
+    })
+}
+
+/// Inject trace context into a carrier using B3 multi-headers.
+pub fn inject(context: &InjectSpanContext, carrier: &mut dyn Injector) {
+    carrier.set(B3_TRACE_ID_KEY, format_b3_trace_id(context.trace_id));
+    carrier.set(B3_SPAN_ID_KEY, format!("{:016x}", context.span_id));
+
+    let Some(priority) = context.sampling.priority else {
+        return;
+    };
+    let p = priority.into_i8();
+    if p <= 0 {
+        carrier.set(B3_SAMPLED_KEY, "0".to_string());
+    } else if p == 1 {
+        carrier.set(B3_SAMPLED_KEY, "1".to_string());
+    } else {
+        carrier.set(B3_FLAGS_KEY, "1".to_string());
+    }
+}
+
+/// Returns the header keys used by B3 multi-header propagation.
+pub fn keys() -> &'static [String] {
+    B3_HEADER_KEYS.as_slice()
+}
+
+fn parse_trace_id(hex: &str) -> Option<u128> {
+    let id = match u128::from_str_radix(hex, 16) {
+        Ok(id) => id,
+        Err(e) => {
+            dd_warn!("Propagator (b3multi): malformed trace_id {hex:?}: {e}");
+            return None;
+        }
+    };
+    if id == 0 {
+        return None;
+    }
+    Some(id)
+}
+
+/// Parses a B3 span id. Returns `None` only on a hex-parse failure; an
+/// explicit `0` value is accepted and returned as `Some(0)` so the caller
+/// can distinguish "malformed" (reject the context) from "zero / no parent"
+/// (accept the context with span_id 0).
+fn parse_span_id(hex: &str) -> Option<u64> {
+    match u64::from_str_radix(hex, 16) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            dd_warn!("Propagator (b3multi): malformed span_id {hex:?}: {e}");
+            None
+        }
+    }
+}
+
+fn extract_priority(carrier: &dyn Extractor) -> Option<SamplingPriority> {
+    // `X-B3-Flags: 1` (debug) always takes precedence per the Python tracer.
+    if carrier.get(B3_FLAGS_KEY) == Some("1") {
+        return Some(priority::USER_KEEP);
+    }
+    match carrier.get(B3_SAMPLED_KEY) {
+        Some("0") => Some(priority::AUTO_REJECT),
+        Some("1") => Some(priority::AUTO_KEEP),
+        _ => None,
+    }
+}
+
+fn format_b3_trace_id(trace_id: u128) -> String {
+    if trace_id > u64::MAX as u128 {
+        format!("{trace_id:032x}")
+    } else {
+        format!("{trace_id:016x}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::core::configuration::{Config, TracePropagationStyle};
+    use crate::core::sampling::priority;
+    use crate::propagation::{context::span_context_to_inject, Propagator};
+
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn extract_missing_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-sampled", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_64_bit_trace_id() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "00f067aa0ba902b7"),
+            ("x-b3-sampled", "1"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_KEEP));
+        assert!(ctx.is_remote);
+    }
+
+    #[test]
+    fn extract_128_bit_trace_id() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7"),
+            ("x-b3-spanid", "e457b5a2e4d86bd1"),
+            ("x-b3-sampled", "0"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128);
+        assert_eq!(ctx.span_id, 0xe457_b5a2_e4d8_6bd1);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_REJECT));
+    }
+
+    #[test]
+    fn extract_zero_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-traceid", "0000000000000000"), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_malformed_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-traceid", "nothex"), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_missing_span_id_yields_zero() {
+        let carrier = headers(&[("x-b3-traceid", "80f198ee56343ba8")]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn extract_zero_span_id_yields_zero() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "0000000000000000"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn extract_malformed_span_id_rejects_context() {
+        // A valid trace id paired with a garbage span id must reject the
+        // whole context — silently dropping a malformed span id to 0 could
+        // let a bogus b3 context override later, valid propagation headers.
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "nothex"),
+        ]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_flags_debug_promotes_to_user_keep() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "1"),
+            ("x-b3-sampled", "0"),
+            ("x-b3-flags", "1"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_unknown_sampled_value_defers_priority() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-sampled", "maybe"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.sampling.priority, None);
+    }
+
+    #[test]
+    fn inject_64_bit_trace_id_emits_16_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["x-b3-traceid"], "80f198ee56343ba8");
+        assert_eq!(carrier["x-b3-spanid"], "00f067aa0ba902b7");
+        assert_eq!(carrier["x-b3-sampled"], "1");
+        assert!(!carrier.contains_key("x-b3-flags"));
+    }
+
+    #[test]
+    fn inject_128_bit_trace_id_emits_32_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128,
+            span_id: 0xe457_b5a2_e4d8_6bd1,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_REJECT),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["x-b3-traceid"], "80f198ee56343ba864fe8b2a57d3eff7");
+        assert_eq!(carrier["x-b3-spanid"], "e457b5a2e4d86bd1");
+        assert_eq!(carrier["x-b3-sampled"], "0");
+    }
+
+    #[test]
+    fn inject_user_keep_emits_flags_not_sampled() {
+        let mut ctx = SpanContext {
+            trace_id: 1,
+            span_id: 2,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier.get("x-b3-flags").map(String::as_str), Some("1"));
+        assert!(!carrier.contains_key("x-b3-sampled"));
+    }
+
+    #[test]
+    fn inject_without_priority_omits_sampled_and_flags() {
+        let mut ctx = SpanContext {
+            trace_id: 1,
+            span_id: 2,
+            sampling: Sampling {
+                priority: None,
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert!(!carrier.contains_key("x-b3-sampled"));
+        assert!(!carrier.contains_key("x-b3-flags"));
+    }
+
+    #[test]
+    fn propagator_dispatch_routes_to_b3multi() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "1"),
+            ("x-b3-sampled", "1"),
+        ]);
+        let propagator = TracePropagationStyle::B3Multi;
+        let ctx = propagator
+            .extract(&carrier, &Config::builder().build())
+            .expect("b3multi dispatch should produce context");
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+    }
+
+    #[test]
+    fn propagator_dispatch_exposes_keys() {
+        let propagator = TracePropagationStyle::B3Multi;
+        let k: &[String] = <TracePropagationStyle as Propagator<Config>>::keys(&propagator);
+        assert_eq!(k.len(), 4);
+        assert!(k.iter().any(|s| s == "x-b3-traceid"));
+        assert!(k.iter().any(|s| s == "x-b3-spanid"));
+        assert!(k.iter().any(|s| s == "x-b3-sampled"));
+        assert!(k.iter().any(|s| s == "x-b3-flags"));
+    }
+}

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -14,6 +14,8 @@ use config::{get_extractors, get_injectors};
 use datadog::DATADOG_LAST_PARENT_ID_KEY;
 use tracecontext::TRACESTATE_KEY;
 
+/// B3 multi-header propagation (`x-b3-*` headers).
+pub mod b3multi;
 /// W3C Baggage propagation (`baggage` header).
 pub mod baggage;
 pub mod carrier;

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -5,7 +5,7 @@ use crate::core::configuration::TracePropagationStyle;
 use serde::{Deserialize, Deserializer};
 
 use crate::propagation::{
-    baggage,
+    b3multi, baggage,
     carrier::{Extractor, Injector},
     context::{InjectSpanContext, SpanContext},
     datadog, tracecontext, PropagationConfig, Propagator,
@@ -18,10 +18,11 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::extract(carrier, config),
             Self::TraceContext => tracecontext::extract(carrier),
+            Self::B3Multi => b3multi::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
-            // B3 propagators are wired in subsequent changes.
-            Self::B3Multi | Self::B3SingleHeader => None,
+            // The B3 single-header propagator is wired in a subsequent change.
+            Self::B3SingleHeader => None,
         }
     }
 
@@ -29,10 +30,11 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::inject(context, carrier, config),
             Self::TraceContext => tracecontext::inject(context, carrier),
+            Self::B3Multi => b3multi::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
-            // B3 propagators are wired in subsequent changes.
-            Self::B3Multi | Self::B3SingleHeader => {}
+            // The B3 single-header propagator is wired in a subsequent change.
+            Self::B3SingleHeader => {}
         }
     }
 
@@ -40,8 +42,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
+            Self::B3Multi => b3multi::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None | Self::B3Multi | Self::B3SingleHeader => &NONE_KEYS,
+            Self::None | Self::B3SingleHeader => &NONE_KEYS,
         }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of #253 (the enum variants). Adds `datadog-opentelemetry/src/propagation/b3multi.rs` with extract/inject/keys, wires it into the `TracePropagationStyle::B3Multi` dispatch, and adds the `"b3multi"` case to `FromStr` now that the propagator actually works (deferred from #253 to avoid the extract-first regression).

Semantics mirror dd-trace-py `_B3MultiHeader` so wire-level behavior matches the other Datadog tracers:

- `extract` returns `None` if `x-b3-traceid` is missing, unparseable, or zero. **A present-but-malformed `x-b3-spanid` also rejects the whole context** (matches dd-trace-py raising `ValueError`); a missing or zero span id is accepted as `0`.
- 128-bit trace ids are kept as a single `u128`; **no** `_dd.p.tid` split and **no** `_dd.parent_id` tag — those are tracecontext-specific in this crate.
- Sampling decode: `x-b3-sampled=0 → AUTO_REJECT`, `=1 → AUTO_KEEP`, `x-b3-flags=1 → USER_KEEP` (debug takes precedence over `sampled`).
- `inject` emits 32 hex chars for 128-bit ids, 16 otherwise; `priority > 1` emits `x-b3-flags: 1` and suppresses `x-b3-sampled` (the two should never both be set per the spec).

## Review feedback addressed (Codex)

- **P2: malformed B3 span IDs**: `extract_malformed_span_id_rejects_context` now asserts that `x-b3-traceid: <valid>; x-b3-spanid: nothex` returns `None` instead of silently coercing span_id to 0.
- The new test `extract_zero_span_id_yields_zero` keeps the "explicit zero is OK" path locked in.

## Test plan

- [x] 16 unit tests in `propagation::b3multi::test` covering: missing/malformed/zero trace id, 64- and 128-bit ids, sampling decode (incl. flags overriding sampled), zero/missing/malformed span id, inject 64-/128-bit, inject priority mapping, `Propagator` dispatch routing, and `keys()` shape.
- [x] `cargo test -p datadog-opentelemetry --lib propagation::` — passes, no regressions.
- [x] `cargo test -p datadog-opentelemetry --lib core::configuration::configuration::tests::test_propagation_style_b3` — new `test_propagation_style_b3multi_parsed_from_env` asserts b3multi now parses while b3 is still dropped (added in #255).
- [x] `cargo clippy -p datadog-opentelemetry --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` with the pinned nightly — clean.

## Base branch

Targets `feat/b3-propagation-style-enum` (#253). Will be retargeted to `main` once that lands.
