### PR TITLE
feat: otel thread-level context sharing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +290,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -360,10 +384,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -553,7 +596,7 @@ dependencies = [
  "libdd-trace-utils",
  "log",
  "lru",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-appender-log",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -602,6 +645,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -689,6 +738,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1269,6 +1324,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,26 +1881,33 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-appender-log"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e50c59a96bd6a723a4329c5db31eb04fa4488c5f141ae7b9d4fd587439e6ee1"
+version = "0.32.0"
 dependencies = [
  "log",
- "opentelemetry",
+ "opentelemetry 0.32.0",
 ]
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+version = "0.32.0"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1794,25 +1915,21 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+version = "0.32.0"
 dependencies = [
  "http",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -1821,15 +1938,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+version = "0.32.0"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -1838,32 +1954,27 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+version = "0.32.0"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+version = "0.32.0"
 dependencies = [
  "chrono",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry_sdk",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+version = "0.32.1"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -1973,6 +2084,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,7 +2144,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
@@ -2078,6 +2195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2238,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2310,9 +2437,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2331,11 +2458,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2438,6 +2562,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2470,11 +2595,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2614,18 +2767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +2827,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,7 +2853,7 @@ name = "simple_tracing"
 version = "0.4.0"
 dependencies = [
  "datadog-opentelemetry",
- "opentelemetry",
+ "opentelemetry 0.32.0",
 ]
 
 [[package]]
@@ -3041,6 +3198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tools"
 version = "0.4.0"
 dependencies = [
@@ -3150,7 +3318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -3428,6 +3596,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "build_common"
+version = "36.0.0"
+dependencies = [
+ "cbindgen",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +291,25 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
+]
 
 [[package]]
 name = "cc"
@@ -590,6 +618,7 @@ dependencies = [
  "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",
+ "libdd-otel-thread-ctx",
  "libdd-sampling",
  "libdd-telemetry",
  "libdd-tinybytes",
@@ -694,6 +723,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1563,6 +1598,14 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_yaml",
+]
+
+[[package]]
+name = "libdd-otel-thread-ctx"
+version = "1.0.0"
+dependencies = [
+ "build_common",
+ "cc",
 ]
 
 [[package]]
@@ -2767,6 +2810,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,6 +3032,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3222,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -3820,6 +3924,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ opentelemetry = { path = "../opentelemetry-rust/opentelemetry", features = [
     "trace",
     "metrics",
     "logs",
+    "experimental_context_observer",
 ], default-features = false }
 opentelemetry-otlp = { path = "../opentelemetry-rust/opentelemetry-otlp", features = [
     "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,21 +35,21 @@ libdd-common = { version = "4.2.0", default-features = false }
 libdd-tinybytes = { version = "1.1.1", default-features = false }
 libdd-library-config = { version = "2.0.0", default-features = false }
 libdd-sampling = { version = "4.0.0", default-features = false }
-opentelemetry_sdk = { version = "0.31.0", features = [
+opentelemetry_sdk = { path = "../opentelemetry-rust/opentelemetry-sdk", features = [
     "trace",
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry = { version = "0.31.0", features = [
+opentelemetry = { path = "../opentelemetry-rust/opentelemetry", features = [
     "trace",
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry-otlp = { path = "../opentelemetry-rust/opentelemetry-otlp", features = [
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.31.0", features = [
+opentelemetry-semantic-conventions = { path = "../opentelemetry-rust/opentelemetry-semantic-conventions", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1.44.1" }

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -92,7 +92,7 @@ tracing-subscriber = { version = "0.3" }
 
 # Testing the logging API 
 log = { version = "0.4.21" }
-opentelemetry-appender-log = { version = "0.31.0" }
+opentelemetry-appender-log = { path = "../../opentelemetry-rust/opentelemetry-appender-log" }
 
 # Benchmarking
 criterion = "0.5.1"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -71,6 +71,9 @@ percent-encoding = "2.3.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
 libdd-library-config = { workspace = true }
+# Publisher of the per-thread OTel context TLS slot read by the Datadog eBPF profiler.
+# Linux-only; enabled through the `profiling-thread-ctx` feature.
+libdd-otel-thread-ctx = { path = "../../libdatadog-thread-ctx/libdd-otel-thread-ctx", optional = true }
 
 [dev-dependencies]
 assert_unordered = "0.3"
@@ -114,6 +117,15 @@ logs-http = [
     "opentelemetry-otlp/reqwest-blocking-client",
 ]
 _unstable_propagation = []
+# Publishes the active OTel span context into a per-thread TLS slot so out-of-process readers
+# (e.g. the Datadog eBPF profiler) can correlate CPU profiles with live traces. Linux-only; the
+# integration code is additionally gated on `#[cfg(target_os = "linux")]`. Enabling
+# `libdd-library-config/otel-thread-ctx` lets us advertise the thread-local attribute keys in the
+# published OTel process context, so readers know the process emits thread contexts.
+profiling-thread-ctx = [
+    "dep:libdd-otel-thread-ctx",
+    "libdd-library-config/otel-thread-ctx",
+]
 https = [
     "libdd-data-pipeline/https",
     "libdd-capabilities-impl/https",

--- a/datadog-opentelemetry/examples/propagator/Cargo.toml
+++ b/datadog-opentelemetry/examples/propagator/Cargo.toml
@@ -20,10 +20,10 @@ hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["full"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-opentelemetry-http = "0.31.0"
-opentelemetry-stdout = { version = "0.31.0", features = ["trace", "logs"] }
-opentelemetry-semantic-conventions = "0.31.0"
-opentelemetry-appender-tracing = "0.31.0"
+opentelemetry-http = { path = "../../../../opentelemetry-rust/opentelemetry-http" }
+opentelemetry-stdout = { path = "../../../../opentelemetry-rust/opentelemetry-stdout", features = ["trace", "logs"] }
+opentelemetry-semantic-conventions = { workspace = true }
+opentelemetry-appender-tracing = { path = "../../../../opentelemetry-rust/opentelemetry-appender-tracing" }
 
 tracing = { version = ">=0.1.40", default-features = false, features = ["std"] }
 # `tracing-core >=0.1.33` is required for compatibility with `tracing >=0.1.40`.

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1890,6 +1890,12 @@ impl Config {
             service_env: self.env().map(str::to_owned),
             service_version: self.version().map(str::to_owned),
             container_id: libdd_common::entity_id::get_container_id().map(str::to_owned),
+            // Advertise that this process publishes per-thread OTel context records. An empty list
+            // means we only emit the implicit index-0 key (`datadog.local_root_span_id`); add more
+            // here if `thread_ctx` starts encoding extra attributes. `None` (the default) would
+            // tell readers we don't emit thread contexts at all.
+            #[cfg(feature = "profiling-thread-ctx")]
+            threadlocal_attribute_keys: Some(Vec::new()),
             // TODO: add the process tags. For now, we can't easily get them.
             ..Default::default()
         }

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -304,6 +304,8 @@ mod telemetry_logs_exporter;
 #[cfg(any(feature = "metrics-grpc", feature = "metrics-http"))]
 mod telemetry_metrics_exporter;
 mod text_map_propagator;
+#[cfg(all(target_os = "linux", feature = "profiling-thread-ctx"))]
+mod thread_ctx;
 mod trace_id;
 
 use std::sync::{Arc, RwLock};
@@ -525,6 +527,12 @@ fn make_tracer(
 ) -> (SdkTracerProvider, DatadogPropagator) {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let registry = TraceRegistry::new(config.clone());
+
+        // Publish the active span context into the per-thread TLS slot so out-of-process readers
+        // (e.g. the Datadog eBPF profiler) can correlate CPU profiles with live traces.
+        #[cfg(all(target_os = "linux", feature = "profiling-thread-ctx"))]
+        crate::thread_ctx::install_observer(registry.clone());
+
         let resource_slot = Arc::new(RwLock::new(Resource::builder_empty().build()));
         // Sampler only needs config for initialization (reads initial sampling rules)
         // Runtime updates come via config callback, so no need for shared config

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -77,13 +77,13 @@ impl ShouldSample for Sampler {
         span_kind: &opentelemetry::trace::SpanKind,
         attributes: &[opentelemetry::KeyValue],
         _links: &[opentelemetry::trace::Link],
-    ) -> opentelemetry::trace::SamplingResult {
+    ) -> opentelemetry_sdk::trace::SamplingResult {
         // If the library has been disabled, we make every span take a Drop decision
         // This way they will not store any data (attributes, name, errors, ...) and will not be
         // passed to span processors
         if !self.cfg.enabled() {
-            return opentelemetry::trace::SamplingResult {
-                decision: opentelemetry::trace::SamplingDecision::Drop,
+            return opentelemetry_sdk::trace::SamplingResult {
+                decision: opentelemetry_sdk::trace::SamplingDecision::Drop,
                 attributes: vec![],
                 trace_state: TraceState::NONE,
             };
@@ -174,15 +174,15 @@ impl ShouldSample for Sampler {
                     trace_propagation_data,
                 ) {
                     RegisterTracePropagationResult::Existing(sampling_decision) => {
-                        return opentelemetry::trace::SamplingResult {
+                        return opentelemetry_sdk::trace::SamplingResult {
                             // If at this point the sampling decision is still None, we will
                             // end up sending the span to the agent without a sampling priority,
                             // which will later take a decision.
                             // So the span is marked as RecordAndSample because we treat it as such
                             decision: if sampling_decision.priority.is_none_or(|p| p.is_keep()) {
-                                opentelemetry::trace::SamplingDecision::RecordAndSample
+                                opentelemetry_sdk::trace::SamplingDecision::RecordAndSample
                             } else {
-                                opentelemetry::trace::SamplingDecision::RecordOnly
+                                opentelemetry_sdk::trace::SamplingDecision::RecordOnly
                             },
                             attributes: Vec::new(),
                             trace_state: parent_context
@@ -195,7 +195,7 @@ impl ShouldSample for Sampler {
             }
         }
 
-        opentelemetry::trace::SamplingResult {
+        opentelemetry_sdk::trace::SamplingResult {
             decision: crate::sampling::otel_mappings::priority_to_otel_decision(
                 result.get_priority(),
             ),
@@ -214,10 +214,10 @@ mod tests {
     use super::*;
     use crate::core::configuration::SamplingRuleConfig;
     use opentelemetry::{
-        trace::{SamplingDecision, SpanContext, SpanKind, TraceId, TraceState},
+        trace::{SpanContext, SpanKind, TraceId, TraceState},
         Context, SpanId, TraceFlags,
     };
-    use opentelemetry_sdk::trace::ShouldSample;
+    use opentelemetry_sdk::trace::{SamplingDecision, ShouldSample};
     use std::collections::HashMap;
 
     #[test]

--- a/datadog-opentelemetry/src/sampling/otel_mappings.rs
+++ b/datadog-opentelemetry/src/sampling/otel_mappings.rs
@@ -295,11 +295,11 @@ impl crate::sampling::AttributeFactory for OtelAttributeFactory {
 /// - `RecordOnly` if the priority indicates the trace should be dropped
 pub(crate) fn priority_to_otel_decision(
     priority: crate::core::sampling::SamplingPriority,
-) -> opentelemetry::trace::SamplingDecision {
+) -> opentelemetry_sdk::trace::SamplingDecision {
     if priority.is_keep() {
-        opentelemetry::trace::SamplingDecision::RecordAndSample
+        opentelemetry_sdk::trace::SamplingDecision::RecordAndSample
     } else {
-        opentelemetry::trace::SamplingDecision::RecordOnly
+        opentelemetry_sdk::trace::SamplingDecision::RecordOnly
     }
 }
 

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -146,6 +146,20 @@ impl InnerTraceRegistry {
         }
     }
 
+    /// Look up the local root span ID for a given trace ID, if it has been registered.
+    ///
+    /// Returns `None` if the trace is unknown or its root span ID has not been set yet (the
+    /// sentinel `[0; 8]` value).
+    #[cfg(all(target_os = "linux", feature = "profiling-thread-ctx"))]
+    fn get_local_root_span_id(&self, trace_id: [u8; 16]) -> Option<[u8; 8]> {
+        let trace = self.registry.get(&trace_id)?;
+        if trace.local_root_span_id == [0u8; 8] {
+            None
+        } else {
+            Some(trace.local_root_span_id)
+        }
+    }
+
     /// Register a new trace with the given trace ID and span ID.
     /// If the trace is already registered, increment the open span count.
     /// If the trace is not registered, create a new entry with the given trace ID
@@ -327,6 +341,17 @@ impl TraceRegistry {
             .write()
             .expect("Failed to acquire lock on trace registry");
         inner.register_local_root_span(trace_id, root_span_id);
+    }
+
+    /// Look up the local root span ID for a given trace ID.
+    ///
+    /// Returns `None` if the trace is unknown or its root span ID has not been set yet.
+    #[cfg(all(target_os = "linux", feature = "profiling-thread-ctx"))]
+    pub(crate) fn get_local_root_span_id(&self, trace_id: [u8; 16]) -> Option<[u8; 8]> {
+        self.get_shard(trace_id)
+            .read()
+            .expect("Failed to acquire lock on trace registry")
+            .get_local_root_span_id(trace_id)
     }
 
     /// Register a new span with the given trace ID and span ID.

--- a/datadog-opentelemetry/src/thread_ctx.rs
+++ b/datadog-opentelemetry/src/thread_ctx.rs
@@ -1,0 +1,139 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-thread OTel context publishing for the eBPF profiler.
+//!
+//! This module keeps the per-thread `otel_thread_ctx_v1` TLS slot (defined in [OTEP #4947]) in sync
+//! with the OTel span that is currently active on each thread. An out-of-process reader such as the
+//! Datadog eBPF profiler can then correlate CPU profiles with live traces without any in-process
+//! instrumentation beyond SDK initialization.
+//!
+//! The integration hooks into the [`ContextObserver`] extension of `opentelemetry`, which fires a
+//! callback on every context push/pop (i.e. every [`ContextGuard`] enter/exit). On each switch we
+//! publish the destination context's pre-built record into the TLS slot, or detach the slot when
+//! the destination has no active span.
+//!
+//! The whole module is Linux-only and gated behind the `profiling-thread-ctx` feature.
+//!
+//! [OTEP #4947]: https://github.com/open-telemetry/opentelemetry-specification/pull/4947
+//! [`ContextGuard`]: opentelemetry::ContextGuard
+
+use std::any::Any;
+use std::sync::Arc;
+
+use libdd_otel_thread_ctx::linux::{SharedThreadContext, ThreadContext};
+use opentelemetry::{
+    context::{ContextObserver, GlobalContextObserver, ObserverContextView},
+    trace::TraceContextExt,
+    Context,
+};
+
+use crate::span_processor::TraceRegistry;
+
+/// Observer-side view of an OTel [`Context`], cached in the context's `observer_cx_view` slot.
+///
+/// It is a transparent newtype over a pre-built, immutable [`ThreadContext`]. `observer_cx_view`
+/// already stores the view behind an `Arc`, so wrapping the record directly (rather than holding
+/// an inner `Arc<ThreadContext>`) means a single heap allocation per [`Context`] value: that same
+/// allocation is reused as the [`SharedThreadContext`] published to the TLS slot (see
+/// [`view_thread_ctx`]).
+///
+/// On every context switch the `Arc` is cloned (a single atomic increment) and its record pointer
+/// is swapped into the thread's TLS slot — no trace/span data is copied on the hot path. The
+/// record is built at most once per [`Context`] value, on the first `on_context_enter`, and reused
+/// on every subsequent re-entry into the same context value.
+#[repr(transparent)]
+struct DatadogContextView(ThreadContext);
+
+impl ObserverContextView for DatadogContextView {}
+
+/// The Datadog [`ContextObserver`]. Publishes the active span context to the TLS slot on every
+/// context enter/exit.
+struct DatadogContextObserver {
+    registry: TraceRegistry,
+}
+
+impl DatadogContextObserver {
+    fn new(registry: TraceRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+/// Returns the `Arc<ThreadContext>` to attach for `cx`, building and caching it in the context's
+/// `observer_cx_view` slot on first use. Returns `None` when `cx` has no valid span — in that case
+/// the caller should detach the TLS slot.
+fn view_thread_ctx(cx: &Context, registry: &TraceRegistry) -> Option<Arc<ThreadContext>> {
+    let span = cx.span();
+    let span_ctx = span.span_context();
+    if !span_ctx.is_valid() {
+        return None;
+    }
+    let trace_id = span_ctx.trace_id().to_bytes();
+    let span_id = span_ctx.span_id().to_bytes();
+
+    let view = cx.observer_cx_view().get_or_init(|| {
+        // If the local root span isn't registered yet (e.g. a freshly extracted remote context,
+        // before the first local child span starts), fall back to the current span id. The next
+        // context enter for the first local span will carry the correct local root span id.
+        let local_root_span_id = registry.get_local_root_span_id(trace_id).unwrap_or(span_id);
+        let view: Arc<dyn ObserverContextView> = Arc::new(DatadogContextView(ThreadContext::new(
+            trace_id,
+            span_id,
+            local_root_span_id,
+            &[],
+        )));
+        view
+    });
+
+    // `view` is an `Arc<dyn ObserverContextView>`. Confirm it really points at our concrete type
+    // before reinterpreting the allocation. This is always the case once the observer is installed
+    // (we are the sole writer of this slot), but the check is cheap and keeps the cast honest.
+    (view.as_ref() as &dyn Any).downcast_ref::<DatadogContextView>()?;
+
+    // Reuse the view's own allocation as the `Arc<ThreadContext>` to attach, avoiding a second
+    // allocation. Cloning bumps the strong count to balance the reference we hand out.
+    //
+    // SAFETY: the slot holds a `DatadogContextView` (checked above), which is `#[repr(transparent)]`
+    // over `ThreadContext`. The two therefore have identical size and alignment, so the `Arc`
+    // refcount header lives at the same offset and `Arc::<ThreadContext>::from_raw` reclaims the
+    // very allocation `Arc::into_raw` produced. Casting the `dyn ObserverContextView` fat pointer
+    // to a thin `*const ThreadContext` yields the record's data address.
+    let record = Arc::into_raw(Arc::clone(view)) as *const ThreadContext;
+    Some(unsafe { Arc::from_raw(record) })
+}
+
+/// Publish (or detach) the TLS slot to reflect `cx`'s active span.
+fn publish(cx: &Context, registry: &TraceRegistry) {
+    match view_thread_ctx(cx, registry) {
+        // Cloning the `Arc` bumps the refcount; `attach` moves that reference into the TLS slot
+        // and returns the previously attached context, which we drop immediately (decrementing the
+        // outgoing context's refcount — its cached `DatadogContextView` keeps the record alive).
+        Some(thread_ctx) => {
+            let _ = SharedThreadContext::from(thread_ctx).attach();
+        }
+        // No active span in the destination context → clear the slot.
+        None => {
+            let _ = SharedThreadContext::detach();
+        }
+    }
+}
+
+impl ContextObserver for DatadogContextObserver {
+    fn on_context_enter(&self, _from: &Context, to: &Context) {
+        publish(to, &self.registry);
+    }
+
+    fn on_context_exit(&self, _from: &Context, to: &Context) {
+        // On exit, `to` is the outer context we are returning to: restore its span (or detach).
+        publish(to, &self.registry);
+    }
+}
+
+/// Register the Datadog context observer globally.
+///
+/// Must be called once, during SDK initialization, before any span is started. Because
+/// [`GlobalContextObserver`] is backed by a `OnceLock`, subsequent calls are silently ignored
+/// (with an `opentelemetry` warning log).
+pub(crate) fn install_observer(registry: TraceRegistry) {
+    GlobalContextObserver::set(Arc::new(DatadogContextObserver::new(registry)));
+}


### PR DESCRIPTION
# What does this PR do?

This PR publishes the current opentelemetry-rust context as an [OTel thread-level context](https://github.com/open-telemetry/opentelemetry-specification/pull/4947) as well. The changes rely for now of yet unmerged changes in opentelemetry-rust and libdatadog.

Since the patch to opentelemetry-rust was developed from a recent version, there's also a bit of unrelated boilerplate changes corresponding to upgrading to the latest opentelemetry-rust.

# Motivation

Adding support for the thread-context level OTEP will enhance the eBPF full host profiler with contexts.

# Additional Notes
