### PR TITLE
docs(otel): gate logs/metrics reader modules on docsrs

### DIFF
--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -291,9 +291,9 @@ pub(crate) mod sampling;
 mod span_processor;
 
 mod ddtrace_transform;
-#[cfg(any(feature = "logs-grpc", feature = "logs-http"))]
+#[cfg(any(feature = "logs-grpc", feature = "logs-http", docsrs))]
 mod logs_reader;
-#[cfg(any(feature = "metrics-grpc", feature = "metrics-http"))]
+#[cfg(any(feature = "metrics-grpc", feature = "metrics-http", docsrs))]
 mod metrics_reader;
 mod otlp_utils;
 mod span_exporter;


### PR DESCRIPTION
# What does this PR do?

Compile the logs_reader and metrics_reader modules under the docsrs cfg so their public builders (already gated on docsrs) resolve when docs.rs builds with default features.