### PR TITLE
ci: release automation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,36 +4,24 @@ on:
   push:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+'
+env:
+  RUST_VERSION: 1.87.0
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - name: "Checkout sources"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-
-      - name: "Resolve Rust version from Cargo.toml"
-        id: rust
-        shell: bash
-        run: |
-          version="$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
-          if [ -z "${version}" ]; then
-            echo "::error::could not read rust-version from [workspace.package] in Cargo.toml"
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: "Install Rust ${{ steps.rust.outputs.version }}"
-        shell: bash
-        env:
-          RUST_VERSION: ${{ steps.rust.outputs.version }}
-        run: rustup install "${RUST_VERSION}" && rustup default "${RUST_VERSION}"
+      - name: "Install Rust ${RUST_VERSION}"
+        run: rustup install ${RUST_VERSION} && rustup default ${RUST_VERSION}
 
       - name: "Install nextest"
         uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # 2.49.15
         with:
           tool: nextest@0.9.96
+
+      - name: "Checkout sources"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: "Get tag"
         id: tag

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - '*-v[0-9]+.[0-9]+.[0-9]+'
+      - '*-v[0-9]+.[0-9]+.[0-9]+*'
 env:
   RUST_VERSION: 1.87.0
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,24 +4,36 @@ on:
   push:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+'
-env:
-  RUST_VERSION: 1.87.0
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - name: "Install Rust ${RUST_VERSION}"
-        run: rustup install ${RUST_VERSION} && rustup default ${RUST_VERSION}
+      - name: "Checkout sources"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: "Resolve Rust version from Cargo.toml"
+        id: rust
+        shell: bash
+        run: |
+          version="$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "::error::could not read rust-version from [workspace.package] in Cargo.toml"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: "Install Rust ${{ steps.rust.outputs.version }}"
+        shell: bash
+        env:
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
+        run: rustup install "${RUST_VERSION}" && rustup default "${RUST_VERSION}"
 
       - name: "Install nextest"
         uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # 2.49.15
         with:
           tool: nextest@0.9.96
-
-      - name: "Checkout sources"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: "Get tag"
         id: tag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,8 @@ debug = false
 incremental = false
 opt-level = 3
 
+[workspace.metadata.release]
+shared-version = true
+publish = false
+tag = false
+push = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,39 @@
+# git-cliff configuration for datadog-opentelemetry.
+#
+# Used by scripts/prepare-release.sh to render the list of changelog entries for a release: a plain
+# (ungrouped) list of the meaningful commits since the previous tag, each linking its PR. The
+# "## <version> (<date>)" heading and placement in CHANGELOG.md are handled by the script, so this
+# config emits only the bullet list.
+
+[changelog]
+header = ""
+# One bullet per commit, no grouping. `commit.message` is the conventional-commit description
+# (type/scope prefix stripped by the parser below).
+body = """
+{%- for commit in commits %}
+- {{ commit.message | upper_first }}
+{%- endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+# Keep commits that don't follow the convention (rare) rather than silently dropping them.
+filter_unconventional = false
+# Only emit commits that a parser keeps (drops the skipped types below).
+filter_commits = true
+# Turn the trailing "(#123)" that squash-merges add into a Markdown link to the PR.
+commit_preprocessors = [
+    { pattern = '\(#([0-9]+)\)', replace = "in https://github.com/DataDog/dd-trace-rs/pull/${1}" },
+]
+# Omit chore/ci/docs/test; keep everything else in a single (unused) group.
+commit_parsers = [
+    { message = "^chore", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^docs", skip = true },
+    { message = "^test", skip = true },
+    { message = ".*", group = "changes" },
+]
+tag_pattern = "datadog-opentelemetry-v[0-9]*"
+sort_commits = "newest"

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -165,8 +165,8 @@ required-features = ["test-utils"]
 # Version references kept in sync on every release proposal by `cargo release replace`.
 # File paths are relative to this manifest (datadog-opentelemetry/).
 pre-release-replacements = [
-    { file = "../README.md", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1 },
-    { file = "../README.md", search = 'docs\.rs/datadog-opentelemetry/[0-9]+\.[0-9]+\.[0-9]+/', replace = 'docs.rs/datadog-opentelemetry/{{version}}/', min = 1 },
-    { file = "src/lib.rs", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1 },
-    { file = "../.github/ISSUE_TEMPLATE/bug_report.yml", search = 'placeholder: "[0-9]+\.[0-9]+\.[0-9]+"', replace = 'placeholder: "{{version}}"', min = 1 },
+    { file = "../README.md", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1, prerelease = true },
+    { file = "../README.md", search = 'docs\.rs/datadog-opentelemetry/[0-9]+\.[0-9]+\.[0-9]+/', replace = 'docs.rs/datadog-opentelemetry/{{version}}/', min = 1, prerelease = true },
+    { file = "src/lib.rs", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1, prerelease = true },
+    { file = "../.github/ISSUE_TEMPLATE/bug_report.yml", search = 'placeholder: "[0-9]+\.[0-9]+\.[0-9]+"', replace = 'placeholder: "{{version}}"', min = 1, prerelease = true },
 ]

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -160,3 +160,13 @@ name = "otel_sampling_benchmark"
 harness = false
 path = "benches/otel_sampling_benchmark.rs"
 required-features = ["test-utils"]
+
+[package.metadata.release]
+# Version references kept in sync on every release proposal by `cargo release replace`.
+# File paths are relative to this manifest (datadog-opentelemetry/).
+pre-release-replacements = [
+    { file = "../README.md", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1 },
+    { file = "../README.md", search = 'docs\.rs/datadog-opentelemetry/[0-9]+\.[0-9]+\.[0-9]+/', replace = 'docs.rs/datadog-opentelemetry/{{version}}/', min = 1 },
+    { file = "src/lib.rs", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1 },
+    { file = "../.github/ISSUE_TEMPLATE/bug_report.yml", search = 'placeholder: "[0-9]+\.[0-9]+\.[0-9]+"', replace = 'placeholder: "{{version}}"', min = 1 },
+]

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -166,7 +166,7 @@ required-features = ["test-utils"]
 # File paths are relative to this manifest (datadog-opentelemetry/).
 pre-release-replacements = [
     { file = "../README.md", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1, prerelease = true },
-    { file = "../README.md", search = 'docs\.rs/datadog-opentelemetry/[0-9]+\.[0-9]+\.[0-9]+/', replace = 'docs.rs/datadog-opentelemetry/{{version}}/', min = 1, prerelease = true },
+    { file = "../README.md", search = 'docs\.rs/datadog-opentelemetry/[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?/', replace = 'docs.rs/datadog-opentelemetry/{{version}}/', min = 1, prerelease = true },
     { file = "src/lib.rs", search = 'datadog-opentelemetry = \{ version = "[^"]+" \}', replace = 'datadog-opentelemetry = { version = "{{version}}" }', min = 1, prerelease = true },
-    { file = "../.github/ISSUE_TEMPLATE/bug_report.yml", search = 'placeholder: "[0-9]+\.[0-9]+\.[0-9]+"', replace = 'placeholder: "{{version}}"', min = 1, prerelease = true },
+    { file = "../.github/ISSUE_TEMPLATE/bug_report.yml", search = 'placeholder: "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?"', replace = 'placeholder: "{{version}}"', min = 1, prerelease = true },
 ]

--- a/datadog-opentelemetry/tests/integration_tests/mod.rs
+++ b/datadog-opentelemetry/tests/integration_tests/mod.rs
@@ -49,7 +49,7 @@ pub async fn make_test_agent(session_name: &'static str) -> DatadogTestAgent {
             ("SNAPSHOT_CI", "0"),
             (
                 "SNAPSHOT_IGNORED_ATTRS",
-                "span_id,trace_id,parent_id,duration,start,meta.otel.trace_id,metrics.busy_ns,metrics.idle_ns,metrics.thread.id,metrics.code.line.number,metrics.thread.id,span_events.time_unix_nano,span_events.attributes.code.line.number",
+                "span_id,trace_id,parent_id,duration,start,meta.otel.trace_id,meta.telemetry.sdk.version,metrics.busy_ns,metrics.idle_ns,metrics.thread.id,metrics.code.line.number,metrics.thread.id,span_events.time_unix_nano,span_events.attributes.code.line.number",
             ),
         ],
     )

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_not_applied_to_non_local_root_child.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_not_applied_to_non_local_root_child.json
@@ -14,8 +14,7 @@
       "otel.trace_id": "0000000000000000112210f47de98115",
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,
@@ -38,8 +37,7 @@
          "otel.trace_id": "0000000000000000112210f47de98115",
          "span.kind": "internal",
          "telemetry.sdk.language": "rust",
-         "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0"
+         "telemetry.sdk.name": "datadog"
        },
        "metrics": {
          "_sampling_priority_v1": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_only_no_trace_context_applies_baggage_span_tags.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_only_no_trace_context_applies_baggage_span_tags.json
@@ -15,8 +15,7 @@
       "otel.trace_id": "6a3a5a6c00000000525a2c317a438eb3",
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_with_trace_context_applies_baggage_span_tags.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_baggage_with_trace_context_applies_baggage_span_tags.json
@@ -14,8 +14,7 @@
       "otel.trace_id": "0000000000000000112210f47de98115",
       "span.kind": "server",
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction.json
@@ -19,8 +19,7 @@
 
 
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_sampling_priority_v1": 2.0,
@@ -47,8 +46,7 @@
 
 
          "telemetry.sdk.language": "rust",
-         "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0"
+         "telemetry.sdk.name": "datadog"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_ignore.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_ignore.json
@@ -15,8 +15,7 @@
         "otel.trace_id": "6a2912f7000000003fef098aa6d0543f",
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
-        "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.5.0"
+        "telemetry.sdk.name": "datadog"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_child_not_relinked.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_child_not_relinked.json
@@ -15,8 +15,7 @@
         "otel.trace_id": "6a2aa1fc00000000d8864be77751666b",
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
-        "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.5.0"
+        "telemetry.sdk.name": "datadog"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,
@@ -52,8 +51,7 @@
         "otel.trace_id": "6a2aa1fc00000000d8864be77751666b",
         "span.kind": "internal",
         "telemetry.sdk.language": "rust",
-        "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.5.0"
+        "telemetry.sdk.name": "datadog"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_multiple_contexts.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_multiple_contexts.json
@@ -15,8 +15,7 @@
         "otel.trace_id": "6a2960bc00000000dcfe3384505b6fc5",
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
-        "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.5.0"
+        "telemetry.sdk.name": "datadog"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_single_context.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_injection_extraction_extract_behavior_restart_single_context.json
@@ -15,8 +15,7 @@
         "otel.trace_id": "6a2960bb0000000075bbcd986de6224f",
         "span.kind": "server",
         "telemetry.sdk.language": "rust",
-        "telemetry.sdk.name": "datadog",
-        "telemetry.sdk.version": "0.5.0"
+        "telemetry.sdk.name": "datadog"
       },
       "metrics": {
         "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
@@ -15,8 +15,7 @@
       "otel.trace_id": "6a432ae900000000fadb9ed3e75ee6b8",
       "span.kind": "client",
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
@@ -17,8 +17,7 @@
 
 
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
@@ -17,8 +17,7 @@
 
 
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_dd.rule_psr": 1.0,
@@ -45,8 +44,7 @@
 
 
          "telemetry.sdk.language": "rust",
-         "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0"
+         "telemetry.sdk.name": "datadog"
        },
        "metrics": {
          "_dd.measured": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_trace_writer_synchronous_mode.json
@@ -16,8 +16,7 @@
 
 
       "telemetry.sdk.language": "rust",
-      "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0"
+      "telemetry.sdk.name": "datadog"
     },
     "metrics": {
       "_sampling_priority_v1": 1.0,

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_instrument_error_reporting.json
@@ -24,7 +24,6 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_instrument_error_reporting"
     },
     "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_remote_span_extraction_propagation.json
@@ -21,7 +21,6 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
     },
     "metrics": {
@@ -56,7 +55,6 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_remote_span_extraction_propagation"
        },
        "metrics": {

--- a/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
+++ b/datadog-opentelemetry/tests/snapshots/tracing_api/test_smoke.json
@@ -20,7 +20,6 @@
 
       "telemetry.sdk.language": "rust",
       "telemetry.sdk.name": "datadog",
-      "telemetry.sdk.version": "0.5.0",
       "thread.name": "integration_tests::tracing_api::test_smoke"
     },
     "metrics": {
@@ -55,7 +54,6 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {
@@ -89,7 +87,6 @@
 
          "telemetry.sdk.language": "rust",
          "telemetry.sdk.name": "datadog",
-         "telemetry.sdk.version": "0.5.0",
          "thread.name": "integration_tests::tracing_api::test_smoke"
        },
        "metrics": {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,6 +8,36 @@
 > If new vulnerabilities exist for the commit being released, discuss with the team whether
 > releasing is safe, or if it should be delayed to resolve the vulnerability.
 
+### Preparing the release with the helper script
+
+`scripts/prepare-release.sh` automates most of the preparation below — the version bump, the
+version-reference updates, the changelog generation, and the verification. It does **not** commit,
+tag, or publish, and it does not replace the surrounding steps: you still bump libdatadog (step 1),
+review the incoming commits (step 2), and merge, tag, and publish (steps 6–9) yourself.
+
+Run it from the tip of the branch you are releasing (usually `main`, up to date with `origin`):
+
+```text
+./scripts/prepare-release.sh <minor|major|patch|VERSION>   # e.g. "minor" or "0.6.0"
+```
+
+It will:
+
+- verify your checkout is in sync with the release branch,
+- bump the workspace crate version,
+- update the version references in `README.md`, `src/lib.rs`, the bug-report issue template, and the
+  `datadog-aws-lambda` dependency pin (plus its lockfile),
+- prepend a `CHANGELOG.md` section listing the commits since the previous release tag,
+- verify that the rustdocs build and that the crate publishes cleanly (a `cargo publish` dry-run).
+
+Then review the working tree — especially the generated changelog, pruning it to customer-facing
+changes — and commit. The script requires `cargo-release` and `git-cliff`; pass `--help` to see its
+options (for example `--base-branch` to cut a hotfix from an older release line).
+
+The manual steps below remain valid and can always be followed instead.
+
+### Manual steps
+
 1. Bump libdatadog dependencies to their latest version. Unless there are specific reasons not to,
    we should make a fresh release of libdatadog crates just before dd-trace-rs releases to benefit
    from upgrades

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,8 +31,12 @@ It will:
 - verify that the rustdocs build and that the crate publishes cleanly (a `cargo publish` dry-run).
 
 Then review the working tree — especially the generated changelog, pruning it to customer-facing
-changes — and commit. The script requires `cargo-release` and `git-cliff`; pass `--help` to see its
-options (for example `--base-branch` to cut a hotfix from an older release line).
+changes — and commit. The script requires `cargo-release`, `git-cliff`, and `jq`; pass `--help` to
+see its options (for example `--base-branch` to cut a hotfix from an older release line).
+
+Because the changelog is built from the commit history since the previous release tag, the script
+needs the full history and tags — it refuses to run on a shallow clone. When invoking it from CI,
+check out with `fetch-depth: 0` (which also fetches tags) so the changelog range resolves correctly.
 
 The manual steps below remain valid and can always be followed instead.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,6 +15,9 @@ version-reference updates, the changelog generation, and the verification. It do
 tag, or publish, and it does not replace the surrounding steps: you still bump libdatadog (step 1),
 review the incoming commits (step 2), and merge, tag, and publish (steps 6–9) yourself.
 
+The script handles the rest of the steps (3–5) and it requires `cargo-release`, `git-cliff`, and
+`jq`.
+
 Run it from the tip of the branch you are releasing (usually `main`, up to date with `origin`):
 
 ```text
@@ -30,9 +33,8 @@ It will:
 - prepend a `CHANGELOG.md` section listing the commits since the previous release tag,
 - verify that the rustdocs build and that the crate publishes cleanly (a `cargo publish` dry-run).
 
-Then review the working tree — especially the generated changelog, pruning it to customer-facing
-changes — and commit. The script requires `cargo-release`, `git-cliff`, and `jq`; pass `--help` to
-see its options (for example `--base-branch` to cut a hotfix from an older release line).
+Then review the working tree — especially the generated changelog, pruning it to user-facing
+changes — and commit.
 
 Because the changelog is built from the commit history since the previous release tag, the script
 needs the full history and tags — it refuses to run on a shallow clone. When invoking it from CI,
@@ -49,7 +51,7 @@ The manual steps below remain valid and can always be followed instead.
 2. Check the commits that are going in the new release, by creating a draft release in github
    <https://github.com/DataDog/dd-trace-rs/releases/new>
 
-3. Append to the CHANGELOG.md, adding only additions/removal/fixes that affect customers
+3. Append to the CHANGELOG.md, adding only additions/removal/fixes that affect users
 
 4. Check that the README and rustdocs are up to date with the current feature set and that they
    render correctly on github. rustdocs can be generated using the following command

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -122,8 +122,21 @@ if [ "$CHECK_SYNC" = true ]; then
     echo -e "${GREEN}✓ In sync with origin/$BASE_BRANCH ($remote_head)${NC}"
 fi
 
-if ! command -v git-cliff >/dev/null 2>&1; then
-    echo -e "${RED}❌ ERROR: git-cliff is required to generate the changelog (install: cargo install git-cliff).${NC}" >&2
+require_tool() {
+    local tool="$1" hint="$2"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo -e "${RED}❌ ERROR: $tool is required but was not found ($hint).${NC}" >&2
+        exit 1
+    fi
+}
+require_tool git-cliff "install: cargo install git-cliff"
+require_tool cargo-release "install: cargo install cargo-release"
+require_tool jq "install it via your package manager, e.g. apt-get install jq / brew install jq"
+
+# A shallow clone hides older commits and tags
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    echo -e "${RED}❌ ERROR: shallow clone detected; the changelog needs full history and tags.${NC}" >&2
+    echo "   Run 'git fetch --unshallow --tags', or checkout with fetch-depth: 0 in CI." >&2
     exit 1
 fi
 
@@ -136,8 +149,7 @@ PREV_VERSION="$(crate_version)"
 echo -e "${BLUE}Current version: $PREV_VERSION${NC}"
 
 # Validate the argument: either a known semver level, or an exact version that is well-formed
-# and strictly greater than the current version. Levels are left to cargo-release, which always
-# produces a higher version.
+# and strictly greater than the current version
 case "$LEVEL_OR_VERSION" in
     major|minor|patch|release|rc|beta|alpha) ;;
     *)
@@ -195,7 +207,7 @@ fi
 
 # git-cliff renders the entries: a plain list with PR links, omitting chore/ci/docs/test
 # (see cliff.toml). Strip any leading blank lines it emits before the first bullet.
-commits="$(git cliff --config cliff.toml "${cliff_range[@]}" 2>/dev/null | sed '/./,$!d')"
+commits="$(git cliff --config cliff.toml ${cliff_range[@]+"${cliff_range[@]}"} 2>/dev/null | sed '/./,$!d')"
 if [ -z "$commits" ]; then
     commits="- _No changes._"
 fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -204,17 +204,18 @@ CHANGELOG="$PACKAGE/CHANGELOG.md"
 # The previous tag: the most recent release tag reachable from HEAD (not merely the
 # highest version, which may live on another branch).
 previous_tag="$(git describe --tags --abbrev=0 --match "$PACKAGE-v*" 2>/dev/null || true)"
-if [ -n "$previous_tag" ]; then
-    cliff_range=("$previous_tag..HEAD")
-    echo "Listing commits since $previous_tag" >&2
-else
-    cliff_range=()   # no prior release tag: include all history
-    echo "No previous $PACKAGE release tag found; listing all history" >&2
-fi
 
-# git-cliff renders the entries: a plain list with PR links, omitting chore/ci/docs/test
-# (see cliff.toml). Strip any leading blank lines it emits before the first bullet.
-commits="$(git cliff --config cliff.toml ${cliff_range[@]+"${cliff_range[@]}"} 2>/dev/null | sed '/./,$!d')"
+# git-cliff renders the entries: a plain list with PR links, omitting chore/ci/docs/test (see
+# cliff.toml). Pass an explicit range when there is a previous tag; otherwise omit the range so
+# git-cliff walks all history. (An empty-string range argument makes git-cliff error, so the two
+# cases are branched rather than relying on array expansion.) Strip leading blank lines it emits.
+if [ -n "$previous_tag" ]; then
+    echo "Listing commits since $previous_tag" >&2
+    commits="$(git cliff --config cliff.toml "$previous_tag..HEAD" 2>/dev/null | sed '/./,$!d')"
+else
+    echo "No previous $PACKAGE release tag found; listing all history" >&2
+    commits="$(git cliff --config cliff.toml 2>/dev/null | sed '/./,$!d')"
+fi
 if [ -z "$commits" ]; then
     commits="- _No changes._"
 fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -36,9 +36,8 @@ Usage: $(basename "$0") [OPTIONS] <LEVEL|VERSION>
 Prepares a $PACKAGE release proposal in the working tree (no commit/tag/publish).
 
 Arguments:
-    <LEVEL|VERSION>     A semver level (major|minor|patch) or an exact stable
-                        version (e.g. 0.6.0). Prereleases are not supported
-                        (the publish workflow only triggers on stable X.Y.Z tags).
+    <LEVEL|VERSION>     A semver level (major|minor|patch|release|rc|beta|alpha)
+                        or an exact version (e.g. 0.6.0 or 0.6.0-rc.1).
 
 Options:
     -h, --help                  Show this help message
@@ -149,27 +148,34 @@ crate_version() {
 PREV_VERSION="$(crate_version)"
 echo -e "${BLUE}Current version: $PREV_VERSION${NC}"
 
-# Validate the argument: a stable semver level, or an exact stable version that is well-formed and
-# strictly greater than the current version. Prereleases are rejected: cargo-release skips the
-# pre-release-replacements for prerelease versions (their `prerelease` flag defaults to false), and
-# the publish workflow only triggers on stable X.Y.Z tags anyway.
+# Validate the argument: a semver level (including the prerelease levels), or an exact version
+# (stable X.Y.Z or a prerelease X.Y.Z-<suffix>). For exact versions the requested value must differ
+# from the current one and, when both are stable, be strictly greater. The monotonic check is
+# limited to stable-vs-stable because `sort -V` mis-orders prereleases (it ranks 1.0.0-rc.1 above
+# 1.0.0), which would otherwise wrongly reject finalizing a prerelease.
 case "$LEVEL_OR_VERSION" in
-    major|minor|patch) ;;
-    release|rc|beta|alpha)
-        echo -e "${RED}❌ ERROR: prerelease level '$LEVEL_OR_VERSION' is not supported; use major|minor|patch or a stable version.${NC}" >&2
-        exit 1
-        ;;
+    major|minor|patch|release|rc|beta|alpha) ;;
     *)
-        if ! printf '%s' "$LEVEL_OR_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo -e "${RED}❌ ERROR: '$LEVEL_OR_VERSION' is not a supported level or stable version${NC}" >&2
-            echo "   Expected major|minor|patch or a stable semver version (e.g. 0.6.0); prereleases are not supported." >&2
+        if ! printf '%s' "$LEVEL_OR_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo -e "${RED}❌ ERROR: '$LEVEL_OR_VERSION' is not a valid version or release level${NC}" >&2
+            echo "   Expected a level (major|minor|patch|release|rc|beta|alpha) or a semver version (e.g. 0.6.0 or 0.6.0-rc.1)." >&2
             exit 1
         fi
-        highest="$(printf '%s\n%s\n' "$PREV_VERSION" "$LEVEL_OR_VERSION" | sort -V | tail -n1)"
-        if [ "$LEVEL_OR_VERSION" = "$PREV_VERSION" ] || [ "$highest" != "$LEVEL_OR_VERSION" ]; then
-            echo -e "${RED}❌ ERROR: version $LEVEL_OR_VERSION must be greater than the current version $PREV_VERSION${NC}" >&2
+        if [ "$LEVEL_OR_VERSION" = "$PREV_VERSION" ]; then
+            echo -e "${RED}❌ ERROR: version $LEVEL_OR_VERSION is the same as the current version${NC}" >&2
             exit 1
         fi
+        # Only guard ordering when neither version is a prerelease (contains a '-').
+        case "$PREV_VERSION$LEVEL_OR_VERSION" in
+            *-*) ;;
+            *)
+                highest="$(printf '%s\n%s\n' "$PREV_VERSION" "$LEVEL_OR_VERSION" | sort -V | tail -n1)"
+                if [ "$highest" != "$LEVEL_OR_VERSION" ]; then
+                    echo -e "${RED}❌ ERROR: version $LEVEL_OR_VERSION must be greater than the current version $PREV_VERSION${NC}" >&2
+                    exit 1
+                fi
+                ;;
+        esac
         ;;
 esac
 
@@ -192,7 +198,12 @@ fi
 # The instrumentation crates are a separate workspace, so cargo-release does not touch them.
 # Bump their datadog-opentelemetry dependency pin (kept as major.minor to match the existing
 # style) and refresh that workspace's lockfile so it stays consistent with the released version.
-version_req="$(printf '%s' "$NEW_VERSION" | cut -d. -f1,2)"
+# For a stable release keep the pin as major.minor; for a prerelease pin the exact version, since a
+# caret requirement on major.minor (e.g. "0.6") does not match a prerelease (0.6.0-rc.1 < 0.6.0).
+case "$NEW_VERSION" in
+    *-*) version_req="$NEW_VERSION" ;;
+    *)   version_req="$(printf '%s' "$NEW_VERSION" | cut -d. -f1,2)" ;;
+esac
 lambda_manifest="instrumentation/datadog-aws-lambda/Cargo.toml"
 echo -e "${BLUE}--- Bumping datadog-opentelemetry pin in $lambda_manifest to $version_req ---${NC}"
 sed -i -E "s|(datadog-opentelemetry = \{ version = \")[^\"]+|\1${version_req}|g" "$lambda_manifest"

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -27,6 +27,7 @@ DOC_TOOLCHAIN="nightly"
 RUN_PUBLISH_DRY_RUN=true
 ALLOW_DIRTY=false
 CHECK_SYNC=true
+CODEX_JIRA_URL="https://datadoghq.atlassian.net/jira/software/c/projects/APMSP/boards/29727?quickFilter=32571"
 
 usage() {
     cat << EOF
@@ -78,6 +79,20 @@ if [ -z "$LEVEL_OR_VERSION" ]; then
     echo "" >&2
     usage
     exit 1
+fi
+
+echo -e "${BLUE}Codex Findings (Jira): $CODEX_JIRA_URL${NC}" >&2
+if [ -t 0 ]; then
+    read -r -p "Have you reviewed them for this release? [y/N] " codex_ack
+    case "$codex_ack" in
+        y|Y|yes|Yes) ;;
+        *)
+            echo -e "${RED}❌ Aborting: please review them before releasing.${NC}" >&2
+            exit 1
+            ;;
+    esac
+else
+    echo -e "${BLUE}⚠️  Reminder: review the Codex Findings before releasing.${NC}" >&2
 fi
 
 # A dirty tree means the resulting commit would include unrelated changes, so fail early with a

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+# Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# Prepares a datadog-opentelemetry release *proposal* in the working tree:
+#   1. bumps the (workspace-shared) crate version,
+#   2. updates version references (README, lib.rs, bug report template) via
+#      cargo-release `pre-release-replacements`,
+#   3. prepends a changelog section listing the commits since the last release (via git-cliff),
+#   4. verifies the result (rustdocs build, reference consistency, publish dry-run).
+#
+# It intentionally does NOT commit, tag, publish, or push. The caller (the
+# release-proposal workflow) opens the PR; tagging and publishing remain manual
+# (git tag -> .github/workflows/publish.yaml -> scripts/publish-crate.sh).
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PACKAGE="datadog-opentelemetry"
+BASE_BRANCH="main"
+DOC_TOOLCHAIN="nightly"
+RUN_PUBLISH_DRY_RUN=true
+ALLOW_DIRTY=false
+CHECK_SYNC=true
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] <LEVEL|VERSION>
+
+Prepares a $PACKAGE release proposal in the working tree (no commit/tag/publish).
+
+Arguments:
+    <LEVEL|VERSION>     A semver level (major|minor|patch|release|rc|beta|alpha)
+                        or an exact version (e.g. 0.5.0).
+
+Options:
+    -h, --help                  Show this help message
+        --base-branch <NAME>    Branch to release from and verify sync against (default: $BASE_BRANCH).
+                                Use a hotfix/release branch to cut a hotfix from an older line.
+        --allow-dirty           Proceed even if the working tree has uncommitted changes
+        --no-sync-check         Skip verifying HEAD matches the latest origin/<base-branch> commit
+        --no-publish-dry-run    Skip the 'cargo publish --dry-run' verification step
+        --doc-toolchain <NAME>  Rust toolchain used for the rustdocs build (default: $DOC_TOOLCHAIN)
+
+Examples:
+    $(basename "$0") minor
+    $(basename "$0") 0.5.0
+    $(basename "$0") --base-branch hotfix/0.5.x 0.5.1
+EOF
+}
+
+LEVEL_OR_VERSION=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --base-branch) BASE_BRANCH="$2"; shift 2 ;;
+        --allow-dirty) ALLOW_DIRTY=true; shift ;;
+        --no-sync-check) CHECK_SYNC=false; shift ;;
+        --no-publish-dry-run) RUN_PUBLISH_DRY_RUN=false; shift ;;
+        --doc-toolchain) DOC_TOOLCHAIN="$2"; shift 2 ;;
+        -*) echo -e "${RED}Unknown option: $1${NC}" >&2; usage; exit 1 ;;
+        *)
+            if [ -n "$LEVEL_OR_VERSION" ]; then
+                echo -e "${RED}❌ ERROR: unexpected extra argument '$1'${NC}" >&2
+                exit 1
+            fi
+            LEVEL_OR_VERSION="$1"; shift ;;
+    esac
+done
+
+if [ -z "$LEVEL_OR_VERSION" ]; then
+    echo -e "${RED}❌ ERROR: missing <LEVEL|VERSION>${NC}" >&2
+    echo "" >&2
+    usage
+    exit 1
+fi
+
+# A dirty tree means the resulting commit would include unrelated changes, so fail early with a
+# clear message unless the caller explicitly opts in with --allow-dirty.
+if [ "$ALLOW_DIRTY" != true ] && [ -n "$(git status --porcelain)" ]; then
+    echo -e "${RED}❌ ERROR: working tree is not clean. Commit or stash changes first, or pass --allow-dirty.${NC}" >&2
+    exit 1
+fi
+
+# The proposal must be cut from the tip of the base branch; a stale checkout would list the wrong
+# commits and bump from the wrong base. Verify HEAD matches the freshly-fetched origin/$BASE_BRANCH.
+if [ "$CHECK_SYNC" = true ]; then
+    echo -e "${BLUE}--- Checking sync with origin/$BASE_BRANCH ---${NC}"
+    if ! git fetch --quiet origin "$BASE_BRANCH"; then
+        echo -e "${RED}❌ ERROR: failed to fetch origin/$BASE_BRANCH${NC}" >&2
+        exit 1
+    fi
+    local_head="$(git rev-parse HEAD)"
+    remote_head="$(git rev-parse FETCH_HEAD)"
+    if [ "$local_head" != "$remote_head" ]; then
+        echo -e "${RED}❌ ERROR: HEAD is not in sync with the latest origin/$BASE_BRANCH commit.${NC}" >&2
+        echo "   HEAD:                $local_head" >&2
+        echo "   origin/$BASE_BRANCH: $remote_head" >&2
+        echo "   Update to the latest $BASE_BRANCH (e.g. git pull --ff-only origin $BASE_BRANCH), or pass --no-sync-check." >&2
+        exit 1
+    fi
+    echo -e "${GREEN}✓ In sync with origin/$BASE_BRANCH ($remote_head)${NC}"
+fi
+
+if ! command -v git-cliff >/dev/null 2>&1; then
+    echo -e "${RED}❌ ERROR: git-cliff is required to generate the changelog (install: cargo install git-cliff).${NC}" >&2
+    exit 1
+fi
+
+crate_version() {
+    cargo metadata --format-version=1 --no-deps \
+        | jq -r --arg p "$PACKAGE" '.packages[] | select(.name == $p) | .version'
+}
+
+PREV_VERSION="$(crate_version)"
+echo -e "${BLUE}Current version: $PREV_VERSION${NC}"
+
+# Validate the argument: either a known semver level, or an exact version that is well-formed
+# and strictly greater than the current version. Levels are left to cargo-release, which always
+# produces a higher version.
+case "$LEVEL_OR_VERSION" in
+    major|minor|patch|release|rc|beta|alpha) ;;
+    *)
+        if ! printf '%s' "$LEVEL_OR_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo -e "${RED}❌ ERROR: '$LEVEL_OR_VERSION' is not a valid version or release level${NC}" >&2
+            echo "   Expected a level (major|minor|patch|release|rc|beta|alpha) or a semver version (e.g. 0.6.0)." >&2
+            exit 1
+        fi
+        highest="$(printf '%s\n%s\n' "$PREV_VERSION" "$LEVEL_OR_VERSION" | sort -V | tail -n1)"
+        if [ "$LEVEL_OR_VERSION" = "$PREV_VERSION" ] || [ "$highest" != "$LEVEL_OR_VERSION" ]; then
+            echo -e "${RED}❌ ERROR: version $LEVEL_OR_VERSION must be greater than the current version $PREV_VERSION${NC}" >&2
+            exit 1
+        fi
+        ;;
+esac
+
+# 1. Bump the version (shared across the workspace via [workspace.package]).
+echo -e "${BLUE}--- Bumping version ($LEVEL_OR_VERSION) ---${NC}"
+cargo release version "$LEVEL_OR_VERSION" --package "$PACKAGE" --execute --no-confirm
+
+# 2. Apply pre-release replacements (docs + changelog).
+echo -e "${BLUE}--- Updating version references and changelog ---${NC}"
+cargo release replace --package "$PACKAGE" --execute --no-confirm
+
+NEW_VERSION="$(crate_version)"
+echo -e "${GREEN}Bumped $PREV_VERSION -> $NEW_VERSION${NC}"
+
+if [ "$NEW_VERSION" = "$PREV_VERSION" ]; then
+    echo -e "${RED}❌ ERROR: version did not change${NC}" >&2
+    exit 1
+fi
+
+# The instrumentation crates are a separate workspace, so cargo-release does not touch them.
+# Bump their datadog-opentelemetry dependency pin (kept as major.minor to match the existing
+# style) and refresh that workspace's lockfile so it stays consistent with the released version.
+version_req="$(printf '%s' "$NEW_VERSION" | cut -d. -f1,2)"
+lambda_manifest="instrumentation/datadog-aws-lambda/Cargo.toml"
+echo -e "${BLUE}--- Bumping datadog-opentelemetry pin in $lambda_manifest to $version_req ---${NC}"
+sed -i -E "s|(datadog-opentelemetry = \{ version = \")[^\"]+|\1${version_req}|g" "$lambda_manifest"
+cargo update --manifest-path instrumentation/Cargo.toml --package datadog-opentelemetry
+
+# 3. Prepend a changelog section listing the commits since the last release.
+echo -e "${BLUE}--- Populating changelog for $NEW_VERSION ---${NC}"
+CHANGELOG="$PACKAGE/CHANGELOG.md"
+# The previous tag: the most recent release tag reachable from HEAD (not merely the
+# highest version, which may live on another branch).
+previous_tag="$(git describe --tags --abbrev=0 --match "$PACKAGE-v*" 2>/dev/null || true)"
+if [ -n "$previous_tag" ]; then
+    cliff_range=("$previous_tag..HEAD")
+    echo "Listing commits since $previous_tag" >&2
+else
+    cliff_range=()   # no prior release tag: include all history
+    echo "No previous $PACKAGE release tag found; listing all history" >&2
+fi
+
+# git-cliff renders the entries: a plain list with PR links, omitting chore/ci/docs/test
+# (see cliff.toml). Strip any leading blank lines it emits before the first bullet.
+commits="$(git cliff --config cliff.toml "${cliff_range[@]}" 2>/dev/null | sed '/./,$!d')"
+if [ -z "$commits" ]; then
+    commits="- _No changes._"
+fi
+
+# Insert a new "## <version> (<date>)" section right after the "# Changelog" title line.
+release_date="$(date +'%b %d, %Y')"
+tmp="$(mktemp)"
+{
+    printf '# Changelog\n\n'
+    printf '## %s (%s)\n\n' "$NEW_VERSION" "$release_date"
+    printf '%s\n\n' "$commits"
+    # everything after the original "# Changelog" title line (drop its following blank line)
+    tail -n +2 "$CHANGELOG" | sed '1{/^$/d}'
+} > "$tmp"
+mv "$tmp" "$CHANGELOG"
+
+# 3a. Verify rustdocs still build (mirrors docs/releasing.md).
+echo -e "${BLUE}--- Building rustdocs (+$DOC_TOOLCHAIN) ---${NC}"
+RUSTDOCFLAGS="--cfg docsrs" cargo "+$DOC_TOOLCHAIN" doc --package "$PACKAGE" --no-deps
+
+# 3b. Verify every version reference now points at the new version.
+echo -e "${BLUE}--- Verifying version references ---${NC}"
+fail=0
+check() {
+    local description="$1" file="$2" pattern="$3"
+    if ! grep -qF "$pattern" "$file"; then
+        echo -e "${RED}  ✗ $description not updated in $file (expected '$pattern')${NC}" >&2
+        fail=1
+    else
+        echo -e "${GREEN}  ✓ $description${NC}"
+    fi
+}
+check "README install snippet"  "README.md"                          "datadog-opentelemetry = { version = \"$NEW_VERSION\" }"
+check "README docs.rs link"     "README.md"                          "docs.rs/datadog-opentelemetry/$NEW_VERSION/"
+check "lib.rs install snippet"  "$PACKAGE/src/lib.rs"                "datadog-opentelemetry = { version = \"$NEW_VERSION\" }"
+check "bug report template"     ".github/ISSUE_TEMPLATE/bug_report.yml" "placeholder: \"$NEW_VERSION\""
+check "aws-lambda dep pin"      "$lambda_manifest"                   "datadog-opentelemetry = { version = \"$version_req\""
+check "changelog section"       "$PACKAGE/CHANGELOG.md"              "## $NEW_VERSION"
+if [ "$fail" -ne 0 ]; then
+    echo -e "${RED}❌ ERROR: version reference verification failed${NC}" >&2
+    exit 1
+fi
+
+# 3c. Verify the crate still packages/publishes cleanly against the updated lockfile.
+if [ "$RUN_PUBLISH_DRY_RUN" = true ]; then
+    echo -e "${BLUE}--- cargo publish --dry-run ---${NC}"
+    cargo publish --package "$PACKAGE" --all-features --locked --dry-run --allow-dirty
+fi
+
+echo -e "${GREEN}✓ Release proposal prepared: $PREV_VERSION -> $NEW_VERSION${NC}"
+
+# Expose results to GitHub Actions when running in CI.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "prev_version=$PREV_VERSION"
+        echo "new_version=$NEW_VERSION"
+    } >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -36,8 +36,9 @@ Usage: $(basename "$0") [OPTIONS] <LEVEL|VERSION>
 Prepares a $PACKAGE release proposal in the working tree (no commit/tag/publish).
 
 Arguments:
-    <LEVEL|VERSION>     A semver level (major|minor|patch|release|rc|beta|alpha)
-                        or an exact version (e.g. 0.5.0).
+    <LEVEL|VERSION>     A semver level (major|minor|patch) or an exact stable
+                        version (e.g. 0.6.0). Prereleases are not supported
+                        (the publish workflow only triggers on stable X.Y.Z tags).
 
 Options:
     -h, --help                  Show this help message
@@ -148,14 +149,20 @@ crate_version() {
 PREV_VERSION="$(crate_version)"
 echo -e "${BLUE}Current version: $PREV_VERSION${NC}"
 
-# Validate the argument: either a known semver level, or an exact version that is well-formed
-# and strictly greater than the current version
+# Validate the argument: a stable semver level, or an exact stable version that is well-formed and
+# strictly greater than the current version. Prereleases are rejected: cargo-release skips the
+# pre-release-replacements for prerelease versions (their `prerelease` flag defaults to false), and
+# the publish workflow only triggers on stable X.Y.Z tags anyway.
 case "$LEVEL_OR_VERSION" in
-    major|minor|patch|release|rc|beta|alpha) ;;
+    major|minor|patch) ;;
+    release|rc|beta|alpha)
+        echo -e "${RED}❌ ERROR: prerelease level '$LEVEL_OR_VERSION' is not supported; use major|minor|patch or a stable version.${NC}" >&2
+        exit 1
+        ;;
     *)
-        if ! printf '%s' "$LEVEL_OR_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
-            echo -e "${RED}❌ ERROR: '$LEVEL_OR_VERSION' is not a valid version or release level${NC}" >&2
-            echo "   Expected a level (major|minor|patch|release|rc|beta|alpha) or a semver version (e.g. 0.6.0)." >&2
+        if ! printf '%s' "$LEVEL_OR_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo -e "${RED}❌ ERROR: '$LEVEL_OR_VERSION' is not a supported level or stable version${NC}" >&2
+            echo "   Expected major|minor|patch or a stable semver version (e.g. 0.6.0); prereleases are not supported." >&2
             exit 1
         fi
         highest="$(printf '%s\n%s\n' "$PREV_VERSION" "$LEVEL_OR_VERSION" | sort -V | tail -n1)"

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -256,7 +256,7 @@ publish_crate() {
         return 1
     fi
     
-    local publish_cmd="cargo publish --package $crate_name --token $token --all-features"
+    local publish_cmd="cargo publish --locked --package $crate_name --token $token --all-features"
     
     if [ "$dry_run" = "true" ]; then
         publish_cmd="$publish_cmd --dry-run"

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -19,6 +19,12 @@ ALLOWED_CRATES=(
 
 LIBDATADOG_OWNERS="github:datadog:libdatadog-owners"
 
+# Semver version with an optional prerelease suffix (e.g. 1.2.3 or 1.2.3-rc.1).
+VERSION_REGEX='[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?'
+# Full release tag: {crate-name}-v{version}. Used with `[[ ... =~ $TAG_REGEX ]]` (unquoted);
+# on match, BASH_REMATCH[1] is the crate name and BASH_REMATCH[2] is the version.
+TAG_REGEX="^(.+)-v(${VERSION_REGEX})$"
+
 usage() {
     cat << EOF
 Usage: $(basename "$0") [OPTIONS] <tag1> [tag2] [tag3] ...
@@ -61,7 +67,7 @@ validate_tag() {
     local tag=$1
     
     # Check format: {crate-name}-v{semver}
-    if [[ ! "$tag" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    if [[ ! "$tag" =~ $TAG_REGEX ]]; then
         echo -e "${RED}❌ Invalid tag format: $tag${NC}" >&2
         echo "   Expected format: {crate-name}-v{version} (e.g., libdd-common-v1.0.0)" >&2
         return 1
@@ -104,7 +110,7 @@ sort_tags() {
     local -a final_sorted=()
     for allowed in "${ALLOWED_CRATES[@]}"; do
         for tag in "${sorted_tags[@]}"; do
-            if [[ "$tag" =~ ^${allowed}-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ "$tag" =~ ^${allowed}-v${VERSION_REGEX}$ ]]; then
                 final_sorted+=("$tag")
             fi
         done
@@ -186,7 +192,7 @@ publish_crate() {
     echo "Processing tag: $tag" >&2
     
     # Extract crate name and version
-    if [[ "$tag" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    if [[ "$tag" =~ $TAG_REGEX ]]; then
         local crate_name="${BASH_REMATCH[1]}"
         local crate_version="${BASH_REMATCH[2]}"
         echo "Crate: $crate_name" >&2
@@ -286,7 +292,7 @@ check_crate_only() {
     echo "Processing tag: $tag" >&2
     
     # Extract crate name and version
-    if [[ "$tag" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    if [[ "$tag" =~ $TAG_REGEX ]]; then
         local crate_name="${BASH_REMATCH[1]}"
         local crate_version="${BASH_REMATCH[2]}"
         echo "Crate: $crate_name" >&2
@@ -338,7 +344,7 @@ check_publication_status() {
         if check_crate_only "$tag"; then
             ((++published))
         else
-            if [[ "$tag" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            if [[ "$tag" =~ $TAG_REGEX ]]; then
                 ((++not_published))
             else
                 ((++failed))


### PR DESCRIPTION
# What does this PR do?

- Remove hardcoded version from integration test files snapshots
- Add the `prepare-release.sh` script to automate manual tasks needed to prepare a new release: 
  - Verify rustdocs
  - Replace versions found in README.md and other files
  - Bump Cargo.toml versions
  - Update CHANGELOG entries
- Add cargo release and git cliff config files
