### PR TITLE
feat(propagation): add B3Multi and B3SingleHeader variants

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -785,6 +785,10 @@ pub enum TracePropagationStyle {
     TraceContext,
     /// W3C Baggage propagation format using the `baggage` header.
     Baggage,
+    /// B3 multi-header propagation format using `x-b3-*` headers.
+    B3Multi,
+    /// B3 single-header propagation format using the `b3` header.
+    B3SingleHeader,
     /// No propagation - trace context is not propagated.
     None,
 }
@@ -817,6 +821,12 @@ impl FromStr for TracePropagationStyle {
             "datadog" => Ok(TracePropagationStyle::Datadog),
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
+            // `b3multi` and `b3` are added to from_str alongside the b3multi and b3
+            // single-header propagator implementations. Accepting them here while their
+            // extractors are no-ops would regress users who set
+            // DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog with
+            // DD_TRACE_PROPAGATION_EXTRACT_FIRST=true — the no-op b3 propagator would be
+            // picked first and Datadog headers would never be tried.
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -829,6 +839,8 @@ impl Display for TracePropagationStyle {
             TracePropagationStyle::Datadog => "datadog",
             TracePropagationStyle::TraceContext => "tracecontext",
             TracePropagationStyle::Baggage => "baggage",
+            TracePropagationStyle::B3Multi => "b3multi",
+            TracePropagationStyle::B3SingleHeader => "b3",
             TracePropagationStyle::None => "none",
         };
         write!(f, "{style}")
@@ -3059,6 +3071,31 @@ mod tests {
                 TracePropagationStyle::TraceContext,
             ])
             .as_deref()
+        );
+    }
+
+    #[test]
+    fn test_propagation_style_b3_display() {
+        // `b3multi` and `b3` round-trip via Display now that the variants exist;
+        // FromStr support is added when the respective propagators land.
+        assert_eq!(TracePropagationStyle::B3Multi.to_string(), "b3multi");
+        assert_eq!(TracePropagationStyle::B3SingleHeader.to_string(), "b3");
+    }
+
+    #[test]
+    fn test_propagation_style_b3_not_yet_parsed_from_env() {
+        // Until each B3 propagator lands, b3multi/b3 in the env var are dropped
+        // (FromStr returns Err, the env-var deserializer silently filters those).
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+
+        assert_eq!(
+            config.trace_propagation_style_extract(),
+            Some(vec![TracePropagationStyle::Datadog]).as_deref()
         );
     }
 

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -20,6 +20,8 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::TraceContext => tracecontext::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
+            // B3 propagators are wired in subsequent changes.
+            Self::B3Multi | Self::B3SingleHeader => None,
         }
     }
 
@@ -29,6 +31,8 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::TraceContext => tracecontext::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
+            // B3 propagators are wired in subsequent changes.
+            Self::B3Multi | Self::B3SingleHeader => {}
         }
     }
 
@@ -37,7 +41,7 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None => &NONE_KEYS,
+            Self::None | Self::B3Multi | Self::B3SingleHeader => &NONE_KEYS,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `B3Multi` and `B3SingleHeader` variants to `TracePropagationStyle`.
- Extend `Display` so the variants render as their canonical Datadog tracer names (`b3multi`, `b3`).
- Wire the new variants into the `Propagator` dispatch as no-ops (extract → `None`, inject → no-op, keys → `&[]`) for exhaustive matching.

**`FromStr` parsing is intentionally deferred** to the per-propagator follow-ups so each style only starts parsing once its extract/inject actually works. Accepting `b3` / `b3multi` here while their dispatch is a no-op would regress users with `DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog` + `DD_TRACE_PROPAGATION_EXTRACT_FIRST=true` — the no-op b3 would be selected first and Datadog headers would never be tried (raised by Codex review on the initial revision).

## Test plan

- [x] `cargo test -p datadog-opentelemetry --lib core::configuration::` — passes.
- [x] `cargo test -p datadog-opentelemetry --lib propagation::` — passes (existing tests unaffected; new variants currently exercise the no-op dispatch arms).
- [x] `cargo clippy -p datadog-opentelemetry --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` with the pinned nightly — clean.
- [x] New test `test_propagation_style_b3_not_yet_parsed_from_env` asserts that env-var parsing silently drops `b3`/`b3multi` for now, leaving working styles intact.
- [ ] Follow-up PRs add `FromStr` cases alongside the real propagators.

## Follow-ups

- #254: `b3multi.rs` propagator + `"b3multi"` parsing.
- #255: `b3.rs` single-header propagator + `"b3"` parsing.
- #256: Fill in the existing `// todo: add b3` markers in `propagation/mod.rs` (cross-style conflict / span-link tests).
