### PR TITLE
feat(propagation): implement B3 single-header propagator

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -822,7 +822,7 @@ impl FromStr for TracePropagationStyle {
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
             "b3multi" => Ok(TracePropagationStyle::B3Multi),
-            // `b3` is added to from_str alongside the b3 single-header propagator.
+            "b3" => Ok(TracePropagationStyle::B3SingleHeader),
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -3077,27 +3077,47 @@ mod tests {
     }
 
     #[test]
-    fn test_propagation_style_b3multi_parsed_from_env() {
-        // b3multi parses (it has a working propagator now); b3 is still dropped
-        // until the b3 single-header propagator lands.
+    fn test_propagation_style_b3_parsed_from_env() {
+        // Both b3multi and b3 now parse from env (case-insensitive).
         let mut sources = CompositeSource::new();
         sources.add_source(HashMapSource::from_iter(
-            [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
+            [
+                (
+                    "DD_TRACE_PROPAGATION_STYLE",
+                    "datadog,tracecontext,b3multi,b3",
+                ),
+                ("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "B3Multi,B3"),
+                ("DD_TRACE_PROPAGATION_STYLE_INJECT", "b3,b3multi"),
+            ],
             ConfigSourceOrigin::EnvVar,
         ));
         let config = Config::builder_with_sources(&sources).build();
 
         assert_eq!(
-            config.trace_propagation_style_extract(),
+            config.trace_propagation_style(),
             Some(vec![
+                TracePropagationStyle::Datadog,
+                TracePropagationStyle::TraceContext,
                 TracePropagationStyle::B3Multi,
-                TracePropagationStyle::Datadog
+                TracePropagationStyle::B3SingleHeader,
             ])
             .as_deref()
         );
         assert_eq!(
-            TracePropagationStyle::from_str("B3Multi").unwrap(),
-            TracePropagationStyle::B3Multi
+            config.trace_propagation_style_extract(),
+            Some(vec![
+                TracePropagationStyle::B3Multi,
+                TracePropagationStyle::B3SingleHeader,
+            ])
+            .as_deref()
+        );
+        assert_eq!(
+            config.trace_propagation_style_inject(),
+            Some(vec![
+                TracePropagationStyle::B3SingleHeader,
+                TracePropagationStyle::B3Multi,
+            ])
+            .as_deref()
         );
     }
 

--- a/datadog-opentelemetry/src/propagation/b3.rs
+++ b/datadog-opentelemetry/src/propagation/b3.rs
@@ -1,0 +1,374 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! B3 single-header trace context propagation.
+//!
+//! Implements the [B3 single-header propagation format] used by Zipkin and
+//! compatible tracers. A single `b3` header carries the trace id, span id,
+//! sampling state, and an optional (ignored) parent span id, separated by
+//! `-`.
+//!
+//! Behavior matches the Python tracer's `_B3SingleHeader` so wire-level
+//! semantics stay aligned with the other Datadog tracers. In particular,
+//! sampling-only forms (`b3: 0`, `b3: 1`, `b3: d`) are preserved: the
+//! returned [`SpanContext`] carries a zero trace id and the upstream
+//! sampling decision so callers can honor the upstream accept/deny/debug
+//! intent rather than fall back to local sampling policy.
+//!
+//! [B3 single-header propagation format]: https://github.com/openzipkin/b3-propagation#single-header
+
+use std::sync::LazyLock;
+
+use crate::core::sampling::{priority, SamplingPriority};
+use crate::dd_warn;
+use crate::propagation::{
+    carrier::{Extractor, Injector},
+    context::{InjectSpanContext, Sampling, SpanContext},
+};
+
+/// B3 single-header name.
+pub const B3_SINGLE_KEY: &str = "b3";
+
+static B3_SINGLE_HEADER_KEYS: LazyLock<[String; 1]> = LazyLock::new(|| [B3_SINGLE_KEY.to_owned()]);
+
+/// Extract trace context from a carrier using the `b3` single header.
+///
+/// The header is parsed as `{trace_id}-{span_id}-{sampling_state}-{parent_span_id}`,
+/// with the trailing fields optional. Returns `None` when:
+///
+/// - the header is missing or empty;
+/// - the trace-and-span form is present but the trace id is malformed or zero;
+/// - the span id is present but malformed (a missing or zero span id is accepted and recorded as
+///   `0`);
+/// - the sampling-only form is present but the sampling value is unknown.
+///
+/// The sampling-only forms `b3: 0`, `b3: 1`, and `b3: d` are preserved as a
+/// context with `trace_id = 0`, `span_id = 0`, and the parsed priority, so
+/// the upstream sampling decision survives even when no trace ids were sent.
+pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
+    let header = carrier.get(B3_SINGLE_KEY)?;
+    if header.is_empty() {
+        return None;
+    }
+
+    let mut parts = header.split('-');
+    let first = parts.next();
+    let second = parts.next();
+    let third = parts.next();
+    // Any trailing parent span id is ignored per the B3 spec.
+
+    let (trace_id, span_id, priority): (u128, u64, Option<SamplingPriority>) =
+        match (first, second, third) {
+            // Sampling-only form: a single segment is the sampling state.
+            // An unknown sampling token (anything but `0`/`1`/`d`) makes the
+            // whole header useless — bail out.
+            (Some(s), None, None) => (0, 0, Some(parse_priority(s)?)),
+            (Some(t), Some(s), sampled) => {
+                let trace_id = parse_trace_id(t)?;
+                let span_id = parse_span_id(s)?;
+                let priority = sampled.and_then(parse_priority);
+                (trace_id, span_id, priority)
+            }
+            // `split` always yields at least one element, so this branch is unreachable.
+            _ => return None,
+        };
+
+    Some(SpanContext {
+        trace_id,
+        span_id,
+        sampling: Sampling {
+            priority,
+            mechanism: None,
+        },
+        origin: None,
+        tags: std::collections::HashMap::new(),
+        links: Vec::new(),
+        is_remote: true,
+        tracestate: None,
+    })
+}
+
+/// Inject trace context into a carrier as a `b3` single header.
+pub fn inject(context: &InjectSpanContext, carrier: &mut dyn Injector) {
+    let trace_id = format_b3_trace_id(context.trace_id);
+    let mut header = format!("{trace_id}-{:016x}", context.span_id);
+    if let Some(priority) = context.sampling.priority {
+        let p = priority.into_i8();
+        if p <= 0 {
+            header.push_str("-0");
+        } else if p == 1 {
+            header.push_str("-1");
+        } else {
+            header.push_str("-d");
+        }
+    }
+    carrier.set(B3_SINGLE_KEY, header);
+}
+
+/// Returns the header keys used by B3 single-header propagation.
+pub fn keys() -> &'static [String] {
+    B3_SINGLE_HEADER_KEYS.as_slice()
+}
+
+fn parse_trace_id(hex: &str) -> Option<u128> {
+    let id = match u128::from_str_radix(hex, 16) {
+        Ok(id) => id,
+        Err(e) => {
+            dd_warn!("Propagator (b3): malformed trace_id {hex:?}: {e}");
+            return None;
+        }
+    };
+    if id == 0 {
+        return None;
+    }
+    Some(id)
+}
+
+/// Parses a B3 span id. Returns `None` only on hex-parse failure; an
+/// explicit `0` is accepted so callers can distinguish "malformed → reject
+/// the whole context" from "zero / no parent → accept with span_id 0".
+fn parse_span_id(hex: &str) -> Option<u64> {
+    match u64::from_str_radix(hex, 16) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            dd_warn!("Propagator (b3): malformed span_id {hex:?}: {e}");
+            None
+        }
+    }
+}
+
+fn parse_priority(sampled: &str) -> Option<SamplingPriority> {
+    match sampled {
+        "0" => Some(priority::AUTO_REJECT),
+        "1" => Some(priority::AUTO_KEEP),
+        "d" => Some(priority::USER_KEEP),
+        _ => None,
+    }
+}
+
+fn format_b3_trace_id(trace_id: u128) -> String {
+    if trace_id > u64::MAX as u128 {
+        format!("{trace_id:032x}")
+    } else {
+        format!("{trace_id:016x}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::core::configuration::{Config, TracePropagationStyle};
+    use crate::core::sampling::priority;
+    use crate::propagation::{context::span_context_to_inject, Propagator};
+
+    use super::*;
+
+    fn carrier_with(header: &str) -> HashMap<String, String> {
+        HashMap::from([("b3".to_string(), header.to_string())])
+    }
+
+    #[test]
+    fn extract_missing_header_returns_none() {
+        let carrier: HashMap<String, String> = HashMap::new();
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_empty_header_returns_none() {
+        let carrier = carrier_with("");
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_sampling_only_forms_preserve_upstream_decision() {
+        // Sampling-only `b3: 0/1/d` carries no trace ids but does carry an
+        // explicit upstream sampling decision; the propagator returns a
+        // zero-trace context so the sampler can honor that decision.
+        let ctx0 = extract(&carrier_with("0")).unwrap();
+        assert_eq!(ctx0.trace_id, 0);
+        assert_eq!(ctx0.span_id, 0);
+        assert_eq!(ctx0.sampling.priority, Some(priority::AUTO_REJECT));
+
+        let ctx1 = extract(&carrier_with("1")).unwrap();
+        assert_eq!(ctx1.sampling.priority, Some(priority::AUTO_KEEP));
+
+        let ctxd = extract(&carrier_with("d")).unwrap();
+        assert_eq!(ctxd.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_sampling_only_unknown_value_returns_none() {
+        // A single-segment header with an unknown sampling token gives us
+        // neither ids nor a usable sampling decision — drop it entirely.
+        assert_eq!(extract(&carrier_with("xyz")), None);
+    }
+
+    #[test]
+    fn extract_malformed_span_id_rejects_context() {
+        // A valid trace id paired with a garbage span id rejects the whole
+        // context — silently coercing to span_id 0 could let a bogus b3
+        // context override later, valid propagation headers.
+        assert_eq!(extract(&carrier_with("80f198ee56343ba8-nothex-1")), None);
+    }
+
+    #[test]
+    fn extract_two_part_form_has_no_sampling() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-00f067aa0ba902b7")).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, None);
+        assert!(ctx.is_remote);
+    }
+
+    #[test]
+    fn extract_three_part_form_parses_sampling() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-00f067aa0ba902b7-1")).unwrap();
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_KEEP));
+    }
+
+    #[test]
+    fn extract_four_part_form_ignores_parent_span_id() {
+        let ctx = extract(&carrier_with(
+            "80f198ee56343ba8-00f067aa0ba902b7-0-05e3ac9a4f6e3b90",
+        ))
+        .unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_REJECT));
+    }
+
+    #[test]
+    fn extract_128_bit_trace_id() {
+        let ctx = extract(&carrier_with(
+            "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d",
+        ))
+        .unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128);
+        assert_eq!(ctx.span_id, 0xe457_b5a2_e4d8_6bd1);
+        assert_eq!(ctx.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_zero_trace_id_returns_none() {
+        assert_eq!(extract(&carrier_with("0000000000000000-1-1")), None);
+    }
+
+    #[test]
+    fn extract_malformed_trace_id_returns_none() {
+        assert_eq!(extract(&carrier_with("nothex-1-1")), None);
+    }
+
+    #[test]
+    fn extract_unknown_sampling_value_defers_priority() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-1-xyz")).unwrap();
+        assert_eq!(ctx.sampling.priority, None);
+    }
+
+    #[test]
+    fn extract_zero_span_id_yields_zero() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-0000000000000000-1")).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn inject_no_priority_omits_sampling_segment() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: None,
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7");
+    }
+
+    #[test]
+    fn inject_auto_keep_appends_one() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-1");
+    }
+
+    #[test]
+    fn inject_auto_reject_appends_zero() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_REJECT),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-0");
+    }
+
+    #[test]
+    fn inject_user_keep_appends_debug() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-d");
+    }
+
+    #[test]
+    fn inject_128_bit_trace_id_emits_32_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128,
+            span_id: 0xe457_b5a2_e4d8_6bd1,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(
+            carrier["b3"],
+            "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d"
+        );
+    }
+
+    #[test]
+    fn propagator_dispatch_routes_to_b3_single() {
+        let carrier = carrier_with("80f198ee56343ba8-00f067aa0ba902b7-1");
+        let propagator = TracePropagationStyle::B3SingleHeader;
+        let ctx = propagator
+            .extract(&carrier, &Config::builder().build())
+            .expect("b3 single-header dispatch should produce context");
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+    }
+
+    #[test]
+    fn propagator_dispatch_exposes_keys() {
+        let propagator = TracePropagationStyle::B3SingleHeader;
+        let k: &[String] = <TracePropagationStyle as Propagator<Config>>::keys(&propagator);
+        assert_eq!(k, &["b3".to_string()]);
+    }
+}

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -14,6 +14,8 @@ use config::{get_extractors, get_injectors};
 use datadog::DATADOG_LAST_PARENT_ID_KEY;
 use tracecontext::TRACESTATE_KEY;
 
+/// B3 single-header propagation (`b3` header).
+pub mod b3;
 /// B3 multi-header propagation (`x-b3-*` headers).
 pub mod b3multi;
 /// W3C Baggage propagation (`baggage` header).

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -5,7 +5,7 @@ use crate::core::configuration::TracePropagationStyle;
 use serde::{Deserialize, Deserializer};
 
 use crate::propagation::{
-    b3multi, baggage,
+    b3, b3multi, baggage,
     carrier::{Extractor, Injector},
     context::{InjectSpanContext, SpanContext},
     datadog, tracecontext, PropagationConfig, Propagator,
@@ -19,10 +19,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::extract(carrier, config),
             Self::TraceContext => tracecontext::extract(carrier),
             Self::B3Multi => b3multi::extract(carrier),
+            Self::B3SingleHeader => b3::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
-            // The B3 single-header propagator is wired in a subsequent change.
-            Self::B3SingleHeader => None,
         }
     }
 
@@ -31,10 +30,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::inject(context, carrier, config),
             Self::TraceContext => tracecontext::inject(context, carrier),
             Self::B3Multi => b3multi::inject(context, carrier),
+            Self::B3SingleHeader => b3::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
-            // The B3 single-header propagator is wired in a subsequent change.
-            Self::B3SingleHeader => {}
         }
     }
 
@@ -43,8 +41,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
             Self::B3Multi => b3multi::keys(),
+            Self::B3SingleHeader => b3::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None | Self::B3SingleHeader => &NONE_KEYS,
+            Self::None => &NONE_KEYS,
         }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of #254 (b3multi). Adds `datadog-opentelemetry/src/propagation/b3.rs` with extract/inject/keys for the `b3` single header, wires it into `TracePropagationStyle::B3SingleHeader` dispatch, and adds the `"b3"` case to `FromStr` (deferred from #253 to avoid the extract-first regression Codex flagged).

Semantics mirror dd-trace-py `_B3SingleHeader`:

- Parses `{trace_id}-{span_id}-{sampling_state}-{parent_span_id}`. The trailing parent span id is read and discarded per the B3 spec.
- 2-part (`traceid-spanid`) and 3-part (`traceid-spanid-sampling`) forms are both supported.
- **Sampling-only forms `b3: 0`, `b3: 1`, `b3: d` are preserved**: extract returns a `SpanContext` with `trace_id = 0`, `span_id = 0`, and the parsed priority, so downstream samplers can honor the upstream accept/deny/debug decision instead of falling back to local policy. (Earlier revision dropped these — corrected per Codex review.)
- A present-but-malformed span id rejects the whole context; missing or zero span id is accepted as `0`. (Also corrected per Codex review.)
- Sampling: `-0 → AUTO_REJECT`, `-1 → AUTO_KEEP`, `-d → USER_KEEP` (debug).
- Inject: 32 hex chars for 128-bit ids, 16 otherwise. Priority `>1` appends `-d`, `==1` appends `-1`, `<=0` appends `-0`. No priority → no trailing segment.

## Review feedback addressed (Codex)

- **P2: preserve sampling-only B3 decisions** — `extract_sampling_only_forms_preserve_upstream_decision` asserts `b3: 0/1/d` produce a zero-trace context with the parsed priority. `extract_sampling_only_unknown_value_returns_none` asserts an unknown single-segment token (e.g. `b3: xyz`) is still dropped.
- **P2: reject malformed B3 span IDs** — `extract_malformed_span_id_rejects_context` asserts `<valid>-nothex-1` returns `None`. `extract_zero_span_id_yields_zero` keeps the "explicit zero is OK" path locked in.

## Test plan

- [x] 20 unit tests in `propagation::b3::test`. New cases since the initial revision: sampling-only preserved + unknown single-token rejected + malformed span id rejected.
- [x] `cargo test -p datadog-opentelemetry --lib propagation::` — 121 pass, no regressions.
- [x] `cargo test -p datadog-opentelemetry --lib core::configuration::configuration::tests::test_propagation_style_b3` — `test_propagation_style_b3_parsed_from_env` now asserts both b3multi and b3 (case-insensitive) parse and dispatch correctly.
- [x] `cargo clippy -p datadog-opentelemetry --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` with the pinned nightly — clean.

## Base branch

Targets `feat/b3-propagation-b3multi` (#254). Retarget to `main` once #253 and #254 land.
