### PR TITLE
chore: bump workspace version to 0.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Tracer Version(s)
       description: "Version(s) of the tracer affected by this bug"
-      placeholder: "0.4.0"
+      placeholder: "0.5.0"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "propagator"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "datadog-opentelemetry",
  "http-body-util",
@@ -2924,7 +2924,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_tracing"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "datadog-opentelemetry",
  "opentelemetry",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "0.4.0"
+version = "0.5.0"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/dd-trace-rs"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ opentelemetry-sdk.
 Add to you Cargo.toml
 
 ```toml
-datadog-opentelemetry = { version = "0.4.0" }
+datadog-opentelemetry = { version = "0.5.0" }
 ```
 
 ### Creating traces, metrics and logs
@@ -203,7 +203,7 @@ let logging_provider = datadog_opentelemetry::logs()
 
 For advanced usage and configuration information, check out [`DatadogTracingBuilder`],
 [`configuration::ConfigBuilder`] and the
-[library documentation](https://docs.rs/datadog-opentelemetry/0.4.0/datadog_opentelemetry/).
+[library documentation](https://docs.rs/datadog-opentelemetry/0.5.0/datadog_opentelemetry/).
 
 * Through env variables
 

--- a/datadog-opentelemetry/CHANGELOG.md
+++ b/datadog-opentelemetry/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.0 (Jul 10, 2026)
+
+- Upgrade opentelemetry to 0.32 in https://github.com/DataDog/dd-trace-rs/pull/270
+- Add B3 single and multi-header trace propagation support in https://github.com/DataDog/dd-trace-rs/pull/262
+- Add support for `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` parameter in https://github.com/DataDog/dd-trace-rs/pull/248
+- Support `OTEL_PROPAGATORS` as propagation style fallback in https://github.com/DataDog/dd-trace-rs/pull/271
+- Support `OTEL_SERVICE_NAME` as alias for `DD_SERVICE` in https://github.com/DataDog/dd-trace-rs/pull/266
+- Add `with_view` support to `DatadogMetricsBuilder` in https://github.com/DataDog/dd-trace-rs/pull/272
+- Adopt libdatadog's `TraceBuffer` in https://github.com/DataDog/dd-trace-rs/pull/226
+- Propagate session IDs and process lineage to libdatadog in https://github.com/DataDog/dd-trace-rs/pull/216
+- Fix baggage tags to be added to any root span in https://github.com/DataDog/dd-trace-rs/pull/265
+
 ## 0.4.0 (Jun 05, 2026)
 
 - Add support for W3C baggage propagation in https://github.com/DataDog/dd-trace-rs/pull/200

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -16,7 +16,7 @@
 //! Add to you Cargo.toml
 //!
 //! ```toml
-//! datadog-opentelemetry = { version = "0.4.0" }
+//! datadog-opentelemetry = { version = "0.5.0" }
 //! ```
 //!
 //! ### Creating traces, metrics and logs

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_not_applied_to_non_local_root_child.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_not_applied_to_non_local_root_child.json
@@ -15,7 +15,7 @@
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,
@@ -39,7 +39,7 @@
          "span.kind": "internal",
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0"
+         "telemetry.sdk.version": "0.5.0"
        },
        "metrics": {
          "_sampling_priority_v1": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_only_no_trace_context_applies_baggage_span_tags.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_only_no_trace_context_applies_baggage_span_tags.json
@@ -16,7 +16,7 @@
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_with_trace_context_applies_baggage_span_tags.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_with_trace_context_applies_baggage_span_tags.json
@@ -15,7 +15,7 @@
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
@@ -20,7 +20,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_sampling_priority_v1": 2.0,
@@ -48,7 +48,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0"
+         "telemetry.sdk.version": "0.5.0"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_ignore.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_ignore.json
@@ -16,7 +16,7 @@
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
         "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.4.0"
+        "telemetry.sdk.version": "0.5.0"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_child_not_relinked.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_child_not_relinked.json
@@ -16,7 +16,7 @@
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
         "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.4.0"
+        "telemetry.sdk.version": "0.5.0"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,
@@ -53,7 +53,7 @@
         "span.kind": "internal",
         "telemetry.sdk.language": "rust",
         "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.4.0"
+        "telemetry.sdk.version": "0.5.0"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_multiple_contexts.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_multiple_contexts.json
@@ -16,7 +16,7 @@
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
         "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.4.0"
+        "telemetry.sdk.version": "0.5.0"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_single_context.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_single_context.json
@@ -16,7 +16,7 @@
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
         "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.4.0"
+        "telemetry.sdk.version": "0.5.0"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
@@ -16,7 +16,7 @@
       "span.kind": "client",
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
@@ -18,7 +18,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
@@ -18,7 +18,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,
@@ -46,7 +46,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0"
+         "telemetry.sdk.version": "0.5.0"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
@@ -17,7 +17,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0"
+      "telemetry.sdk.version": "0.5.0"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
@@ -24,7 +24,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0",
+      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_instrument_error_reporting"
     },
     "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
@@ -21,7 +21,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0",
+      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
     },
     "metrics": {
@@ -56,7 +56,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0",
+         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
        },
        "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
@@ -20,7 +20,7 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.4.0",
+      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_smoke"
     },
     "metrics": {
@@ -55,7 +55,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0",
+         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {
@@ -89,7 +89,7 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.4.0",
+         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/instrumentation/datadog-aws-lambda/Cargo.toml
+++ b/instrumentation/datadog-aws-lambda/Cargo.toml
@@ -13,7 +13,7 @@ authors.workspace = true
 publish.workspace = true
 
 [dependencies]
-datadog-opentelemetry = { version = "0.4", path = "../../datadog-opentelemetry" }
+datadog-opentelemetry = { version = "0.5", path = "../../datadog-opentelemetry" }
 lambda_runtime = "0.13"
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
@@ -22,6 +22,6 @@ opentelemetry_sdk = { workspace = true, features = ["trace", "metrics", "logs"] 
 tracing = { workspace = true }
 
 [dev-dependencies]
-datadog-opentelemetry = { version = "0.4", path = "../../datadog-opentelemetry", features = ["test-utils"] }
+datadog-opentelemetry = { version = "0.5", path = "../../datadog-opentelemetry", features = ["test-utils"] }
 opentelemetry_sdk = { workspace = true, features = ["trace", "metrics", "logs", "testing"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }


### PR DESCRIPTION
# What does this PR do?

Bump workspace version to 0.5.0