### PR TITLE
refactor(propagation): mute telemetry errors with empty trace_id

### DIFF
--- a/datadog-opentelemetry/src/core/telemetry.rs
+++ b/datadog-opentelemetry/src/core/telemetry.rs
@@ -584,6 +584,62 @@ mod tests {
     }
 
     #[test]
+    fn test_only_template_reaches_telemetry() {
+        use crate::propagation::datadog;
+        use std::collections::HashMap;
+
+        let config = Config::builder().build();
+
+        init_telemetry_inner(
+            &config,
+            Some(Box::new(TestTelemetryHandle::new())),
+            &TELEMETRY,
+        );
+
+        let malformed_trace_id = "not-a-valid-trace-id-secret";
+        let headers = HashMap::from([
+            (
+                "x-datadog-trace-id".to_string(),
+                malformed_trace_id.to_string(),
+            ),
+            ("x-datadog-parent-id".to_string(), "5678".to_string()),
+        ]);
+
+        assert!(datadog::extract(&headers, &config).is_none());
+
+        let t = TELEMETRY.get().unwrap().lock().unwrap();
+        let handle = t
+            .handle
+            .as_ref()
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TestTelemetryHandle>()
+            .expect("Handle should be TestTelemetryHandle");
+
+        let template = "Propagator (datadog): Error extracting trace_id {e}";
+        assert!(
+            handle
+                .logs
+                .iter()
+                .any(|(msg, lvl, _)| msg == template && *lvl == data::LogLevel::Error),
+            "expected the template to be sent to telemetry, got: {:?}",
+            handle.logs,
+        );
+
+        assert!(
+            !handle
+                .logs
+                .iter()
+                .any(|(msg, _, stack)| msg.contains(malformed_trace_id)
+                    || stack
+                        .as_deref()
+                        .is_some_and(|s| s.contains(malformed_trace_id))),
+            "the dynamic trace id leaked into telemetry: {:?}",
+            handle.logs,
+        );
+    }
+
+    #[test]
     fn test_notify_configuration_update() {
         let config = Config::builder().build();
         let telemetry_cell = OnceLock::new();

--- a/datadog-opentelemetry/src/propagation/datadog.rs
+++ b/datadog-opentelemetry/src/propagation/datadog.rs
@@ -263,8 +263,10 @@ fn extract_trace_id(carrier: &dyn Extractor) -> Result<Option<u64>, Error> {
     }
 
     let trace_id = trace_id.parse::<u64>().map_err(|_| {
-        dd_warn!("Propagator (datadog): Failed to decode `trace_id` {trace_id}");
-        Error::extract("Failed to decode `trace_id`", "datadog")
+        Error::extract(
+            format!("Failed to decode `trace_id`: \"{trace_id}\""),
+            "datadog",
+        )
     })?;
     if trace_id == 0 {
         return Err(Error::extract("Invalid `trace_id` found", "datadog"));
@@ -278,10 +280,12 @@ fn extract_parent_id(carrier: &dyn Extractor) -> Result<Option<u64>, Error> {
         None => return Ok(None),
     };
 
-    parent_id
-        .parse::<u64>()
-        .map(Some)
-        .map_err(|_| Error::extract("Failed to decode `parent_id`", "datadog"))
+    parent_id.parse::<u64>().map(Some).map_err(|_| {
+        Error::extract(
+            format!("Failed to decode `parent_id`: \"{parent_id}\""),
+            "datadog",
+        )
+    })
 }
 
 fn extract_sampling_priority(carrier: &dyn Extractor) -> Result<Option<SamplingPriority>, Error> {

--- a/datadog-opentelemetry/src/propagation/datadog.rs
+++ b/datadog-opentelemetry/src/propagation/datadog.rs
@@ -257,9 +257,15 @@ fn extract_trace_id(carrier: &dyn Extractor) -> Result<Option<u64>, Error> {
         None => return Ok(None),
     };
 
-    let trace_id = trace_id
-        .parse::<u64>()
-        .map_err(|_| Error::extract("Failed to decode `trace_id`", "datadog"))?;
+    if trace_id.is_empty() {
+        dd_warn!("Propagator (datadog): Empty `trace_id` found in datadog carrier");
+        return Ok(None);
+    }
+
+    let trace_id = trace_id.parse::<u64>().map_err(|_| {
+        dd_warn!("Propagator (datadog): Failed to decode `trace_id` {trace_id}");
+        Error::extract("Failed to decode `trace_id`", "datadog")
+    })?;
     if trace_id == 0 {
         return Err(Error::extract("Invalid `trace_id` found", "datadog"));
     }
@@ -454,6 +460,27 @@ mod test {
         println!("{:?}", context.tags);
         assert_eq!(context.tags.get("_dd.p.test").unwrap(), "value");
         assert_eq!(context.tags.get("_dd.p.dm"), None);
+    }
+
+    #[test]
+    fn test_extract_datadog_propagator_with_empty_traceid() {
+        let headers = HashMap::from([
+            ("x-datadog-trace-id".to_string(), "".to_string()),
+            ("x-datadog-parent-id".to_string(), "5678".to_string()),
+            ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+            ("x-datadog-origin".to_string(), "synthetics".to_string()),
+            (
+                "x-datadog-tags".to_string(),
+                "_dd.p.test=value,any=tag".to_string(),
+            ),
+        ]);
+
+        let propagator = TracePropagationStyle::Datadog;
+
+        assert_eq!(
+            propagator.extract(&headers, &Config::builder().build()),
+            None
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/propagation/error.rs
+++ b/datadog-opentelemetry/src/propagation/error.rs
@@ -1,12 +1,14 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
+
 use thiserror::Error;
 
-#[derive(Error, Debug, Copy, Clone)]
+#[derive(Error, Debug, Clone)]
 #[error("Cannot {} from {}, {}", operation, propagator_name, message)]
 pub struct Error {
-    pub message: &'static str,
+    pub message: Cow<'static, str>,
     // which propagator this error comes from
     propagator_name: &'static str,
     // what operation was attempted
@@ -16,9 +18,9 @@ pub struct Error {
 impl Error {
     /// Error when extracting a value from a carrier
     #[must_use]
-    pub fn extract(message: &'static str, propagator_name: &'static str) -> Self {
+    pub fn extract(message: impl Into<Cow<'static, str>>, propagator_name: &'static str) -> Self {
         Self {
-            message,
+            message: message.into(),
             propagator_name,
             operation: "extract",
         }
@@ -26,9 +28,9 @@ impl Error {
 
     /// Error when injecting a value into a carrier
     #[allow(clippy::must_use_candidate)]
-    pub fn inject(message: &'static str, propagator_name: &'static str) -> Self {
+    pub fn inject(message: impl Into<Cow<'static, str>>, propagator_name: &'static str) -> Self {
         Self {
-            message,
+            message: message.into(),
             propagator_name,
             operation: "inject",
         }

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -610,7 +610,10 @@ fn parse_traceparent_components(traceparent: &str) -> Option<(&str, &str, &str, 
 
 fn extract_traceparent(traceparent: &str) -> Result<Traceparent, Error> {
     let (version, trace_id, span_id, flags, tail) = parse_traceparent_components(traceparent)
-        .ok_or(Error::extract("invalid traceparent", "traceparent"))?;
+        .ok_or(Error::extract(
+            format!("invalid traceparent: \"{traceparent}\""),
+            "traceparent",
+        ))?;
 
     let trace_id = extract_trace_id(trace_id)?;
 
@@ -664,8 +667,12 @@ fn extract_version(version: &str, tail: &str, trace_flags: u8) -> Result<(), Err
 }
 
 fn extract_trace_id(trace_id: &str) -> Result<u128, Error> {
-    let trace_id = u128::from_str_radix(trace_id, 16)
-        .map_err(|_| Error::extract("Failed to decode trace_id", "traceparent"))?;
+    let trace_id = u128::from_str_radix(trace_id, 16).map_err(|_| {
+        Error::extract(
+            format!("Failed to decode trace_id: \"{trace_id}\""),
+            "traceparent",
+        )
+    })?;
     if trace_id == 0 {
         return Err(Error::extract(
             "`0` value for trace_id is invalid",
@@ -676,8 +683,12 @@ fn extract_trace_id(trace_id: &str) -> Result<u128, Error> {
 }
 
 fn extract_span_id(span_id: &str) -> Result<u64, Error> {
-    let span_id = u64::from_str_radix(span_id, 16)
-        .map_err(|_| Error::extract("Failed to decode span_id", "traceparent"))?;
+    let span_id = u64::from_str_radix(span_id, 16).map_err(|_| {
+        Error::extract(
+            format!("Failed to decode span_id: \"{span_id}\""),
+            "traceparent",
+        )
+    })?;
     if span_id == 0 {
         return Err(Error::extract(
             "`0` value for span_id is invalid",


### PR DESCRIPTION
# What does this PR do?

- Change `datadog` propagator to check if `trace_id` is empty before triggering an Error
- Help debug by adding the trace_id value in a log