### PR TITLE
chore(deps): upgrade opentelemetry to 0.32

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -180,5 +180,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: f2c6cc393bcd996357259ac991c8a6ba1f59177d # main
+      ref: igor/rust/bump-otel-0.32
       push_to_test_optimization: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -180,5 +180,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 271863c89eb498754525cc8a7f59f46868a729e4
+      ref: 271863c89eb498754525cc8a7f59f46868a729e4 # main
       push_to_test_optimization: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -171,7 +171,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@f2c6cc393bcd996357259ac991c8a6ba1f59177d  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@271863c89eb498754525cc8a7f59f46868a729e4  # main
     permissions:
       contents: read
       id-token: write
@@ -180,5 +180,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: igor/rust/bump-otel-0.32
+      ref: 271863c89eb498754525cc8a7f59f46868a729e4
       push_to_test_optimization: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +290,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -360,10 +384,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -604,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +738,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1269,6 +1324,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,9 +1872,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1772,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-log"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e50c59a96bd6a723a4329c5db31eb04fa4488c5f141ae7b9d4fd587439e6ee1"
+checksum = "d7b6863c2e4f280ace0924dce400d46b12c6ff76a720cf6d2c5847ca820e460d"
 dependencies = [
  "log",
  "opentelemetry",
@@ -1782,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -1794,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1807,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1821,13 +1935,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1838,15 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -1855,15 +1970,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -1973,6 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,6 +2200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2243,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2310,9 +2442,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2331,11 +2463,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2438,6 +2567,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2470,11 +2600,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2614,18 +2772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2830,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3041,6 +3203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tools"
 version = "0.4.0"
 dependencies = [
@@ -3145,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -3428,6 +3601,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,21 +35,21 @@ libdd-common = { version = "4.2.0", default-features = false }
 libdd-tinybytes = { version = "1.1.1", default-features = false }
 libdd-library-config = { version = "2.0.0", default-features = false }
 libdd-sampling = { version = "4.0.0", default-features = false }
-opentelemetry_sdk = { version = "0.31.0", features = [
+opentelemetry_sdk = { version = "0.32.0", features = [
     "trace",
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry = { version = "0.31.0", features = [
+opentelemetry = { version = "0.32.0", features = [
     "trace",
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry-otlp = { version = "0.32.0", features = [
     "metrics",
     "logs",
 ], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.31.0", features = [
+opentelemetry-semantic-conventions = { version = "0.32.0", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1.44.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ libdd-common = { version = "4.2.0", default-features = false }
 libdd-tinybytes = { version = "1.1.1", default-features = false }
 libdd-library-config = { version = "2.0.0", default-features = false }
 libdd-sampling = { version = "4.0.0", default-features = false }
-opentelemetry_sdk = { version = "0.32.0", features = [
+opentelemetry_sdk = { version = "0.32.1", features = [
     "trace",
     "metrics",
     "logs",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -15,6 +15,8 @@ async-lock,https://github.com/smol-rs/async-lock,Apache-2.0 OR MIT,Stjepan Glavi
 async-object-pool,https://github.com/alexliesenfeld/async-object-pool,MIT,Alexander Liesenfeld <alexander.liesenfeld@outlook.com>
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
+aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
+aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0),AWS-LC
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
@@ -39,6 +41,7 @@ clap_builder,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_builder 
 clap_derive,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_derive Authors
 clap_lex,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_lex Authors
 colorchoice,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The colorchoice Authors
+combine,https://github.com/Marwes/combine,MIT,Markus Westerlind <marwes91@gmail.com>
 concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>"
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
@@ -114,6 +117,11 @@ is-terminal,https://github.com/sunfishcode/is-terminal,MIT,"softprops <d.tangren
 is_terminal_polyfill,https://github.com/polyfill-rs/is_terminal_polyfill,MIT OR Apache-2.0,The is_terminal_polyfill Authors
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+jni,https://github.com/jni-rs/jni-rs,MIT OR Apache-2.0,jni team
+jni-macros,https://github.com/jni-rs/jni-rs,MIT OR Apache-2.0,The jni-macros Authors
+jni-sys,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Robert Bragg <robert@sixbynine.org>"
+jni-sys-macros,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,Robert Bragg <robert@sixbynine.org>
+jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 konst,https://github.com/rodrimati1992/konst,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 konst_macro_rules,https://github.com/rodrimati1992/konst,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
@@ -174,12 +182,14 @@ pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,T
 plotters,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
 plotters-backend,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
 plotters-svg,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 prost,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
 prost-derive,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-types,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
 quick-xml,https://github.com/tafia/quick-xml,MIT,The quick-xml Authors
 quinn,https://github.com/quinn-rs/quinn,MIT OR Apache-2.0,The quinn Authors
 quinn-proto,https://github.com/quinn-rs/quinn,MIT OR Apache-2.0,The quinn-proto Authors
@@ -210,6 +220,8 @@ rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception
 rustls,https://github.com/rustls/rustls,Apache-2.0 OR ISC OR MIT,The rustls Authors
 rustls-native-certs,https://github.com/rustls/rustls-native-certs,Apache-2.0 OR ISC OR MIT,The rustls-native-certs Authors
 rustls-pki-types,https://github.com/rustls/pki-types,MIT OR Apache-2.0,The rustls-pki-types Authors
+rustls-platform-verifier,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier Authors
+rustls-platform-verifier-android,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier-android Authors
 rustls-webpki,https://github.com/rustls/webpki,ISC,The rustls-webpki Authors
 rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
@@ -225,13 +237,14 @@ serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar 
 serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_regex,https://github.com/tailhook/serde-regex,MIT OR Apache-2.0,paul@colomiets.name
-serde_urlencoded,https://github.com/nox/serde_urlencoded,MIT OR Apache-2.0,Anthony Ramine <n.oxyde@gmail.com>
 serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
 signal-hook-registry,https://github.com/vorner/signal-hook,MIT OR Apache-2.0,"Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>"
+simd_cesu8,https://github.com/seancroach/simd_cesu8,Apache-2.0 OR MIT,Sean C. Roach <me@seancroach.dev>
+simdutf8,https://github.com/rusticstuff/simdutf8,MIT OR Apache-2.0,Hans Kratz <hans@appfour.com>
 similar,https://github.com/mitsuhiko/similar,Apache-2.0,"Armin Ronacher <armin.ronacher@active-4.com>, Pierre-Étienne Meunier <pe@pijul.org>, Brandon Williams <bwilliams.eng@gmail.com>"
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
@@ -264,6 +277,7 @@ tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@toki
 tokio-util,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tonic,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
 tonic-prost,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
+tonic-types,https://github.com/hyperium/tonic,MIT,"Lucio Franco <luciofranco14@gmail.com>, Rafael Lemos <flemos.rafael.dev@gmail.com>"
 tower,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
 tower-http,https://github.com/tower-rs/tower-http,MIT,Tower Maintainers <team@tower-rs.com>
 tower-layer,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
@@ -302,6 +316,7 @@ wasm-metadata,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wa
 wasmparser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Yury Delendik <ydelendik@mozilla.com>
 web-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 web-time,https://github.com/daxpedda/web-time,MIT OR Apache-2.0,The web-time Authors
+webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-root-certs Authors
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ datadog-opentelemetry = { version = "0.4.0" }
 #### Tracing
 
 To trace functions, you can either use the `opentelemetry` crate's
-[API](https://docs.rs/opentelemetry/0.31.0/opentelemetry/trace/index.html) or the `tracing` crate
+[API](https://docs.rs/opentelemetry/0.32.0/opentelemetry/trace/index.html) or the `tracing` crate
 [API](https://docs.rs/tracing/0.1.44/tracing/) with the `tracing-opentelemetry`
 [bridge](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/).
 
 #### Metrics
 
 To collect metrics, use the `opentelemetry` crate's
-[Metrics API](https://docs.rs/opentelemetry/0.31.0/opentelemetry/metrics/index.html). For more
+[Metrics API](https://docs.rs/opentelemetry/0.32.0/opentelemetry/metrics/index.html). For more
 details, see the
 [Datadog OpenTelemetry Rust documentation](https://docs.datadoghq.com/opentelemetry/instrument/dd_sdks/api_support/?platform=metrics&prog_lang=rust).
 
@@ -69,7 +69,7 @@ metrics
 Requires
 
 * [`tracing-subscriber`](https://docs.rs/tracing-subscriber/0.3.22/tracing_subscriber/)
-* [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)
+* [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.33.0/tracing_opentelemetry/)
 * [`tracing`](https://docs.rs/tracing/0.1.44/tracing/)
 
 ```rust ,no_run
@@ -96,7 +96,7 @@ tracer_provider
 
 Requires
 
-* [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) with the `trace` feature
+* [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) with the `trace` feature
   enabled
 
 ```rust ,no_run
@@ -125,7 +125,7 @@ tracer_provider
 Requires
 
 * the `metrics` feature of this crate to be enabled
-* [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) with the `metrics` feature
+* [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) with the `metrics` feature
   enabled
 * [`tokio`](https://docs.rs/tokio)
 
@@ -154,7 +154,7 @@ Requires
 
 * the `logs` feature of this crate to be enabled
 * [`log`](https://docs.rs/log/0.4.29/log/)
-* [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.31.0/opentelemetry_appender_log/)
+* [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.32.0/opentelemetry_appender_log/)
 * [`tokio`](https://docs.rs/tokio)
 
 The logger provider MUST be initialized within a tokio context
@@ -231,11 +231,11 @@ datadog_opentelemetry::tracing()
 
 * MSRV: 1.87
 
-* [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) version: 0.31
-* [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)
-  version: 0.32
-* [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.31.0/opentelemetry_appender_log/)
-  version 0.31
+* [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) version: 0.32
+* [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.33.0/tracing_opentelemetry/)
+  version: 0.33
+* [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.32.0/opentelemetry_appender_log/)
+  version 0.32
 * [`log`](https://docs.rs/log/0.4.29/log/) version 0.4
 
 ## Features

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -122,6 +122,7 @@ https = [
     "libdd-common/https",
     "opentelemetry-otlp?/reqwest-rustls",
     "opentelemetry-otlp?/tls-roots",
+    "opentelemetry-otlp?/tls-ring",
 ]
 test-utils = [
     "libdd-data-pipeline/test-utils",

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -87,12 +87,12 @@ datadog-opentelemetry = { path = ".", features = ["test-utils"] }
 
 # Testing the tracing API
 tracing = { version = "0.1.4" }
-tracing-opentelemetry = { version = "0.32" }
+tracing-opentelemetry = { version = "0.33" }
 tracing-subscriber = { version = "0.3" }
 
 # Testing the logging API 
 log = { version = "0.4.21" }
-opentelemetry-appender-log = { version = "0.31.0" }
+opentelemetry-appender-log = { version = "0.32.0" }
 
 # Benchmarking
 criterion = "0.5.1"

--- a/datadog-opentelemetry/benches/otel_sampling_benchmark.rs
+++ b/datadog-opentelemetry/benches/otel_sampling_benchmark.rs
@@ -7,8 +7,8 @@ use datadog_opentelemetry::core_pub_hack::test_utils::benchmarks::{
     memory_allocated_measurement, MeasurementName, ReportingAllocator,
 };
 use datadog_opentelemetry::sampler::Sampler;
-use opentelemetry::{trace::SamplingDecision, trace::SpanKind, KeyValue, TraceId};
-use opentelemetry_sdk::trace::ShouldSample;
+use opentelemetry::{trace::SpanKind, KeyValue, TraceId};
+use opentelemetry_sdk::trace::{SamplingDecision, ShouldSample};
 use std::collections::HashMap;
 use std::hint::black_box;
 use std::sync::{Arc, RwLock};

--- a/datadog-opentelemetry/examples/propagator/Cargo.toml
+++ b/datadog-opentelemetry/examples/propagator/Cargo.toml
@@ -20,10 +20,10 @@ hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["full"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-opentelemetry-http = "0.31.0"
-opentelemetry-stdout = { version = "0.31.0", features = ["trace", "logs"] }
-opentelemetry-semantic-conventions = "0.31.0"
-opentelemetry-appender-tracing = "0.31.0"
+opentelemetry-http = "0.32.0"
+opentelemetry-stdout = { version = "0.32.0", features = ["trace", "logs"] }
+opentelemetry-semantic-conventions = "0.32.0"
+opentelemetry-appender-tracing = "0.32.0"
 
 tracing = { version = ">=0.1.40", default-features = false, features = ["std"] }
 # `tracing-core >=0.1.33` is required for compatibility with `tracing >=0.1.40`.

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -607,9 +607,20 @@ fn create_dd_resource(resource: Resource, cfg: &Config) -> Resource {
     // Collect attributes to add
     let mut attributes = Vec::new();
 
+    // The OpenTelemetry SDK falls back to a spec-defined default service name when none
+    // is configured: "unknown_service" or "unknown_service:<executable name>" (the latter
+    // since opentelemetry 0.32, which made the fallback spec-compliant). Treat either as unset.
+    let otel_service_is_default = otel_service_name
+        .as_ref()
+        .map(|name| {
+            let name = name.as_str();
+            name == "unknown_service" || name.starts_with("unknown_service:")
+        })
+        .unwrap_or(true);
+
     // Handle service name
-    if otel_service_name.is_none() || otel_service_name.unwrap().as_str() == "unknown_service" {
-        // If the OpenTelemetry service name is not set or is "unknown_service",
+    if otel_service_is_default {
+        // If the OpenTelemetry service name is not set or is the SDK default,
         // we override it with the Datadog service name.
         attributes.push((
             Key::from_static_str(SERVICE_NAME),

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -223,7 +223,7 @@
 //!
 //! * [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) version: 0.32
 //! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.33.0/tracing_opentelemetry/)
-//!   version: 0.32
+//!   version: 0.33
 //! * [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.32.0/opentelemetry_appender_log/)
 //!   version 0.32
 //! * [`log`](https://docs.rs/log/0.4.29/log/) version 0.4

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -23,11 +23,11 @@
 //!
 //! #### Tracing
 //!
-//! To trace functions, you can either use the `opentelemetry` crate's [API](https://docs.rs/opentelemetry/0.31.0/opentelemetry/trace/index.html) or the `tracing` crate [API](https://docs.rs/tracing/0.1.44/tracing/) with the `tracing-opentelemetry` [bridge](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/).
+//! To trace functions, you can either use the `opentelemetry` crate's [API](https://docs.rs/opentelemetry/0.32.0/opentelemetry/trace/index.html) or the `tracing` crate [API](https://docs.rs/tracing/0.1.44/tracing/) with the `tracing-opentelemetry` [bridge](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/).
 //!
 //! #### Metrics
 //!
-//! To collect metrics, use the `opentelemetry` crate's [Metrics API](https://docs.rs/opentelemetry/0.31.0/opentelemetry/metrics/index.html).
+//! To collect metrics, use the `opentelemetry` crate's [Metrics API](https://docs.rs/opentelemetry/0.32.0/opentelemetry/metrics/index.html).
 //! For more details, see the [Datadog OpenTelemetry Rust documentation](https://docs.datadoghq.com/opentelemetry/instrument/dd_sdks/api_support/?platform=metrics&prog_lang=rust).
 //!
 //! #### Logging
@@ -47,7 +47,7 @@
 //!
 //! Requires
 //! * [`tracing-subscriber`](https://docs.rs/tracing-subscriber/0.3.22/tracing_subscriber/)
-//! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)
+//! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.33.0/tracing_opentelemetry/)
 //! * [`tracing`](https://docs.rs/tracing/0.1.44/tracing/)
 //!
 //! ```no_run
@@ -73,7 +73,7 @@
 //! #### Opentelemetry trace API
 //!
 //! Requires
-//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) with the `trace`
+//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) with the `trace`
 //!   feature enabled
 //!
 //! ```no_run
@@ -101,7 +101,7 @@
 //!
 //! Requires
 //! * the `metrics` feature of this crate to be enabled
-//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) with the `metrics`
+//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) with the `metrics`
 //!   feature enabled
 //! * [`tokio`](https://docs.rs/tokio)
 //!
@@ -129,7 +129,7 @@
 //! Requires
 //! * the `logs` feature of this crate to be enabled
 //! * [`log`](https://docs.rs/log/0.4.29/log/)
-//! * [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.31.0/opentelemetry_appender_log/)
+//! * [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.32.0/opentelemetry_appender_log/)
 //! * [`tokio`](https://docs.rs/tokio)
 //!
 //! The logger provider MUST be initialized within a tokio context
@@ -221,11 +221,11 @@
 //!
 //! * MSRV: 1.87
 //!
-//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.31.0/opentelemetry/) version: 0.31
-//! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.32.1/tracing_opentelemetry/)
+//! * [`opentelemetry`](https://docs.rs/opentelemetry/0.32.0/opentelemetry/) version: 0.32
+//! * [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.33.0/tracing_opentelemetry/)
 //!   version: 0.32
-//! * [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.31.0/opentelemetry_appender_log/)
-//!   version 0.31
+//! * [`opentelemetry-appender-log`](https://docs.rs/opentelemetry-appender-log/0.32.0/opentelemetry_appender_log/)
+//!   version 0.32
 //! * [`log`](https://docs.rs/log/0.4.29/log/) version 0.4
 //!
 //! ## Features

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -77,13 +77,13 @@ impl ShouldSample for Sampler {
         span_kind: &opentelemetry::trace::SpanKind,
         attributes: &[opentelemetry::KeyValue],
         _links: &[opentelemetry::trace::Link],
-    ) -> opentelemetry::trace::SamplingResult {
+    ) -> opentelemetry_sdk::trace::SamplingResult {
         // If the library has been disabled, we make every span take a Drop decision
         // This way they will not store any data (attributes, name, errors, ...) and will not be
         // passed to span processors
         if !self.cfg.enabled() {
-            return opentelemetry::trace::SamplingResult {
-                decision: opentelemetry::trace::SamplingDecision::Drop,
+            return opentelemetry_sdk::trace::SamplingResult {
+                decision: opentelemetry_sdk::trace::SamplingDecision::Drop,
                 attributes: vec![],
                 trace_state: TraceState::NONE,
             };
@@ -174,15 +174,15 @@ impl ShouldSample for Sampler {
                     trace_propagation_data,
                 ) {
                     RegisterTracePropagationResult::Existing(sampling_decision) => {
-                        return opentelemetry::trace::SamplingResult {
+                        return opentelemetry_sdk::trace::SamplingResult {
                             // If at this point the sampling decision is still None, we will
                             // end up sending the span to the agent without a sampling priority,
                             // which will later take a decision.
                             // So the span is marked as RecordAndSample because we treat it as such
                             decision: if sampling_decision.priority.is_none_or(|p| p.is_keep()) {
-                                opentelemetry::trace::SamplingDecision::RecordAndSample
+                                opentelemetry_sdk::trace::SamplingDecision::RecordAndSample
                             } else {
-                                opentelemetry::trace::SamplingDecision::RecordOnly
+                                opentelemetry_sdk::trace::SamplingDecision::RecordOnly
                             },
                             attributes: Vec::new(),
                             trace_state: parent_context
@@ -195,7 +195,7 @@ impl ShouldSample for Sampler {
             }
         }
 
-        opentelemetry::trace::SamplingResult {
+        opentelemetry_sdk::trace::SamplingResult {
             decision: crate::sampling::otel_mappings::priority_to_otel_decision(
                 result.get_priority(),
             ),
@@ -214,10 +214,10 @@ mod tests {
     use super::*;
     use crate::core::configuration::SamplingRuleConfig;
     use opentelemetry::{
-        trace::{SamplingDecision, SpanContext, SpanKind, TraceId, TraceState},
+        trace::{SpanContext, SpanKind, TraceId, TraceState},
         Context, SpanId, TraceFlags,
     };
-    use opentelemetry_sdk::trace::ShouldSample;
+    use opentelemetry_sdk::trace::{SamplingDecision, ShouldSample};
     use std::collections::HashMap;
 
     #[test]

--- a/datadog-opentelemetry/src/sampling/otel_mappings.rs
+++ b/datadog-opentelemetry/src/sampling/otel_mappings.rs
@@ -295,11 +295,11 @@ impl crate::sampling::AttributeFactory for OtelAttributeFactory {
 /// - `RecordOnly` if the priority indicates the trace should be dropped
 pub(crate) fn priority_to_otel_decision(
     priority: crate::core::sampling::SamplingPriority,
-) -> opentelemetry::trace::SamplingDecision {
+) -> opentelemetry_sdk::trace::SamplingDecision {
     if priority.is_keep() {
-        opentelemetry::trace::SamplingDecision::RecordAndSample
+        opentelemetry_sdk::trace::SamplingDecision::RecordAndSample
     } else {
-        opentelemetry::trace::SamplingDecision::RecordOnly
+        opentelemetry_sdk::trace::SamplingDecision::RecordOnly
     }
 }
 

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -10,17 +10,22 @@ use datadog_opentelemetry::configuration::{
 use datadog_opentelemetry::log::LevelFilter;
 use datadog_opentelemetry::make_test_tracer;
 use opentelemetry::global::ObjectSafeSpan;
-use opentelemetry::trace::{
-    SamplingDecision, SamplingResult, SpanBuilder, TraceContextExt, TraceState, Tracer,
-    TracerProvider,
-};
+use opentelemetry::trace::{SpanBuilder, TraceContextExt, Tracer, TracerProvider};
 use opentelemetry::Context;
 
 use crate::integration_tests::{
     assert_subset, make_extractor, make_test_agent, with_test_agent_session,
 };
 
+// NOTE: This test originally used `SpanBuilder::with_sampling_result` to force a
+// per-span RecordOnly vs RecordAndSample decision and assert that only the sampled
+// span is exported. opentelemetry 0.32 removed that method — a caller can no longer
+// override the sampling decision; it is made solely by the configured Sampler.
+// Re-enabling this requires driving the Datadog sampler to deterministic keep/drop
+// decisions (e.g. via sampling rules) and regenerating the snapshot. Left ignored
+// pending that redesign.
 #[tokio::test]
+#[ignore = "with_sampling_result removed in opentelemetry 0.32; needs sampler-driven redesign + snapshot regen"]
 async fn test_received_traces() {
     const SESSION_NAME: &str = "opentelemetry_api/test_received_traces";
     with_test_agent_session(
@@ -28,23 +33,11 @@ async fn test_received_traces() {
         Config::builder(),
         |_, tracer_provider, _, _| {
             let tracer = tracer_provider.tracer("test");
-            for decision in [
-                SamplingDecision::RecordOnly,
-                SamplingDecision::RecordAndSample,
-            ] {
-                {
-                    let base_ctx = Context::new();
-                    let span = SpanBuilder::from_name("test")
-                        .with_kind(opentelemetry::trace::SpanKind::Client)
-                        .with_sampling_result(SamplingResult {
-                            decision,
-                            attributes: vec![],
-                            trace_state: TraceState::default(),
-                        })
-                        .start_with_context(&tracer, &base_ctx);
-                    drop(span)
-                };
-            }
+            let base_ctx = Context::new();
+            let span = SpanBuilder::from_name("test")
+                .with_kind(opentelemetry::trace::SpanKind::Client)
+                .start_with_context(&tracer, &base_ctx);
+            drop(span)
         },
     )
     .await;

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -17,29 +17,45 @@ use crate::integration_tests::{
     assert_subset, make_extractor, make_test_agent, with_test_agent_session,
 };
 
-// NOTE: This test originally used `SpanBuilder::with_sampling_result` to force a
-// per-span RecordOnly vs RecordAndSample decision and assert that only the sampled
-// span is exported. opentelemetry 0.32 removed that method — a caller can no longer
-// override the sampling decision; it is made solely by the configured Sampler.
-// Re-enabling this requires driving the Datadog sampler to deterministic keep/drop
-// decisions (e.g. via sampling rules) and regenerating the snapshot. Left ignored
-// pending that redesign.
+// Verify the Datadog span processor exports only the spans the sampler keeps.
+// opentelemetry 0.32 removed `SpanBuilder::with_sampling_result`, so a caller can no
+// longer force the per-span decision; we drive it deterministically with sampling
+// rules instead: a `sample_rate` of 0.0 -> drop -> `RecordOnly` (not exported) and a
+// `sample_rate` of 1.0 -> keep -> `RecordAndSample` (exported). The snapshot must
+// therefore contain only the kept span.
 #[tokio::test]
-#[ignore = "with_sampling_result removed in opentelemetry 0.32; needs sampler-driven redesign + snapshot regen"]
 async fn test_received_traces() {
     const SESSION_NAME: &str = "opentelemetry_api/test_received_traces";
-    with_test_agent_session(
-        SESSION_NAME,
-        Config::builder(),
-        |_, tracer_provider, _, _| {
-            let tracer = tracer_provider.tracer("test");
-            let base_ctx = Context::new();
-            let span = SpanBuilder::from_name("test")
-                .with_kind(opentelemetry::trace::SpanKind::Client)
-                .start_with_context(&tracer, &base_ctx);
-            drop(span)
+    let mut cfg = Config::builder();
+    cfg.set_trace_sampling_rules(vec![
+        SamplingRuleConfig {
+            resource: Some("kept-span".to_string()),
+            sample_rate: 1.0,
+            ..SamplingRuleConfig::default()
         },
-    )
+        SamplingRuleConfig {
+            resource: Some("dropped-span".to_string()),
+            sample_rate: 0.0,
+            ..SamplingRuleConfig::default()
+        },
+    ]);
+    with_test_agent_session(SESSION_NAME, cfg, |_, tracer_provider, _, _| {
+        let tracer = tracer_provider.tracer("test");
+
+        // Dropped by the sampler (RecordOnly): must NOT be exported to the agent.
+        drop(
+            SpanBuilder::from_name("dropped-span")
+                .with_kind(opentelemetry::trace::SpanKind::Client)
+                .start_with_context(&tracer, &Context::new()),
+        );
+
+        // Kept by the sampler (RecordAndSample): must be exported to the agent.
+        drop(
+            SpanBuilder::from_name("kept-span")
+                .with_kind(opentelemetry::trace::SpanKind::Client)
+                .start_with_context(&tracer, &Context::new()),
+        );
+    })
     .await;
 }
 

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
@@ -2,27 +2,28 @@
   {
     "name": "client.request",
     "service": "unnamed-rust-service",
-    "resource": "test",
+    "resource": "kept-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
     "meta": {
+      "_dd.p.dm": "-3",
+      "_dd.p.ksr": "1",
       "otel.scope.name": "test",
       "otel.status_code": "Unset",
-      "otel.trace_id": "69b987960000000076b816bfa5f386cf",
+      "otel.trace_id": "6a432ae900000000fadb9ed3e75ee6b8",
       "span.kind": "client",
-
-
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
       "telemetry.sdk.version": "0.4.0"
     },
     "metrics": {
       "_dd.measured": 1.0,
-      "_sampling_priority_v1": 1.0,
+      "_dd.rule_psr": 1.0,
+      "_sampling_priority_v1": 2.0,
       "_top_level": 1.0
     },
     "duration": 1000,
-    "start": 1773766550861045000
+    "start": 1782786793752101000
   }]]

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces_tracestats.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces_tracestats.json
@@ -5,16 +5,30 @@
     "Stats": [
       {
         "Name": "client.request",
-        "Resource": "test",
+        "Resource": "dropped-span",
         "Service": "unnamed-rust-service",
         "Type": "http",
         "HTTPStatusCode": 0,
         "Synthetics": false,
-        "Hits": 2,
-        "TopLevelHits": 2,
-        "Duration": 58000,
+        "Hits": 1,
+        "TopLevelHits": 1,
+        "Duration": 9000,
         "Errors": 0,
-        "OkSummary": 2119,
+        "OkSummary": 37,
+        "ErrorSummary": 24
+      },
+      {
+        "Name": "client.request",
+        "Resource": "kept-span",
+        "Service": "unnamed-rust-service",
+        "Type": "http",
+        "HTTPStatusCode": 0,
+        "Synthetics": false,
+        "Hits": 1,
+        "TopLevelHits": 1,
+        "Duration": 1000,
+        "Errors": 0,
+        "OkSummary": 37,
         "ErrorSummary": 24
       }
     ]

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -1458,9 +1458,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1471,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1498,13 +1498,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1515,25 +1516,25 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -1597,6 +1598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1661,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1807,9 +1823,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1825,9 +1841,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower 0.5.3",
@@ -1989,18 +2002,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2270,6 +2271,17 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
  "tonic",
 ]
 

--- a/instrumentation/Cargo.toml
+++ b/instrumentation/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 serde = "1.0.194"
 serde_json = "1.0.140"
 opentelemetry = { version = "0.32.0", features = ["trace", "metrics", "logs"], default-features = false }
-opentelemetry_sdk = { version = "0.32.0", default-features = false }
+opentelemetry_sdk = { version = "0.32.1", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.0", features = ["semconv_experimental"] }
 tracing = { version = "0.1", default-features = false }
 tokio = { version = "1.44.1" }

--- a/instrumentation/Cargo.toml
+++ b/instrumentation/Cargo.toml
@@ -17,8 +17,8 @@ publish = false
 [workspace.dependencies]
 serde = "1.0.194"
 serde_json = "1.0.140"
-opentelemetry = { version = "0.31.0", features = ["trace", "metrics", "logs"], default-features = false }
-opentelemetry_sdk = { version = "0.31.0", default-features = false }
-opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.32.0", features = ["trace", "metrics", "logs"], default-features = false }
+opentelemetry_sdk = { version = "0.32.0", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.32.0", features = ["semconv_experimental"] }
 tracing = { version = "0.1", default-features = false }
 tokio = { version = "1.44.1" }


### PR DESCRIPTION
## Summary

Upgrades the OpenTelemetry stack from **0.31 → 0.32** across the root and `instrumentation` workspaces.

- Bumped `opentelemetry`, `opentelemetry-otlp`, `opentelemetry-semantic-conventions` → `0.32`; `opentelemetry_sdk` → **`0.32.1`** (see Security below)
- `tracing-opentelemetry` → `0.33` (matching release), and the example `opentelemetry-appender-*` / `-stdout` / `-http` crates → `0.32`

## Security

`opentelemetry_sdk` is pinned to **0.32.1** to address **CVE-2026-48504** (RUSTSEC): unbounded memory allocation in W3C Baggage propagation — oversized inbound `baggage` headers can drive excessive CPU/memory use (DoS). 0.32.1 enforces the W3C limits (8192-byte header, 64 list members) in `BaggagePropagator`, which this crate uses. The core `opentelemetry` crate has no 0.32.1 and is not the affected crate, so it stays at 0.32.0.

## Breaking changes adapted

1. **Sampling types relocated** — `SamplingDecision` / `SamplingResult` moved from `opentelemetry::trace` to `opentelemetry_sdk::trace`. Updated imports/paths in the sampler, otel mappings, and the otel sampling benchmark.
2. **Spec-compliant `service.name` fallback** — the SDK default is now `unknown_service:<executable>` instead of bare `unknown_service`. `create_dd_resource` now treats both the bare value and the `unknown_service:` prefix as unset before applying the Datadog service name. (Caught by a failing unit test.)
3. **`SpanBuilder::with_sampling_result` removed** — sampling is now decided solely by the configured `Sampler`. The `test_received_traces` integration test relied on this to force per-span decisions; it is `#[ignore]`d with a note pending a sampler-driven redesign + snapshot regeneration.

## Why upgrade

Beyond the CVE fix: exporter correctness fixes — `ExportError` default timeout corrected (5ns → 5s), `shutdown_with_timeout()` fixed for `grpc-tonic`, multi-HTTP-client selection fix, plus the W3C trace-context unknown-flags spec fix.

https://github.com/DataDog/dd-trace-rs/issues/267

🤖 Generated with [Claude Code](https://claude.com/claude-code)