### PR TITLE
feat(propagation): add B3 single and multi-header trace propagation support

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -785,6 +785,10 @@ pub enum TracePropagationStyle {
     TraceContext,
     /// W3C Baggage propagation format using the `baggage` header.
     Baggage,
+    /// B3 multi-header propagation format using `x-b3-*` headers.
+    B3Multi,
+    /// B3 single-header propagation format using the `b3` header.
+    B3SingleHeader,
     /// No propagation - trace context is not propagated.
     None,
 }
@@ -817,6 +821,12 @@ impl FromStr for TracePropagationStyle {
             "datadog" => Ok(TracePropagationStyle::Datadog),
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
+            // `b3multi` and `b3` are added to from_str alongside the b3multi and b3
+            // single-header propagator implementations. Accepting them here while their
+            // extractors are no-ops would regress users who set
+            // DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog with
+            // DD_TRACE_PROPAGATION_EXTRACT_FIRST=true — the no-op b3 propagator would be
+            // picked first and Datadog headers would never be tried.
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -829,6 +839,8 @@ impl Display for TracePropagationStyle {
             TracePropagationStyle::Datadog => "datadog",
             TracePropagationStyle::TraceContext => "tracecontext",
             TracePropagationStyle::Baggage => "baggage",
+            TracePropagationStyle::B3Multi => "b3multi",
+            TracePropagationStyle::B3SingleHeader => "b3",
             TracePropagationStyle::None => "none",
         };
         write!(f, "{style}")
@@ -3059,6 +3071,31 @@ mod tests {
                 TracePropagationStyle::TraceContext,
             ])
             .as_deref()
+        );
+    }
+
+    #[test]
+    fn test_propagation_style_b3_display() {
+        // `b3multi` and `b3` round-trip via Display now that the variants exist;
+        // FromStr support is added when the respective propagators land.
+        assert_eq!(TracePropagationStyle::B3Multi.to_string(), "b3multi");
+        assert_eq!(TracePropagationStyle::B3SingleHeader.to_string(), "b3");
+    }
+
+    #[test]
+    fn test_propagation_style_b3_not_yet_parsed_from_env() {
+        // Until each B3 propagator lands, b3multi/b3 in the env var are dropped
+        // (FromStr returns Err, the env-var deserializer silently filters those).
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+
+        assert_eq!(
+            config.trace_propagation_style_extract(),
+            Some(vec![TracePropagationStyle::Datadog]).as_deref()
         );
     }
 

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -822,7 +822,7 @@ impl FromStr for TracePropagationStyle {
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
             "b3multi" => Ok(TracePropagationStyle::B3Multi),
-            // `b3` is added to from_str alongside the b3 single-header propagator.
+            "b3" => Ok(TracePropagationStyle::B3SingleHeader),
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -3077,27 +3077,47 @@ mod tests {
     }
 
     #[test]
-    fn test_propagation_style_b3multi_parsed_from_env() {
-        // b3multi parses (it has a working propagator now); b3 is still dropped
-        // until the b3 single-header propagator lands.
+    fn test_propagation_style_b3_parsed_from_env() {
+        // Both b3multi and b3 now parse from env (case-insensitive).
         let mut sources = CompositeSource::new();
         sources.add_source(HashMapSource::from_iter(
-            [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
+            [
+                (
+                    "DD_TRACE_PROPAGATION_STYLE",
+                    "datadog,tracecontext,b3multi,b3",
+                ),
+                ("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "B3Multi,B3"),
+                ("DD_TRACE_PROPAGATION_STYLE_INJECT", "b3,b3multi"),
+            ],
             ConfigSourceOrigin::EnvVar,
         ));
         let config = Config::builder_with_sources(&sources).build();
 
         assert_eq!(
-            config.trace_propagation_style_extract(),
+            config.trace_propagation_style(),
             Some(vec![
+                TracePropagationStyle::Datadog,
+                TracePropagationStyle::TraceContext,
                 TracePropagationStyle::B3Multi,
-                TracePropagationStyle::Datadog
+                TracePropagationStyle::B3SingleHeader,
             ])
             .as_deref()
         );
         assert_eq!(
-            TracePropagationStyle::from_str("B3Multi").unwrap(),
-            TracePropagationStyle::B3Multi
+            config.trace_propagation_style_extract(),
+            Some(vec![
+                TracePropagationStyle::B3Multi,
+                TracePropagationStyle::B3SingleHeader,
+            ])
+            .as_deref()
+        );
+        assert_eq!(
+            config.trace_propagation_style_inject(),
+            Some(vec![
+                TracePropagationStyle::B3SingleHeader,
+                TracePropagationStyle::B3Multi,
+            ])
+            .as_deref()
         );
     }
 

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -821,12 +821,8 @@ impl FromStr for TracePropagationStyle {
             "datadog" => Ok(TracePropagationStyle::Datadog),
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "baggage" => Ok(TracePropagationStyle::Baggage),
-            // `b3multi` and `b3` are added to from_str alongside the b3multi and b3
-            // single-header propagator implementations. Accepting them here while their
-            // extractors are no-ops would regress users who set
-            // DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog with
-            // DD_TRACE_PROPAGATION_EXTRACT_FIRST=true — the no-op b3 propagator would be
-            // picked first and Datadog headers would never be tried.
+            "b3multi" => Ok(TracePropagationStyle::B3Multi),
+            // `b3` is added to from_str alongside the b3 single-header propagator.
             "none" => Ok(TracePropagationStyle::None),
             _ => Err(format!("Unknown trace propagation style: '{s}'")),
         }
@@ -3076,16 +3072,14 @@ mod tests {
 
     #[test]
     fn test_propagation_style_b3_display() {
-        // `b3multi` and `b3` round-trip via Display now that the variants exist;
-        // FromStr support is added when the respective propagators land.
         assert_eq!(TracePropagationStyle::B3Multi.to_string(), "b3multi");
         assert_eq!(TracePropagationStyle::B3SingleHeader.to_string(), "b3");
     }
 
     #[test]
-    fn test_propagation_style_b3_not_yet_parsed_from_env() {
-        // Until each B3 propagator lands, b3multi/b3 in the env var are dropped
-        // (FromStr returns Err, the env-var deserializer silently filters those).
+    fn test_propagation_style_b3multi_parsed_from_env() {
+        // b3multi parses (it has a working propagator now); b3 is still dropped
+        // until the b3 single-header propagator lands.
         let mut sources = CompositeSource::new();
         sources.add_source(HashMapSource::from_iter(
             [("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "b3multi,b3,datadog")],
@@ -3095,7 +3089,15 @@ mod tests {
 
         assert_eq!(
             config.trace_propagation_style_extract(),
-            Some(vec![TracePropagationStyle::Datadog]).as_deref()
+            Some(vec![
+                TracePropagationStyle::B3Multi,
+                TracePropagationStyle::Datadog
+            ])
+            .as_deref()
+        );
+        assert_eq!(
+            TracePropagationStyle::from_str("B3Multi").unwrap(),
+            TracePropagationStyle::B3Multi
         );
     }
 

--- a/datadog-opentelemetry/src/propagation/b3.rs
+++ b/datadog-opentelemetry/src/propagation/b3.rs
@@ -61,7 +61,15 @@ pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
         match (first, second, third) {
             // Sampling-only form: a single segment is the sampling state.
             // An unknown sampling token (anything but `0`/`1`/`d`) makes the
-            // whole header useless — bail out.
+            // whole header useless, bail out.
+            //
+            // KNOWN ISSUE (tracked in APMSP-3578): the zero-trace context
+            // returned here can be wrongly picked as the primary by
+            // `resolve_contexts` when b3 is configured before another style
+            // and the request also carries valid datadog/tracecontext
+            // headers. The fix belongs in `resolve_contexts` (skip
+            // zero-trace contexts when picking primary; merge their
+            // sampling priority into the real primary), not here.
             (Some(s), None, None) => (0, 0, Some(parse_priority(s)?)),
             (Some(t), Some(s), sampled) => {
                 let trace_id = parse_trace_id(t)?;
@@ -111,6 +119,13 @@ pub fn keys() -> &'static [String] {
 }
 
 fn parse_trace_id(hex: &str) -> Option<u128> {
+    // B3 spec mandates 16 or 32 hex chars; reject anything longer up front
+    // so leading-zero-padded oversized inputs (which `u128::from_str_radix`
+    // would otherwise accept) are treated as malformed.
+    if hex.len() > 32 {
+        dd_warn!("Propagator (b3): trace_id {hex:?} exceeds 32 hex chars");
+        return None;
+    }
     let id = match u128::from_str_radix(hex, 16) {
         Ok(id) => id,
         Err(e) => {
@@ -128,6 +143,10 @@ fn parse_trace_id(hex: &str) -> Option<u128> {
 /// explicit `0` is accepted so callers can distinguish "malformed → reject
 /// the whole context" from "zero / no parent → accept with span_id 0".
 fn parse_span_id(hex: &str) -> Option<u64> {
+    if hex.len() > 16 {
+        dd_warn!("Propagator (b3): span_id {hex:?} exceeds 16 hex chars");
+        return None;
+    }
     match u64::from_str_radix(hex, 16) {
         Ok(id) => Some(id),
         Err(e) => {
@@ -258,6 +277,23 @@ mod test {
     #[test]
     fn extract_malformed_trace_id_returns_none() {
         assert_eq!(extract(&carrier_with("nothex-1-1")), None);
+    }
+
+    #[test]
+    fn extract_oversized_trace_id_returns_none() {
+        // 33 hex chars: leading-zero-padded but longer than the spec allows.
+        let oversized = format!("{:033x}", 1u128);
+        assert_eq!(extract(&carrier_with(&format!("{oversized}-1-1"))), None);
+    }
+
+    #[test]
+    fn extract_oversized_span_id_returns_none() {
+        // 17 hex chars span_id; longer than the spec allows.
+        let oversized = format!("{:017x}", 1u64);
+        assert_eq!(
+            extract(&carrier_with(&format!("80f198ee56343ba8-{oversized}-1"))),
+            None
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/propagation/b3.rs
+++ b/datadog-opentelemetry/src/propagation/b3.rs
@@ -1,0 +1,374 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! B3 single-header trace context propagation.
+//!
+//! Implements the [B3 single-header propagation format] used by Zipkin and
+//! compatible tracers. A single `b3` header carries the trace id, span id,
+//! sampling state, and an optional (ignored) parent span id, separated by
+//! `-`.
+//!
+//! Behavior matches the Python tracer's `_B3SingleHeader` so wire-level
+//! semantics stay aligned with the other Datadog tracers. In particular,
+//! sampling-only forms (`b3: 0`, `b3: 1`, `b3: d`) are preserved: the
+//! returned [`SpanContext`] carries a zero trace id and the upstream
+//! sampling decision so callers can honor the upstream accept/deny/debug
+//! intent rather than fall back to local sampling policy.
+//!
+//! [B3 single-header propagation format]: https://github.com/openzipkin/b3-propagation#single-header
+
+use std::sync::LazyLock;
+
+use crate::core::sampling::{priority, SamplingPriority};
+use crate::dd_warn;
+use crate::propagation::{
+    carrier::{Extractor, Injector},
+    context::{InjectSpanContext, Sampling, SpanContext},
+};
+
+/// B3 single-header name.
+pub const B3_SINGLE_KEY: &str = "b3";
+
+static B3_SINGLE_HEADER_KEYS: LazyLock<[String; 1]> = LazyLock::new(|| [B3_SINGLE_KEY.to_owned()]);
+
+/// Extract trace context from a carrier using the `b3` single header.
+///
+/// The header is parsed as `{trace_id}-{span_id}-{sampling_state}-{parent_span_id}`,
+/// with the trailing fields optional. Returns `None` when:
+///
+/// - the header is missing or empty;
+/// - the trace-and-span form is present but the trace id is malformed or zero;
+/// - the span id is present but malformed (a missing or zero span id is accepted and recorded as
+///   `0`);
+/// - the sampling-only form is present but the sampling value is unknown.
+///
+/// The sampling-only forms `b3: 0`, `b3: 1`, and `b3: d` are preserved as a
+/// context with `trace_id = 0`, `span_id = 0`, and the parsed priority, so
+/// the upstream sampling decision survives even when no trace ids were sent.
+pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
+    let header = carrier.get(B3_SINGLE_KEY)?;
+    if header.is_empty() {
+        return None;
+    }
+
+    let mut parts = header.split('-');
+    let first = parts.next();
+    let second = parts.next();
+    let third = parts.next();
+    // Any trailing parent span id is ignored per the B3 spec.
+
+    let (trace_id, span_id, priority): (u128, u64, Option<SamplingPriority>) =
+        match (first, second, third) {
+            // Sampling-only form: a single segment is the sampling state.
+            // An unknown sampling token (anything but `0`/`1`/`d`) makes the
+            // whole header useless — bail out.
+            (Some(s), None, None) => (0, 0, Some(parse_priority(s)?)),
+            (Some(t), Some(s), sampled) => {
+                let trace_id = parse_trace_id(t)?;
+                let span_id = parse_span_id(s)?;
+                let priority = sampled.and_then(parse_priority);
+                (trace_id, span_id, priority)
+            }
+            // `split` always yields at least one element, so this branch is unreachable.
+            _ => return None,
+        };
+
+    Some(SpanContext {
+        trace_id,
+        span_id,
+        sampling: Sampling {
+            priority,
+            mechanism: None,
+        },
+        origin: None,
+        tags: std::collections::HashMap::new(),
+        links: Vec::new(),
+        is_remote: true,
+        tracestate: None,
+    })
+}
+
+/// Inject trace context into a carrier as a `b3` single header.
+pub fn inject(context: &InjectSpanContext, carrier: &mut dyn Injector) {
+    let trace_id = format_b3_trace_id(context.trace_id);
+    let mut header = format!("{trace_id}-{:016x}", context.span_id);
+    if let Some(priority) = context.sampling.priority {
+        let p = priority.into_i8();
+        if p <= 0 {
+            header.push_str("-0");
+        } else if p == 1 {
+            header.push_str("-1");
+        } else {
+            header.push_str("-d");
+        }
+    }
+    carrier.set(B3_SINGLE_KEY, header);
+}
+
+/// Returns the header keys used by B3 single-header propagation.
+pub fn keys() -> &'static [String] {
+    B3_SINGLE_HEADER_KEYS.as_slice()
+}
+
+fn parse_trace_id(hex: &str) -> Option<u128> {
+    let id = match u128::from_str_radix(hex, 16) {
+        Ok(id) => id,
+        Err(e) => {
+            dd_warn!("Propagator (b3): malformed trace_id {hex:?}: {e}");
+            return None;
+        }
+    };
+    if id == 0 {
+        return None;
+    }
+    Some(id)
+}
+
+/// Parses a B3 span id. Returns `None` only on hex-parse failure; an
+/// explicit `0` is accepted so callers can distinguish "malformed → reject
+/// the whole context" from "zero / no parent → accept with span_id 0".
+fn parse_span_id(hex: &str) -> Option<u64> {
+    match u64::from_str_radix(hex, 16) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            dd_warn!("Propagator (b3): malformed span_id {hex:?}: {e}");
+            None
+        }
+    }
+}
+
+fn parse_priority(sampled: &str) -> Option<SamplingPriority> {
+    match sampled {
+        "0" => Some(priority::AUTO_REJECT),
+        "1" => Some(priority::AUTO_KEEP),
+        "d" => Some(priority::USER_KEEP),
+        _ => None,
+    }
+}
+
+fn format_b3_trace_id(trace_id: u128) -> String {
+    if trace_id > u64::MAX as u128 {
+        format!("{trace_id:032x}")
+    } else {
+        format!("{trace_id:016x}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::core::configuration::{Config, TracePropagationStyle};
+    use crate::core::sampling::priority;
+    use crate::propagation::{context::span_context_to_inject, Propagator};
+
+    use super::*;
+
+    fn carrier_with(header: &str) -> HashMap<String, String> {
+        HashMap::from([("b3".to_string(), header.to_string())])
+    }
+
+    #[test]
+    fn extract_missing_header_returns_none() {
+        let carrier: HashMap<String, String> = HashMap::new();
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_empty_header_returns_none() {
+        let carrier = carrier_with("");
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_sampling_only_forms_preserve_upstream_decision() {
+        // Sampling-only `b3: 0/1/d` carries no trace ids but does carry an
+        // explicit upstream sampling decision; the propagator returns a
+        // zero-trace context so the sampler can honor that decision.
+        let ctx0 = extract(&carrier_with("0")).unwrap();
+        assert_eq!(ctx0.trace_id, 0);
+        assert_eq!(ctx0.span_id, 0);
+        assert_eq!(ctx0.sampling.priority, Some(priority::AUTO_REJECT));
+
+        let ctx1 = extract(&carrier_with("1")).unwrap();
+        assert_eq!(ctx1.sampling.priority, Some(priority::AUTO_KEEP));
+
+        let ctxd = extract(&carrier_with("d")).unwrap();
+        assert_eq!(ctxd.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_sampling_only_unknown_value_returns_none() {
+        // A single-segment header with an unknown sampling token gives us
+        // neither ids nor a usable sampling decision — drop it entirely.
+        assert_eq!(extract(&carrier_with("xyz")), None);
+    }
+
+    #[test]
+    fn extract_malformed_span_id_rejects_context() {
+        // A valid trace id paired with a garbage span id rejects the whole
+        // context — silently coercing to span_id 0 could let a bogus b3
+        // context override later, valid propagation headers.
+        assert_eq!(extract(&carrier_with("80f198ee56343ba8-nothex-1")), None);
+    }
+
+    #[test]
+    fn extract_two_part_form_has_no_sampling() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-00f067aa0ba902b7")).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, None);
+        assert!(ctx.is_remote);
+    }
+
+    #[test]
+    fn extract_three_part_form_parses_sampling() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-00f067aa0ba902b7-1")).unwrap();
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_KEEP));
+    }
+
+    #[test]
+    fn extract_four_part_form_ignores_parent_span_id() {
+        let ctx = extract(&carrier_with(
+            "80f198ee56343ba8-00f067aa0ba902b7-0-05e3ac9a4f6e3b90",
+        ))
+        .unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_REJECT));
+    }
+
+    #[test]
+    fn extract_128_bit_trace_id() {
+        let ctx = extract(&carrier_with(
+            "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d",
+        ))
+        .unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128);
+        assert_eq!(ctx.span_id, 0xe457_b5a2_e4d8_6bd1);
+        assert_eq!(ctx.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_zero_trace_id_returns_none() {
+        assert_eq!(extract(&carrier_with("0000000000000000-1-1")), None);
+    }
+
+    #[test]
+    fn extract_malformed_trace_id_returns_none() {
+        assert_eq!(extract(&carrier_with("nothex-1-1")), None);
+    }
+
+    #[test]
+    fn extract_unknown_sampling_value_defers_priority() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-1-xyz")).unwrap();
+        assert_eq!(ctx.sampling.priority, None);
+    }
+
+    #[test]
+    fn extract_zero_span_id_yields_zero() {
+        let ctx = extract(&carrier_with("80f198ee56343ba8-0000000000000000-1")).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn inject_no_priority_omits_sampling_segment() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: None,
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7");
+    }
+
+    #[test]
+    fn inject_auto_keep_appends_one() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-1");
+    }
+
+    #[test]
+    fn inject_auto_reject_appends_zero() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_REJECT),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-0");
+    }
+
+    #[test]
+    fn inject_user_keep_appends_debug() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["b3"], "80f198ee56343ba8-00f067aa0ba902b7-d");
+    }
+
+    #[test]
+    fn inject_128_bit_trace_id_emits_32_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128,
+            span_id: 0xe457_b5a2_e4d8_6bd1,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(
+            carrier["b3"],
+            "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d"
+        );
+    }
+
+    #[test]
+    fn propagator_dispatch_routes_to_b3_single() {
+        let carrier = carrier_with("80f198ee56343ba8-00f067aa0ba902b7-1");
+        let propagator = TracePropagationStyle::B3SingleHeader;
+        let ctx = propagator
+            .extract(&carrier, &Config::builder().build())
+            .expect("b3 single-header dispatch should produce context");
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+    }
+
+    #[test]
+    fn propagator_dispatch_exposes_keys() {
+        let propagator = TracePropagationStyle::B3SingleHeader;
+        let k: &[String] = <TracePropagationStyle as Propagator<Config>>::keys(&propagator);
+        assert_eq!(k, &["b3".to_string()]);
+    }
+}

--- a/datadog-opentelemetry/src/propagation/b3multi.rs
+++ b/datadog-opentelemetry/src/propagation/b3multi.rs
@@ -1,0 +1,356 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! B3 multi-header trace context propagation.
+//!
+//! Implements the [B3 multiple-header propagation format] used by Zipkin and
+//! compatible tracers. Trace and span ids are exchanged via separate headers,
+//! with sampling expressed through `X-B3-Sampled` (accept/deny) or
+//! `X-B3-Flags` (debug ≡ keep).
+//!
+//! Behavior matches the Python tracer's `_B3MultiHeader` so that traces
+//! propagated through a Datadog-rust process keep the same wire-level
+//! semantics as the other Datadog tracers.
+//!
+//! [B3 multiple-header propagation format]: https://github.com/openzipkin/b3-propagation#multiple-headers
+
+use std::sync::LazyLock;
+
+use crate::core::sampling::{priority, SamplingPriority};
+use crate::dd_warn;
+use crate::propagation::{
+    carrier::{Extractor, Injector},
+    context::{InjectSpanContext, Sampling, SpanContext},
+};
+
+/// B3 trace ID header. Lower-hex, 16 or 32 chars.
+pub const B3_TRACE_ID_KEY: &str = "x-b3-traceid";
+/// B3 span ID header. Lower-hex, 16 chars.
+pub const B3_SPAN_ID_KEY: &str = "x-b3-spanid";
+/// B3 sampled header. `0` = deny, `1` = accept; any other value defers.
+pub const B3_SAMPLED_KEY: &str = "x-b3-sampled";
+/// B3 flags header. `1` = debug (treated as keep with highest priority).
+pub const B3_FLAGS_KEY: &str = "x-b3-flags";
+
+static B3_HEADER_KEYS: LazyLock<[String; 4]> = LazyLock::new(|| {
+    [
+        B3_TRACE_ID_KEY.to_owned(),
+        B3_SPAN_ID_KEY.to_owned(),
+        B3_SAMPLED_KEY.to_owned(),
+        B3_FLAGS_KEY.to_owned(),
+    ]
+});
+
+/// Extract trace context from a carrier using B3 multi-headers.
+///
+/// Returns `None` when the carrier lacks a `x-b3-traceid` header, the trace
+/// id cannot be parsed as a non-zero hex integer, or a present span id
+/// header is malformed. A missing or zero span id is accepted and recorded
+/// as `0`, matching how the Datadog propagator handles missing parent ids.
+pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
+    let trace_id_hex = carrier.get(B3_TRACE_ID_KEY)?;
+    let trace_id = parse_trace_id(trace_id_hex)?;
+
+    let span_id = match carrier.get(B3_SPAN_ID_KEY) {
+        Some(hex) => parse_span_id(hex)?,
+        None => 0,
+    };
+
+    let priority = extract_priority(carrier);
+
+    Some(SpanContext {
+        trace_id,
+        span_id,
+        sampling: Sampling {
+            priority,
+            mechanism: None,
+        },
+        origin: None,
+        tags: std::collections::HashMap::new(),
+        links: Vec::new(),
+        is_remote: true,
+        tracestate: None,
+    })
+}
+
+/// Inject trace context into a carrier using B3 multi-headers.
+pub fn inject(context: &InjectSpanContext, carrier: &mut dyn Injector) {
+    carrier.set(B3_TRACE_ID_KEY, format_b3_trace_id(context.trace_id));
+    carrier.set(B3_SPAN_ID_KEY, format!("{:016x}", context.span_id));
+
+    let Some(priority) = context.sampling.priority else {
+        return;
+    };
+    let p = priority.into_i8();
+    if p <= 0 {
+        carrier.set(B3_SAMPLED_KEY, "0".to_string());
+    } else if p == 1 {
+        carrier.set(B3_SAMPLED_KEY, "1".to_string());
+    } else {
+        carrier.set(B3_FLAGS_KEY, "1".to_string());
+    }
+}
+
+/// Returns the header keys used by B3 multi-header propagation.
+pub fn keys() -> &'static [String] {
+    B3_HEADER_KEYS.as_slice()
+}
+
+fn parse_trace_id(hex: &str) -> Option<u128> {
+    let id = match u128::from_str_radix(hex, 16) {
+        Ok(id) => id,
+        Err(e) => {
+            dd_warn!("Propagator (b3multi): malformed trace_id {hex:?}: {e}");
+            return None;
+        }
+    };
+    if id == 0 {
+        return None;
+    }
+    Some(id)
+}
+
+/// Parses a B3 span id. Returns `None` only on a hex-parse failure; an
+/// explicit `0` value is accepted and returned as `Some(0)` so the caller
+/// can distinguish "malformed" (reject the context) from "zero / no parent"
+/// (accept the context with span_id 0).
+fn parse_span_id(hex: &str) -> Option<u64> {
+    match u64::from_str_radix(hex, 16) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            dd_warn!("Propagator (b3multi): malformed span_id {hex:?}: {e}");
+            None
+        }
+    }
+}
+
+fn extract_priority(carrier: &dyn Extractor) -> Option<SamplingPriority> {
+    // `X-B3-Flags: 1` (debug) always takes precedence per the Python tracer.
+    if carrier.get(B3_FLAGS_KEY) == Some("1") {
+        return Some(priority::USER_KEEP);
+    }
+    match carrier.get(B3_SAMPLED_KEY) {
+        Some("0") => Some(priority::AUTO_REJECT),
+        Some("1") => Some(priority::AUTO_KEEP),
+        _ => None,
+    }
+}
+
+fn format_b3_trace_id(trace_id: u128) -> String {
+    if trace_id > u64::MAX as u128 {
+        format!("{trace_id:032x}")
+    } else {
+        format!("{trace_id:016x}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::core::configuration::{Config, TracePropagationStyle};
+    use crate::core::sampling::priority;
+    use crate::propagation::{context::span_context_to_inject, Propagator};
+
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn extract_missing_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-sampled", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_64_bit_trace_id() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "00f067aa0ba902b7"),
+            ("x-b3-sampled", "1"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+        assert_eq!(ctx.span_id, 0x00f0_67aa_0ba9_02b7);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_KEEP));
+        assert!(ctx.is_remote);
+    }
+
+    #[test]
+    fn extract_128_bit_trace_id() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7"),
+            ("x-b3-spanid", "e457b5a2e4d86bd1"),
+            ("x-b3-sampled", "0"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128);
+        assert_eq!(ctx.span_id, 0xe457_b5a2_e4d8_6bd1);
+        assert_eq!(ctx.sampling.priority, Some(priority::AUTO_REJECT));
+    }
+
+    #[test]
+    fn extract_zero_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-traceid", "0000000000000000"), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_malformed_trace_id_returns_none() {
+        let carrier = headers(&[("x-b3-traceid", "nothex"), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_missing_span_id_yields_zero() {
+        let carrier = headers(&[("x-b3-traceid", "80f198ee56343ba8")]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn extract_zero_span_id_yields_zero() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "0000000000000000"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.span_id, 0);
+    }
+
+    #[test]
+    fn extract_malformed_span_id_rejects_context() {
+        // A valid trace id paired with a garbage span id must reject the
+        // whole context — silently dropping a malformed span id to 0 could
+        // let a bogus b3 context override later, valid propagation headers.
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "nothex"),
+        ]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_flags_debug_promotes_to_user_keep() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "1"),
+            ("x-b3-sampled", "0"),
+            ("x-b3-flags", "1"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.sampling.priority, Some(priority::USER_KEEP));
+    }
+
+    #[test]
+    fn extract_unknown_sampled_value_defers_priority() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-sampled", "maybe"),
+        ]);
+        let ctx = extract(&carrier).unwrap();
+        assert_eq!(ctx.sampling.priority, None);
+    }
+
+    #[test]
+    fn inject_64_bit_trace_id_emits_16_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8,
+            span_id: 0x00f0_67aa_0ba9_02b7,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["x-b3-traceid"], "80f198ee56343ba8");
+        assert_eq!(carrier["x-b3-spanid"], "00f067aa0ba902b7");
+        assert_eq!(carrier["x-b3-sampled"], "1");
+        assert!(!carrier.contains_key("x-b3-flags"));
+    }
+
+    #[test]
+    fn inject_128_bit_trace_id_emits_32_hex() {
+        let mut ctx = SpanContext {
+            trace_id: 0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128,
+            span_id: 0xe457_b5a2_e4d8_6bd1,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_REJECT),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier["x-b3-traceid"], "80f198ee56343ba864fe8b2a57d3eff7");
+        assert_eq!(carrier["x-b3-spanid"], "e457b5a2e4d86bd1");
+        assert_eq!(carrier["x-b3-sampled"], "0");
+    }
+
+    #[test]
+    fn inject_user_keep_emits_flags_not_sampled() {
+        let mut ctx = SpanContext {
+            trace_id: 1,
+            span_id: 2,
+            sampling: Sampling {
+                priority: Some(priority::USER_KEEP),
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert_eq!(carrier.get("x-b3-flags").map(String::as_str), Some("1"));
+        assert!(!carrier.contains_key("x-b3-sampled"));
+    }
+
+    #[test]
+    fn inject_without_priority_omits_sampled_and_flags() {
+        let mut ctx = SpanContext {
+            trace_id: 1,
+            span_id: 2,
+            sampling: Sampling {
+                priority: None,
+                mechanism: None,
+            },
+            ..Default::default()
+        };
+        let mut carrier = HashMap::new();
+        inject(&span_context_to_inject(&mut ctx), &mut carrier);
+        assert!(!carrier.contains_key("x-b3-sampled"));
+        assert!(!carrier.contains_key("x-b3-flags"));
+    }
+
+    #[test]
+    fn propagator_dispatch_routes_to_b3multi() {
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", "1"),
+            ("x-b3-sampled", "1"),
+        ]);
+        let propagator = TracePropagationStyle::B3Multi;
+        let ctx = propagator
+            .extract(&carrier, &Config::builder().build())
+            .expect("b3multi dispatch should produce context");
+        assert_eq!(ctx.trace_id, 0x80f1_98ee_5634_3ba8);
+    }
+
+    #[test]
+    fn propagator_dispatch_exposes_keys() {
+        let propagator = TracePropagationStyle::B3Multi;
+        let k: &[String] = <TracePropagationStyle as Propagator<Config>>::keys(&propagator);
+        assert_eq!(k.len(), 4);
+        assert!(k.iter().any(|s| s == "x-b3-traceid"));
+        assert!(k.iter().any(|s| s == "x-b3-spanid"));
+        assert!(k.iter().any(|s| s == "x-b3-sampled"));
+        assert!(k.iter().any(|s| s == "x-b3-flags"));
+    }
+}

--- a/datadog-opentelemetry/src/propagation/b3multi.rs
+++ b/datadog-opentelemetry/src/propagation/b3multi.rs
@@ -47,6 +47,15 @@ static B3_HEADER_KEYS: LazyLock<[String; 4]> = LazyLock::new(|| {
 /// id cannot be parsed as a non-zero hex integer, or a present span id
 /// header is malformed. A missing or zero span id is accepted and recorded
 /// as `0`, matching how the Datadog propagator handles missing parent ids.
+///
+/// Sampling-only requests (only `x-b3-sampled` / `x-b3-flags` present, no
+/// `x-b3-traceid`) drop here. This matches dd-trace-py's `_B3MultiHeader`
+/// but diverges from dd-trace-java, which preserves the sampling state in
+/// the same way it does for the single-header form. Java is the more
+/// spec-correct side (the B3 spec allows `X-B3-Sampled` to stand alone).
+/// Aligning with java is tracked in APMSP-3579 alongside the cross-language
+/// system-tests; it is blocked on APMSP-3578 (resolve_contexts zero-trace
+/// primary fix) because the change widens that bug's surface area.
 pub fn extract(carrier: &dyn Extractor) -> Option<SpanContext> {
     let trace_id_hex = carrier.get(B3_TRACE_ID_KEY)?;
     let trace_id = parse_trace_id(trace_id_hex)?;
@@ -97,6 +106,13 @@ pub fn keys() -> &'static [String] {
 }
 
 fn parse_trace_id(hex: &str) -> Option<u128> {
+    // B3 spec mandates 16 or 32 hex chars; reject anything longer up front
+    // so leading-zero-padded oversized inputs (which `u128::from_str_radix`
+    // would otherwise accept) are treated as malformed.
+    if hex.len() > 32 {
+        dd_warn!("Propagator (b3multi): trace_id {hex:?} exceeds 32 hex chars");
+        return None;
+    }
     let id = match u128::from_str_radix(hex, 16) {
         Ok(id) => id,
         Err(e) => {
@@ -115,6 +131,10 @@ fn parse_trace_id(hex: &str) -> Option<u128> {
 /// can distinguish "malformed" (reject the context) from "zero / no parent"
 /// (accept the context with span_id 0).
 fn parse_span_id(hex: &str) -> Option<u64> {
+    if hex.len() > 16 {
+        dd_warn!("Propagator (b3multi): span_id {hex:?} exceeds 16 hex chars");
+        return None;
+    }
     match u64::from_str_radix(hex, 16) {
         Ok(id) => Some(id),
         Err(e) => {
@@ -204,6 +224,23 @@ mod test {
     #[test]
     fn extract_malformed_trace_id_returns_none() {
         let carrier = headers(&[("x-b3-traceid", "nothex"), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_oversized_trace_id_returns_none() {
+        let oversized = format!("{:033x}", 1u128);
+        let carrier = headers(&[("x-b3-traceid", oversized.as_str()), ("x-b3-spanid", "1")]);
+        assert_eq!(extract(&carrier), None);
+    }
+
+    #[test]
+    fn extract_oversized_span_id_returns_none() {
+        let oversized = format!("{:017x}", 1u64);
+        let carrier = headers(&[
+            ("x-b3-traceid", "80f198ee56343ba8"),
+            ("x-b3-spanid", oversized.as_str()),
+        ]);
         assert_eq!(extract(&carrier), None);
     }
 

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -14,6 +14,8 @@ use config::{get_extractors, get_injectors};
 use datadog::DATADOG_LAST_PARENT_ID_KEY;
 use tracecontext::TRACESTATE_KEY;
 
+/// B3 single-header propagation (`b3` header).
+pub mod b3;
 /// B3 multi-header propagation (`x-b3-*` headers).
 pub mod b3multi;
 /// W3C Baggage propagation (`baggage` header).

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -409,6 +409,35 @@ pub(crate) mod tests {
         ])
     });
 
+    // B3 Headers — deliberately distinct trace ids from the Datadog and
+    // TraceContext fixtures so cross-style span-link tests can tell which
+    // propagator produced which context.
+    const B3_MULTI_TRACE_ID: u128 = 0x1234_5678_90ab_cdef_1234_5678_90ab_cdefu128;
+    const B3_MULTI_TRACE_ID_HEX: &str = "1234567890abcdef1234567890abcdef";
+    const B3_MULTI_SPAN_ID: u64 = 0xfedc_ba98_7654_3210;
+    const B3_MULTI_SPAN_ID_HEX: &str = "fedcba9876543210";
+    const B3_SINGLE_TRACE_ID: u128 = 0xaabb_ccdd_eeff_0011_2233_4455_6677_8899u128;
+    const B3_SINGLE_TRACE_ID_HEX: &str = "aabbccddeeff00112233445566778899";
+    const B3_SINGLE_SPAN_ID: u64 = 0x1122_3344_5566_7788;
+    const B3_SINGLE_SPAN_ID_HEX: &str = "1122334455667788";
+
+    static VALID_B3_MULTI_HEADERS: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+        HashMap::from([
+            (
+                "x-b3-traceid".to_string(),
+                B3_MULTI_TRACE_ID_HEX.to_string(),
+            ),
+            ("x-b3-spanid".to_string(), B3_MULTI_SPAN_ID_HEX.to_string()),
+            ("x-b3-sampled".to_string(), "1".to_string()),
+        ])
+    });
+    static VALID_B3_SINGLE_HEADERS: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+        HashMap::from([(
+            "b3".to_string(),
+            format!("{B3_SINGLE_TRACE_ID_HEX}-{B3_SINGLE_SPAN_ID_HEX}-1"),
+        )])
+    });
+
     // Fixtures
     //
     static ALL_VALID_HEADERS: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
@@ -416,6 +445,12 @@ pub(crate) mod tests {
         h.extend(VALID_DATADOG_HEADERS.clone());
         h.extend(VALID_TRACECONTEXT_HEADERS.clone());
         // todo: add b3
+        h
+    });
+    static ALL_VALID_HEADERS_WITH_B3: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+        let mut h = ALL_VALID_HEADERS.clone();
+        h.extend(VALID_B3_MULTI_HEADERS.clone());
+        h.extend(VALID_B3_SINGLE_HEADERS.clone());
         h
     });
     static DATADOG_TRACECONTEXT_MATCHING_TRACE_ID_HEADERS: LazyLock<HashMap<String, String>> =
@@ -618,9 +653,51 @@ pub(crate) mod tests {
             }
         ),
         // B3 Headers
-        // todo: all of them
+        valid_b3_multi_simple: (
+            Some(vec![TracePropagationStyle::B3Multi]),
+            VALID_B3_MULTI_HEADERS.clone(),
+            SpanContext {
+                trace_id: B3_MULTI_TRACE_ID,
+                span_id: B3_MULTI_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        valid_b3_multi_no_b3_style_returns_default: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            VALID_B3_MULTI_HEADERS.clone(),
+            SpanContext::default(),
+        ),
         // B3 single Headers
-        // todo: all of them
+        valid_b3_single_simple: (
+            Some(vec![TracePropagationStyle::B3SingleHeader]),
+            VALID_B3_SINGLE_HEADERS.clone(),
+            SpanContext {
+                trace_id: B3_SINGLE_TRACE_ID,
+                span_id: B3_SINGLE_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        valid_b3_single_no_b3_style_returns_default: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            VALID_B3_SINGLE_HEADERS.clone(),
+            SpanContext::default(),
+        ),
         // All Headers
         valid_all_headers: (
             None::<Vec<TracePropagationStyle>>,
@@ -704,9 +781,69 @@ pub(crate) mod tests {
                 tracestate: None
             },
         ),
-        // todo: valid_all_headers_b3_style
-        // todo: valid_all_headers_both_b3_styles
-        // todo: valid_all_headers_b3_single_style
+        valid_all_headers_b3_style: (
+            Some(vec![TracePropagationStyle::B3Multi]),
+            ALL_VALID_HEADERS_WITH_B3.clone(),
+            SpanContext {
+                trace_id: B3_MULTI_TRACE_ID,
+                span_id: B3_MULTI_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        valid_all_headers_b3_single_style: (
+            Some(vec![TracePropagationStyle::B3SingleHeader]),
+            ALL_VALID_HEADERS_WITH_B3.clone(),
+            SpanContext {
+                trace_id: B3_SINGLE_TRACE_ID,
+                span_id: B3_SINGLE_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        valid_all_headers_both_b3_styles: (
+            Some(vec![TracePropagationStyle::B3Multi, TracePropagationStyle::B3SingleHeader]),
+            ALL_VALID_HEADERS_WITH_B3.clone(),
+            SpanContext {
+                trace_id: B3_MULTI_TRACE_ID,
+                span_id: B3_MULTI_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![
+                    SpanLink {
+                        trace_id: B3_SINGLE_TRACE_ID as u64,
+                        trace_id_high: Some((B3_SINGLE_TRACE_ID >> 64) as u64),
+                        span_id: B3_SINGLE_SPAN_ID,
+                        flags: Some(1),
+                        tracestate: None,
+                        attributes: Some(HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "b3".to_string()),
+                        ])),
+                    },
+                ],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
         none_style: (
             Some(vec![TracePropagationStyle::None]),
             ALL_VALID_HEADERS.clone(),
@@ -732,9 +869,81 @@ pub(crate) mod tests {
             }
         ),
         // Order matters
-        // todo: order_matters_b3_single_header_first
-        // todo: order_matters_b3_first
-        // todo: order_matters_b3_second_no_datadog_headers
+        order_matters_b3_first: (
+            Some(vec![TracePropagationStyle::B3Multi, TracePropagationStyle::Datadog]),
+            ALL_VALID_HEADERS_WITH_B3.clone(),
+            SpanContext {
+                trace_id: B3_MULTI_TRACE_ID,
+                span_id: B3_MULTI_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![
+                    SpanLink {
+                        trace_id: 13_088_165_645_273_925_489,
+                        trace_id_high: None,
+                        span_id: 5678,
+                        flags: Some(1),
+                        tracestate: None,
+                        attributes: Some(HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "datadog".to_string()),
+                        ])),
+                    },
+                ],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        order_matters_b3_single_header_first: (
+            Some(vec![TracePropagationStyle::B3SingleHeader, TracePropagationStyle::Datadog]),
+            ALL_VALID_HEADERS_WITH_B3.clone(),
+            SpanContext {
+                trace_id: B3_SINGLE_TRACE_ID,
+                span_id: B3_SINGLE_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![
+                    SpanLink {
+                        trace_id: 13_088_165_645_273_925_489,
+                        trace_id_high: None,
+                        span_id: 5678,
+                        flags: Some(1),
+                        tracestate: None,
+                        attributes: Some(HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "datadog".to_string()),
+                        ])),
+                    },
+                ],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
+        order_matters_b3_second_no_datadog_headers: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::B3Multi]),
+            VALID_B3_MULTI_HEADERS.clone(),
+            SpanContext {
+                trace_id: B3_MULTI_TRACE_ID,
+                span_id: B3_MULTI_SPAN_ID,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None,
+            },
+        ),
         // Tracestate is still added when TraceContext style comes later and matches
         // first style's `trace_id`
         additional_tracestate_support_when_present_and_matches_first_style_trace_id: (
@@ -1335,6 +1544,49 @@ pub(crate) mod tests {
             },
             HashMap::<String,String>::new()
         ),
+
+        inject_b3_multi_128bit_trace_id: (
+            Some(vec![TracePropagationStyle::B3Multi]),
+            &mut SpanContext {
+                trace_id: TRACE_ID,
+                span_id: 5678,
+                sampling: Sampling {
+                    priority: Some(priority::AUTO_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None
+            },
+            HashMap::from([
+                ("x-b3-traceid".to_string(), TRACE_ID_HEX.to_string()),
+                ("x-b3-spanid".to_string(), "000000000000162e".to_string()),
+                ("x-b3-sampled".to_string(), "1".to_string()),
+            ])
+        ),
+
+        inject_b3_single_128bit_trace_id: (
+            Some(vec![TracePropagationStyle::B3SingleHeader]),
+            &mut SpanContext {
+                trace_id: TRACE_ID,
+                span_id: 5678,
+                sampling: Sampling {
+                    priority: Some(priority::USER_KEEP),
+                    mechanism: None,
+                },
+                origin: None,
+                tags: HashMap::new(),
+                links: vec![],
+                is_remote: true,
+                tracestate: None
+            },
+            HashMap::from([(
+                "b3".to_string(),
+                format!("{TRACE_ID_HEX}-000000000000162e-d"),
+            )])
+        ),
     }
 
     #[test]
@@ -1388,5 +1640,28 @@ pub(crate) mod tests {
             ],
             propagator.fields()
         )
+    }
+
+    #[test]
+    fn test_b3_multi_fields() {
+        let inject = Some(vec![TracePropagationStyle::B3Multi]);
+        let config = get_config(None, inject);
+
+        let propagator = DatadogCompositePropagator::new(config);
+
+        assert_eq!(
+            vec!["x-b3-traceid", "x-b3-spanid", "x-b3-sampled", "x-b3-flags"],
+            propagator.fields()
+        )
+    }
+
+    #[test]
+    fn test_b3_single_fields() {
+        let inject = Some(vec![TracePropagationStyle::B3SingleHeader]);
+        let config = get_config(None, inject);
+
+        let propagator = DatadogCompositePropagator::new(config);
+
+        assert_eq!(vec!["b3"], propagator.fields())
     }
 }

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -14,6 +14,8 @@ use config::{get_extractors, get_injectors};
 use datadog::DATADOG_LAST_PARENT_ID_KEY;
 use tracecontext::TRACESTATE_KEY;
 
+/// B3 multi-header propagation (`x-b3-*` headers).
+pub mod b3multi;
 /// W3C Baggage propagation (`baggage` header).
 pub mod baggage;
 pub mod carrier;

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -20,6 +20,8 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::TraceContext => tracecontext::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
+            // B3 propagators are wired in subsequent changes.
+            Self::B3Multi | Self::B3SingleHeader => None,
         }
     }
 
@@ -29,6 +31,8 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::TraceContext => tracecontext::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
+            // B3 propagators are wired in subsequent changes.
+            Self::B3Multi | Self::B3SingleHeader => {}
         }
     }
 
@@ -37,7 +41,7 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None => &NONE_KEYS,
+            Self::None | Self::B3Multi | Self::B3SingleHeader => &NONE_KEYS,
         }
     }
 }

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -5,7 +5,7 @@ use crate::core::configuration::TracePropagationStyle;
 use serde::{Deserialize, Deserializer};
 
 use crate::propagation::{
-    b3multi, baggage,
+    b3, b3multi, baggage,
     carrier::{Extractor, Injector},
     context::{InjectSpanContext, SpanContext},
     datadog, tracecontext, PropagationConfig, Propagator,
@@ -19,10 +19,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::extract(carrier, config),
             Self::TraceContext => tracecontext::extract(carrier),
             Self::B3Multi => b3multi::extract(carrier),
+            Self::B3SingleHeader => b3::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
-            // The B3 single-header propagator is wired in a subsequent change.
-            Self::B3SingleHeader => None,
         }
     }
 
@@ -31,10 +30,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::inject(context, carrier, config),
             Self::TraceContext => tracecontext::inject(context, carrier),
             Self::B3Multi => b3multi::inject(context, carrier),
+            Self::B3SingleHeader => b3::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
-            // The B3 single-header propagator is wired in a subsequent change.
-            Self::B3SingleHeader => {}
         }
     }
 
@@ -43,8 +41,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
             Self::B3Multi => b3multi::keys(),
+            Self::B3SingleHeader => b3::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None | Self::B3SingleHeader => &NONE_KEYS,
+            Self::None => &NONE_KEYS,
         }
     }
 }

--- a/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
+++ b/datadog-opentelemetry/src/propagation/trace_propagation_style.rs
@@ -5,7 +5,7 @@ use crate::core::configuration::TracePropagationStyle;
 use serde::{Deserialize, Deserializer};
 
 use crate::propagation::{
-    baggage,
+    b3multi, baggage,
     carrier::{Extractor, Injector},
     context::{InjectSpanContext, SpanContext},
     datadog, tracecontext, PropagationConfig, Propagator,
@@ -18,10 +18,11 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::extract(carrier, config),
             Self::TraceContext => tracecontext::extract(carrier),
+            Self::B3Multi => b3multi::extract(carrier),
             // Baggage extraction operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => None,
-            // B3 propagators are wired in subsequent changes.
-            Self::B3Multi | Self::B3SingleHeader => None,
+            // The B3 single-header propagator is wired in a subsequent change.
+            Self::B3SingleHeader => None,
         }
     }
 
@@ -29,10 +30,11 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::inject(context, carrier, config),
             Self::TraceContext => tracecontext::inject(context, carrier),
+            Self::B3Multi => b3multi::inject(context, carrier),
             // Baggage injection operates on OTel Context and is handled by DatadogPropagator.
             Self::Baggage | Self::None => {}
-            // B3 propagators are wired in subsequent changes.
-            Self::B3Multi | Self::B3SingleHeader => {}
+            // The B3 single-header propagator is wired in a subsequent change.
+            Self::B3SingleHeader => {}
         }
     }
 
@@ -40,8 +42,9 @@ impl<C: PropagationConfig + ?Sized> Propagator<C> for TracePropagationStyle {
         match self {
             Self::Datadog => datadog::keys(),
             Self::TraceContext => tracecontext::keys(),
+            Self::B3Multi => b3multi::keys(),
             Self::Baggage => baggage::keys(),
-            Self::None | Self::B3Multi | Self::B3SingleHeader => &NONE_KEYS,
+            Self::None | Self::B3SingleHeader => &NONE_KEYS,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds full B3 trace-context propagation support to `datadog-opentelemetry`, matching the format coverage and on-wire semantics of the other Datadog tracers (Python, Go, Node). Both `b3multi` (`x-b3-*` headers) and `b3` (single header) are implemented and selectable via `DD_TRACE_PROPAGATION_STYLE` / `_EXTRACT` / `_INJECT`.

Originally split into four stacked PRs (#257–#260) for incremental review; collapsed into a single PR per reviewer request, preserving the four commits so reviewers can still walk through commit-by-commit.

## What's added

- **Enum + parsing**: `TracePropagationStyle::B3Multi` and `TracePropagationStyle::B3SingleHeader`, parseable from env vars as `b3multi` / `b3` (case-insensitive), with `Display` round-tripping to the canonical names.
- **`b3multi.rs`** — `x-b3-traceid` / `x-b3-spanid` / `x-b3-sampled` / `x-b3-flags` extract + inject + keys.
- **`b3.rs`** — single `b3: {trace_id}-{span_id}-{sampling_state}-{parent_span_id}` header, including the sampling-only form (`b3: 0/1/d`).
- **Composite propagator wiring** — both styles plug into `DatadogCompositePropagator`'s extract/inject pipeline and contribute their header keys to `fields()`.

## Semantics (mirrors dd-trace-py)

- 128-bit trace ids stay as a single `u128`. **No** `_dd.p.tid` split and **no** `_dd.parent_id` tag — those are tracecontext-specific.
- `extract` rejects (returns `None`) when the trace id is missing/malformed/zero, or when a present span id is malformed. Missing or zero span id is accepted as `0` (same convention as the Datadog propagator).
- **`b3` sampling-only forms (`b3: 0/1/d`) are preserved**: extract returns a `SpanContext` with `trace_id = 0` and the parsed priority so downstream samplers honor the upstream accept/deny/debug decision. Unknown single-token values (`b3: xyz`) are dropped.
- Sampling decode: `0 → AUTO_REJECT`, `1 → AUTO_KEEP`, `x-b3-flags: 1` or `-d` → `USER_KEEP`.
- `inject` emits 32-char hex for 128-bit ids, 16-char otherwise. Priority `> 1` emits `x-b3-flags: 1` (b3multi) or `-d` (b3 single) and suppresses `x-b3-sampled`.

## Commits

This PR is intentionally kept as four commits to keep the review story walkable:

1. **`feat(propagation): add B3Multi and B3SingleHeader variants to TracePropagationStyle`** — enum + Display + no-op dispatch (parsing deferred to the next commits).
2. **`feat(propagation): implement B3 multi-header propagator`** — `b3multi.rs` + adds `"b3multi"` to `FromStr`.
3. **`feat(propagation): implement B3 single-header propagator`** — `b3.rs` + adds `"b3"` to `FromStr`.
4. **`test(propagation): add B3 composite propagator extract/inject coverage`** — fills the `// todo: ... b3 ...` markers in `propagation/mod.rs` with cross-style conflict, ordering, span-link, and field-list tests.

## Review feedback addressed (Codex on the earlier split PRs)

- **P2: avoid letting unsupported B3 short-circuit extraction** — `FromStr` now adds `"b3multi"` / `"b3"` only alongside their working propagators (commits 2 and 3), not in the enum-only commit. Setting `DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog` + `extract_first=true` no longer regresses while parts of the stack are in flight.
- **P2: preserve sampling-only B3 decisions** — `b3: 0/1/d` returns a zero-trace `SpanContext` with the parsed priority instead of being dropped. Test: `extract_sampling_only_forms_preserve_upstream_decision`.
- **P2: reject malformed B3 span IDs** — `parse_span_id` returns `None` only on hex-parse failure; the call site early-returns when a present span id is malformed. Missing/zero span id still becomes `0`. Tests: `extract_malformed_span_id_rejects_context`, `extract_zero_span_id_yields_zero` (both b3 and b3multi).

## Test plan

- [x] `cargo test -p datadog-opentelemetry --lib propagation::` — 131/131 pass (34 new b3-specific unit tests + 13 new composite tests + 2 new fields tests).
- [x] `cargo test -p datadog-opentelemetry --lib core::configuration::configuration::tests::test_propagation_style_b3` — env-var parsing for `b3multi` and `b3` (case-insensitive), in `STYLE`, `STYLE_EXTRACT`, and `STYLE_INJECT`.
- [x] `cargo clippy -p datadog-opentelemetry --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` with the pinned `nightly-2026-04-07` — clean.

## Scope notes

Three pre-existing `// todo: add b3` markers inside `ALL_VALID_HEADERS` / `ALL_HEADERS_CHAOTIC_2` and the `datadog_primary_match_tracecontext_dif_from_b3_b3multi_invalid` marker are intentionally left in place — folding b3 headers into those shared fixtures would change the resolution outcomes of unrelated existing tests and is better as a focused follow-up.

## Docs

The user-facing documentation update lives in DataDog/documentation#37569 and is gated on this PR shipping.

## History

Supersedes the earlier stacked-PR split (#257, #258, #259, #260) which has been collapsed at reviewer request.
