### PR TITLE
ci(release): add release-proposal-dispatch workflow

### DIFF
--- a/.github/chainguard/self.write.pr.sts.yaml
+++ b/.github/chainguard/self.write.pr.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: "repo:DataDog/dd-trace-rs.*"
 
 claim_pattern:
-  ref: "refs/heads/(main|release)"
+  ref: "^refs/heads/(main|release)$"
   ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-rs/\.github/workflows/release-proposal-dispatch\.yaml@.+
 

--- a/.github/chainguard/self.write.pr.sts.yaml
+++ b/.github/chainguard/self.write.pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rs.*"
+
+claim_pattern:
+  ref: "refs/heads/(main|release)"
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-rs/\.github/workflows/release-proposal-dispatch\.yaml@.+
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/self.write.pr.sts.yaml
+++ b/.github/chainguard/self.write.pr.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: "repo:DataDog/dd-trace-rs.*"
 
 claim_pattern:
-  ref: "^refs/heads/(main|release)$"
+  ref: "^refs/heads/main$"
   ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-rs/\.github/workflows/release-proposal-dispatch\.yaml@.+
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,24 +4,36 @@ on:
   push:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+*'
-env:
-  RUST_VERSION: 1.87.0
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - name: "Install Rust ${RUST_VERSION}"
-        run: rustup install ${RUST_VERSION} && rustup default ${RUST_VERSION}
+      - name: "Checkout sources"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: "Resolve Rust version from Cargo.toml"
+        id: rust
+        shell: bash
+        run: |
+          version="$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "::error::could not read rust-version from [workspace.package] in Cargo.toml"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: "Install Rust ${{ steps.rust.outputs.version }}"
+        shell: bash
+        env:
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
+        run: rustup install "${RUST_VERSION}" && rustup default "${RUST_VERSION}"
 
       - name: "Install nextest"
         uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # 2.49.15
         with:
           tool: nextest@0.9.96
-
-      - name: "Checkout sources"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: "Get tag"
         id: tag

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,36 +4,24 @@ on:
   push:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+*'
+env:
+  RUST_VERSION: 1.87.0
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - name: "Checkout sources"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-
-      - name: "Resolve Rust version from Cargo.toml"
-        id: rust
-        shell: bash
-        run: |
-          version="$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
-          if [ -z "${version}" ]; then
-            echo "::error::could not read rust-version from [workspace.package] in Cargo.toml"
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: "Install Rust ${{ steps.rust.outputs.version }}"
-        shell: bash
-        env:
-          RUST_VERSION: ${{ steps.rust.outputs.version }}
-        run: rustup install "${RUST_VERSION}" && rustup default "${RUST_VERSION}"
+      - name: "Install Rust ${RUST_VERSION}"
+        run: rustup install ${RUST_VERSION} && rustup default ${RUST_VERSION}
 
       - name: "Install nextest"
         uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # 2.49.15
         with:
           tool: nextest@0.9.96
+
+      - name: "Checkout sources"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: "Get tag"
         id: tag

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -1,0 +1,166 @@
+name: Release - Open a release PR
+
+# Opens a `chore(release): proposal vX.Y.Z` pull request that bumps the crate
+# version and updates all version references (docs + changelog). It does NOT
+# tag or publish: after this PR is merged, tag the commit to trigger publishing
+# (see docs/releasing.md and .github/workflows/publish.yaml).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver level (major | minor | patch | rc | beta | alpha) or an exact version (e.g. 0.6.0 or 0.6.0-rc.1)"
+        required: true
+        type: string
+      base-branch:
+        description: "Branch to release from and target the PR at. Use a hotfix/release branch to cut a hotfix from an older line."
+        required: false
+        type: string
+        default: main
+
+jobs:
+  propose:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Enable OIDC
+      contents: write
+      pull-requests: write
+    env:
+      RUSTUP_TOOLCHAIN: 1.92.0
+    steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        # A non-protected branch can't mint a token (see the STS policy). Don't fail the job; the
+        # steps below detect the missing token and fall back to a test run (unsigned push, no PR).
+        continue-on-error: true
+        with:
+          scope: DataDog/dd-trace-rs
+          policy: self.write.pr
+
+      - name: "Checkout sources"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          # Release from (and later target the PR at) the chosen base branch.
+          ref: ${{ inputs.base-branch }}
+          # Full history + tags so prepare-release.sh can list commits since the last release tag.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+
+      - name: "Install cargo-release"
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
+        with:
+          tool: cargo-release@1.1.2
+
+      - name: "Install git-cliff"
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
+        with:
+          tool: git-cliff@2.13.1
+
+      - name: "Prepare release proposal"
+        id: prepare
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: ./scripts/prepare-release.sh --no-codex-check --base-branch "${BASE_BRANCH}" "${VERSION}"
+
+      - name: Configure Git for signing
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          # GET /user is not allowed with installation tokens; use GET /users/ACTOR (who triggered the workflow).
+          GITHUB_USER_RESPONSE=$(curl -s -H "Authorization: token ${GH_TOKEN}" "https://api.github.com/users/${GITHUB_ACTOR}")
+          GIT_USER_NAME=$(echo "${GITHUB_USER_RESPONSE}" | jq -r '.login // empty')
+          GIT_USER_ID=$(echo "${GITHUB_USER_RESPONSE}" | jq -r '.id // empty')
+          if [[ -z "$GIT_USER_NAME" ]]; then
+            GIT_USER_NAME="${GITHUB_ACTOR}"
+            GIT_USER_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
+          else
+            GIT_USER_EMAIL="${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+          fi
+          echo "GIT_USER_NAME: $GIT_USER_NAME"
+          echo "GIT_USER_EMAIL: $GIT_USER_EMAIL"
+          git config --global user.name "$GIT_USER_NAME"
+          git config --global user.email "$GIT_USER_EMAIL"
+
+      - name: "Create local release commit"
+        id: commit
+        shell: bash
+        env:
+          NEW_VERSION: ${{ steps.prepare.outputs.new_version }}
+        run: |
+          base_sha="$(git rev-parse HEAD)"
+
+          git commit -am "chore(release): proposal v${NEW_VERSION}"
+
+          # Timestamp the branch so re-runs (and test runs) never collide on an existing branch.
+          TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+          # commit-headless expects the new commits oldest -> newest, space-separated.
+          commits="$(git log --reverse "${base_sha}".. --format='%H' | tr '\n' ' ' | xargs)"
+          {
+            echo "base_sha=${base_sha}"
+            echo "commits=${commits}"
+            echo "branch=release/proposal-v${NEW_VERSION}/${TIMESTAMP}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: "Push verified commit"
+        if: steps.octo-sts.outcome == 'success'
+        uses: DataDog/commit-headless@action/v2.0.3
+        with:
+          branch: ${{ steps.commit.outputs.branch }}
+          head-sha: ${{ steps.commit.outputs.base_sha }}
+          command: push
+          commits: "${{ steps.commit.outputs.commits }}"
+
+      - name: "Open proposal pull request"
+        if: steps.octo-sts.outcome == 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          NEW_VERSION: ${{ steps.prepare.outputs.new_version }}
+          PREV_VERSION: ${{ steps.prepare.outputs.prev_version }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: |
+          body="$(cat <<EOF
+          Automated release proposal: bumps \`datadog-opentelemetry\` from v${PREV_VERSION} to v${NEW_VERSION}.
+
+          Generated by the **Release proposal** workflow. It bumps the workspace version,
+          updates version references in \`README.md\`, \`src/lib.rs\`, the bug-report template, and
+          the \`datadog-aws-lambda\` dependency pin, and opens a new \`## ${NEW_VERSION}\` changelog section.
+
+          ### Before merging
+          - [ ] Review the auto-populated \`## ${NEW_VERSION}\` changelog; prune to user-facing changes.
+          - [ ] Confirm the libdatadog dependencies are on their intended versions.
+          - [ ] Review the Codex Findings in Jira for new vulnerabilities since the last release:
+                https://datadoghq.atlassian.net/jira/software/c/projects/APMSP/boards/29727?quickFilter=32571
+          - [ ] Confirm README and rustdocs render correctly.
+
+          ### After merging
+          Tag the merge commit as \`datadog-opentelemetry-v${NEW_VERSION}\` and push it to trigger publishing.
+          EOF
+          )"
+
+          if ! gh pr create --base "${BASE_BRANCH}" --head "${BRANCH}" \
+                --title "chore(release): proposal v${NEW_VERSION}" \
+                --body "${body}"; then
+            echo "PR creation failed (a PR for ${BRANCH} may already exist)."
+          fi
+
+      - name: "Test run (no STS token): push unsigned, skip PR"
+        if: steps.octo-sts.outcome != 'success'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          NEW_VERSION: ${{ steps.prepare.outputs.new_version }}
+        run: |
+          echo "::warning::No STS token was minted (expected on a non-protected branch). Running in test mode:"
+          echo "  - pushing an UNSIGNED commit to '${BRANCH}'"
+          echo "  - NOT opening a pull request"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+          echo "::notice::Test run complete for v${NEW_VERSION}. Pushed unsigned branch '${BRANCH}'; no PR was opened."

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -137,6 +137,7 @@ jobs:
       - name: "Push verified commit"
         uses: DataDog/commit-headless@action/v2.0.3
         with:
+          token: ${{ steps.octo-sts.outputs.token }}
           branch: ${{ steps.commit.outputs.branch }}
           head-sha: ${{ steps.commit.outputs.base_sha }}
           create-branch: true

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -27,8 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Enable OIDC
-      contents: write
-      pull-requests: write
+      contents: read
     env:
       # Deliberately above the crate's `rust-version` (1.87.0): cargo-release 1.1.2 needs >= 1.91
       RUST_VERSION: 1.92.0

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -97,16 +97,24 @@ jobs:
 
           git commit -am "chore(release): proposal v${NEW_VERSION}"
 
-          # Timestamp the branch so re-runs (and test runs) never collide on an existing branch.
-          TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-
           # commit-headless expects the new commits oldest -> newest, space-separated.
           commits="$(git log --reverse "${base_sha}".. --format='%H' | tr '\n' ' ' | xargs)"
           {
             echo "base_sha=${base_sha}"
             echo "commits=${commits}"
-            echo "branch=release/proposal-v${NEW_VERSION}/${TIMESTAMP}"
+            echo "branch=release/proposal-v${NEW_VERSION}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: "Fail if the proposal branch already exists"
+        shell: bash
+        env:
+          BRANCH: ${{ steps.commit.outputs.branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Branch '${BRANCH}' already exists on origin. Delete it (or finish its proposal) before re-running."
+            exit 1
+          fi
+          echo "Branch '${BRANCH}' does not exist yet."
 
       - name: "Push verified commit"
         if: steps.octo-sts.outcome == 'success'

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -18,6 +18,10 @@ on:
         type: string
         default: main
 
+concurrency:
+  group: release-proposal-dispatch-group
+  cancel-in-progress: false
+
 jobs:
   propose:
     runs-on: ubuntu-latest
@@ -26,16 +30,26 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      RUSTUP_TOOLCHAIN: 1.92.0
+      # Deliberately above the crate's `rust-version` (1.87.0): cargo-release 1.1.2 needs >= 1.91
+      RUST_VERSION: 1.92.0
     steps:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
-        # A non-protected branch can't mint a token (see the STS policy). Don't fail the job; the
-        # steps below detect the missing token and fall back to a test run (unsigned push, no PR).
         continue-on-error: true
         with:
           scope: DataDog/dd-trace-rs
           policy: self.write.pr
+
+      # A protected ref is expected to mint a token, so a failure there is a real problem (policy,
+      # app installation, or octo-sts outage). Fail fast instead of silently degrading to a test run
+      # that pushes an unsigned branch and opens no PR.
+      - name: "Fail if no STS token was minted on a protected branch"
+        if: steps.octo-sts.outcome != 'success' && github.ref_protected
+        shell: bash
+        run: |
+          echo "::error::No STS token was minted on protected ref '${GITHUB_REF}'. Check the" \
+               ".github/chainguard/self.write.pr.sts.yaml policy and the dd-octo-sts app installation."
+          exit 1
 
       - name: "Checkout sources"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -45,9 +59,13 @@ jobs:
           # Full history + tags so prepare-release.sh can list commits since the last release tag.
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+      # nightly is required by prepare-release.sh's rustdoc check (RUSTDOCFLAGS="--cfg docsrs").
+      - name: "Install Rust toolchains"
+        shell: bash
+        run: |
+          rustup install "${RUST_VERSION}"
+          rustup default "${RUST_VERSION}"
+          rustup toolchain install nightly --profile minimal
 
       - name: "Install cargo-release"
         uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
@@ -67,7 +85,7 @@ jobs:
           BASE_BRANCH: ${{ inputs.base-branch }}
         run: ./scripts/prepare-release.sh --no-codex-check --base-branch "${BASE_BRANCH}" "${VERSION}"
 
-      - name: Configure Git for signing
+      - name: Configure Git author
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GITHUB_ACTOR: ${{ github.actor }}
@@ -95,7 +113,9 @@ jobs:
         run: |
           base_sha="$(git rev-parse HEAD)"
 
-          git commit -am "chore(release): proposal v${NEW_VERSION}"
+          git add -A
+          git --no-pager diff --cached --stat
+          git commit -m "chore(release): proposal v${NEW_VERSION}"
 
           # commit-headless expects the new commits oldest -> newest, space-separated.
           commits="$(git log --reverse "${base_sha}".. --format='%H' | tr '\n' ' ' | xargs)"
@@ -157,11 +177,13 @@ jobs:
           if ! gh pr create --base "${BASE_BRANCH}" --head "${BRANCH}" \
                 --title "chore(release): proposal v${NEW_VERSION}" \
                 --body "${body}"; then
-            echo "PR creation failed (a PR for ${BRANCH} may already exist)."
+            echo "::error::Failed to open the proposal pull request for '${BRANCH}'. The branch was" \
+                 "pushed, so open the PR manually against '${BASE_BRANCH}', or delete the branch and re-run."
+            exit 1
           fi
 
       - name: "Test run (no STS token): push unsigned, skip PR"
-        if: steps.octo-sts.outcome != 'success'
+        if: steps.octo-sts.outcome != 'success' && !github.ref_protected
         shell: bash
         env:
           BRANCH: ${{ steps.commit.outputs.branch }}

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -71,7 +71,17 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           BASE_BRANCH: ${{ inputs.base-branch }}
-        run: ./scripts/prepare-release.sh --no-codex-check --base-branch "${BASE_BRANCH}" "${VERSION}"
+        run: |
+          # The script comes from base-branch, not from this workflow's ref, so a hotfix line cut
+          # from a tag that predates the release automation will not have it.
+          if [ ! -x ./scripts/prepare-release.sh ]; then
+            echo "::error::'${BASE_BRANCH}' has no scripts/prepare-release.sh. Backport the release" \
+                 "automation to that branch first (see docs/releasing.md, 'Cutting a hotfix')."
+            exit 1
+          fi
+          # No --no-codex-check: the script only prompts when stdin is a TTY, so in CI it just logs a
+          # reminder. Not passing it keeps this working with any branch whose script predates the flag.
+          ./scripts/prepare-release.sh --base-branch "${BASE_BRANCH}" "${VERSION}"
 
       - name: Configure Git author
         env:

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -35,21 +35,9 @@ jobs:
     steps:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
-        continue-on-error: true
         with:
           scope: DataDog/dd-trace-rs
           policy: self.write.pr
-
-      # A protected ref is expected to mint a token, so a failure there is a real problem (policy,
-      # app installation, or octo-sts outage). Fail fast instead of silently degrading to a test run
-      # that pushes an unsigned branch and opens no PR.
-      - name: "Fail if no STS token was minted on a protected branch"
-        if: steps.octo-sts.outcome != 'success' && github.ref_protected
-        shell: bash
-        run: |
-          echo "::error::No STS token was minted on protected ref '${GITHUB_REF}'. Check the" \
-               ".github/chainguard/self.write.pr.sts.yaml policy and the dd-octo-sts app installation."
-          exit 1
 
       - name: "Checkout sources"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -137,16 +125,15 @@ jobs:
           echo "Branch '${BRANCH}' does not exist yet."
 
       - name: "Push verified commit"
-        if: steps.octo-sts.outcome == 'success'
         uses: DataDog/commit-headless@action/v2.0.3
         with:
           branch: ${{ steps.commit.outputs.branch }}
           head-sha: ${{ steps.commit.outputs.base_sha }}
+          create-branch: true
           command: push
           commits: "${{ steps.commit.outputs.commits }}"
 
       - name: "Open proposal pull request"
-        if: steps.octo-sts.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
@@ -181,16 +168,3 @@ jobs:
                  "pushed, so open the PR manually against '${BASE_BRANCH}', or delete the branch and re-run."
             exit 1
           fi
-
-      - name: "Test run (no STS token): push unsigned, skip PR"
-        if: steps.octo-sts.outcome != 'success' && !github.ref_protected
-        shell: bash
-        env:
-          BRANCH: ${{ steps.commit.outputs.branch }}
-          NEW_VERSION: ${{ steps.prepare.outputs.new_version }}
-        run: |
-          echo "::warning::No STS token was minted (expected on a non-protected branch). Running in test mode:"
-          echo "  - pushing an UNSIGNED commit to '${BRANCH}'"
-          echo "  - NOT opening a pull request"
-          git push origin "HEAD:refs/heads/${BRANCH}"
-          echo "::notice::Test run complete for v${NEW_VERSION}. Pushed unsigned branch '${BRANCH}'; no PR was opened."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,10 +30,12 @@ Inputs:
 > [!IMPORTANT]
 > Always **dispatch the workflow from `main`** (`--ref main`). Minting the PR token is restricted to
 > protected branches, so to cut a hotfix from an older line keep `--ref main` and set the
-> `base-branch` input (e.g. `-f base-branch=hotfix/0.5.x`) do not dispatch directly from the hotfix
-> branch. Dispatching from a non-protected branch instead runs in a test mode that pushes an
-> unsigned branch and skips the PR (handy for trying the workflow out). The proposal branch name is
-> `release/proposal-v<version>`; the run fails if that branch already exists.
+> `base-branch` input (e.g. `-f base-branch=hotfix/0.5.x`); do not dispatch directly from the
+> hotfix branch. Dispatching from a non-protected branch instead runs in a test mode that pushes an
+> unsigned branch and skips the PR (handy for trying the workflow out). Failing to mint the token
+> from a protected branch is instead treated as a broken policy or app installation and fails the
+> job. The proposal branch name is `release/proposal-v<version>`; the run fails if that branch
+> already exists.
 
 After the workflow opens the PR, review it (especially the generated changelog), merge it, then
 continue with the tag and publish steps (6–9 below). The workflow does **not** tag or publish.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,16 +4,47 @@
 
 > [!CAUTION]
 > Before releasing, check the Codex Security Scanning results board and ensure there are no new
-> vulnerabilities discovered since the last release.
-> If new vulnerabilities exist for the commit being released, discuss with the team whether
-> releasing is safe, or if it should be delayed to resolve the vulnerability.
+> vulnerabilities discovered since the last release. If new vulnerabilities exist for the commit
+> being released, discuss with the team whether releasing is safe, or if it should be delayed to
+> resolve the vulnerability.
+
+### Preparing the release with the GitHub workflow (recommended)
+
+The **Release - Open a release PR** workflow (`.github/workflows/release-proposal-dispatch.yaml`)
+runs the preparation on CI and opens the proposal pull request for you. It runs
+`scripts/prepare-release.sh` (see below), commits the result as a verified (signed) commit, and
+opens a `chore(release): proposal vX.Y.Z` PR that targets the base branch.
+
+Trigger it from the GH UI ("Release - Open a release PR" → **Run workflow**) or with the CLI:
+
+```text
+gh workflow run release-proposal-dispatch.yaml --ref main \
+  -f version=minor      # major | minor | patch | rc | beta | alpha, or an exact 0.6.0 / 0.6.0-rc.1
+```
+
+Inputs:
+
+- `version` — the semver level or exact version to release.
+- `base-branch` — branch to release from and target the PR at (default `main`).
+
+> [!IMPORTANT]
+> Always **dispatch the workflow from `main`** (`--ref main`). Minting the PR token is restricted to
+> protected branches, so to cut a hotfix from an older line keep `--ref main` and set the
+> `base-branch` input (e.g. `-f base-branch=hotfix/0.5.x`) do not dispatch directly from the hotfix
+> branch. Dispatching from a non-protected branch instead runs in a test mode that pushes an
+> unsigned branch and skips the PR (handy for trying the workflow out). The proposal branch name is
+> `release/proposal-v<version>`; the run fails if that branch already exists.
+
+After the workflow opens the PR, review it (especially the generated changelog), merge it, then
+continue with the tag and publish steps (6–9 below). The workflow does **not** tag or publish.
 
 ### Preparing the release with the helper script
 
-`scripts/prepare-release.sh` automates most of the preparation below — the version bump, the
-version-reference updates, the changelog generation, and the verification. It does **not** commit,
-tag, or publish, and it does not replace the surrounding steps: you still bump libdatadog (step 1),
-review the incoming commits (step 2), and merge, tag, and publish (steps 6–9) yourself.
+`scripts/prepare-release.sh` (which the workflow above runs) can also be run locally. It automates
+most of the preparation below — the version bump, the version-reference updates, the changelog
+generation, and the verification. It does **not** commit, tag, or publish, and it does not replace
+the surrounding steps: you still bump libdatadog (step 1), review the incoming commits (step 2), and
+merge, tag, and publish (steps 6–9) yourself.
 
 The script handles the rest of the steps (3–5) and it requires `cargo-release`, `git-cliff`, and
 `jq`.
@@ -88,6 +119,5 @@ git push origin $TAG
 8. Once the tag has been pushed, the publish job will need to be approved by another member of the
    apm-rust github group
 
-9. Make a github release, from the previous release to the new tag.
-   You can auto-generate the release notes.
-   <https://github.com/DataDog/dd-trace-rs/releases/new>
+9. Make a github release, from the previous release to the new tag. You can auto-generate the
+   release notes. <https://github.com/DataDog/dd-trace-rs/releases/new>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,6 +37,37 @@ Inputs:
 After the workflow opens the PR, review it (especially the generated changelog), merge it, then
 continue with the tag and publish steps (6–9 below). The workflow does **not** tag or publish.
 
+### Cutting a hotfix
+
+A hotfix is released from a `hotfix/<major>.<minor>.x` branch instead of `main`, so `main` can keep
+moving. The workflow always runs `main`'s YAML but the **base branch's**
+`scripts/prepare-release.sh`, and releases up to and including v0.5.0 predate the release
+automation — a branch cut from one of those tags carries none of it, so it has to be backported
+before the workflow can prepare a proposal.
+
+1. Create the branch from the release tag being patched, and push it:
+
+```text
+git switch -c hotfix/0.5.x datadog-opentelemetry-v0.5.0
+git push -u origin hotfix/0.5.x
+```
+
+2. Land the fix on that branch (usually a cherry-pick from `main`). If the branch has no
+   `scripts/prepare-release.sh`, backport the release automation too: that script, `cliff.toml`, and
+   the `[package.metadata.release]` block in `datadog-opentelemetry/Cargo.toml`. Without them the
+   workflow fails at the prepare step.
+
+3. Dispatch the workflow **from `main`** (not from the hotfix branch), targeting the hotfix line:
+
+```text
+gh workflow run release-proposal-dispatch.yaml --ref main \
+  -f version=patch -f base-branch=hotfix/0.5.x
+```
+
+4. Review and merge the proposal PR into `hotfix/0.5.x`, then tag that merge commit and push the
+   tag to publish (steps 7–9 below). The changelog covers only the commits since the tag the
+   branch was cut from, so it stays scoped to the hotfix.
+
 ### Preparing the release with the helper script
 
 `scripts/prepare-release.sh` (which the workflow above runs) can also be run locally. It automates

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,11 +31,8 @@ Inputs:
 > Always **dispatch the workflow from `main`** (`--ref main`). Minting the PR token is restricted to
 > protected branches, so to cut a hotfix from an older line keep `--ref main` and set the
 > `base-branch` input (e.g. `-f base-branch=hotfix/0.5.x`); do not dispatch directly from the
-> hotfix branch. Dispatching from a non-protected branch instead runs in a test mode that pushes an
-> unsigned branch and skips the PR (handy for trying the workflow out). Failing to mint the token
-> from a protected branch is instead treated as a broken policy or app installation and fails the
-> job. The proposal branch name is `release/proposal-v<version>`; the run fails if that branch
-> already exists.
+> hotfix branch. The proposal branch name is `release/proposal-v<version>`; the run fails if
+> that branch already exists.
 
 After the workflow opens the PR, review it (especially the generated changelog), merge it, then
 continue with the tag and publish steps (6–9 below). The workflow does **not** tag or publish.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -127,14 +127,16 @@ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p datadog-opentelemetry --no-dep
 
 6. Merge the bump commit in `main`
 
-7. Tag the bump commit with the release version. The tag should follow the following format:
-   `datadog-opentelemetry-v0.0.0`, then push it to github.
+7. Tag the release commit with the version. Set `BUMP_COMMIT_HASH` to the commit being released —
+   the version-bump merge commit on `main` for a normal release, or the hotfix merge commit on the
+   `hotfix/<major>.<minor>.x` branch for a hotfix (do **not** tag `main` for a hotfix). The tag must
+   follow the format `datadog-opentelemetry-v0.0.0`, then push it to github.
 
 ```text
 VERSION="0.0.0" # Placeholder, please replace!
 BUMP_COMMIT_HASH="PUT THE HASH HERE" # Placeholder, please replace!
 TAG="datadog-opentelemetry-v$VERSION"
-git tag $TAG main -m "Release v$VERSION of datadog-opentelemetry"
+git tag $TAG $BUMP_COMMIT_HASH -m "Release v$VERSION of datadog-opentelemetry"
 echo "Tagged release $TAG"
 ```
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -27,6 +27,7 @@ DOC_TOOLCHAIN="nightly"
 RUN_PUBLISH_DRY_RUN=true
 ALLOW_DIRTY=false
 CHECK_SYNC=true
+CHECK_CODEX=true
 CODEX_JIRA_URL="https://datadoghq.atlassian.net/jira/software/c/projects/APMSP/boards/29727?quickFilter=32571"
 
 usage() {
@@ -44,6 +45,7 @@ Options:
         --base-branch <NAME>    Branch to release from and verify sync against (default: $BASE_BRANCH).
                                 Use a hotfix/release branch to cut a hotfix from an older line.
         --allow-dirty           Proceed even if the working tree has uncommitted changes
+        --no-codex-check        Skip the Codex Findings review prompt/reminder
         --no-sync-check         Skip verifying HEAD matches the latest origin/<base-branch> commit
         --no-publish-dry-run    Skip the 'cargo publish --dry-run' verification step
         --doc-toolchain <NAME>  Rust toolchain used for the rustdocs build (default: $DOC_TOOLCHAIN)
@@ -61,6 +63,7 @@ while [[ $# -gt 0 ]]; do
         -h|--help) usage; exit 0 ;;
         --base-branch) BASE_BRANCH="$2"; shift 2 ;;
         --allow-dirty) ALLOW_DIRTY=true; shift ;;
+        --no-codex-check) CHECK_CODEX=false; shift ;;
         --no-sync-check) CHECK_SYNC=false; shift ;;
         --no-publish-dry-run) RUN_PUBLISH_DRY_RUN=false; shift ;;
         --doc-toolchain) DOC_TOOLCHAIN="$2"; shift 2 ;;
@@ -81,18 +84,20 @@ if [ -z "$LEVEL_OR_VERSION" ]; then
     exit 1
 fi
 
-echo -e "${BLUE}Codex Findings (Jira): $CODEX_JIRA_URL${NC}" >&2
-if [ -t 0 ]; then
-    read -r -p "Have you reviewed them for this release? [y/N] " codex_ack
-    case "$codex_ack" in
-        y|Y|yes|Yes) ;;
-        *)
-            echo -e "${RED}❌ Aborting: please review them before releasing.${NC}" >&2
-            exit 1
-            ;;
-    esac
-else
-    echo -e "${BLUE}⚠️  Reminder: review the Codex Findings before releasing.${NC}" >&2
+if [ "$CHECK_CODEX" = true ]; then
+    echo -e "${BLUE}Codex Findings (Jira): $CODEX_JIRA_URL${NC}" >&2
+    if [ -t 0 ]; then
+        read -r -p "Have you reviewed them for this release? [y/N] " codex_ack
+        case "$codex_ack" in
+            y|Y|yes|Yes) ;;
+            *)
+                echo -e "${RED}❌ Aborting: please review them before releasing.${NC}" >&2
+                exit 1
+                ;;
+        esac
+    else
+        echo -e "${BLUE}⚠️  Reminder: review the Codex Findings before releasing.${NC}" >&2
+    fi
 fi
 
 # A dirty tree means the resulting commit would include unrelated changes, so fail early with a


### PR DESCRIPTION
## What

Adds the **Release proposal** GitHub workflow that drives `scripts/prepare-release.sh` (merged in #279), plus its supporting pieces:

- `.github/workflows/release-proposal-dispatch.yaml` — `workflow_dispatch` → resolve toolchain → install `cargo-release`/`git-cliff` → `prepare-release.sh` → signed commit via `commit-headless` → PR via `octo-sts`.
- `.github/workflows/chainguard/self.write.pr.sts.yaml` — the `self.write.pr` STS policy used to mint the PR token.
- `prepare-release.sh` — new `--no-codex-check` flag (the workflow passes it, since the PR checklist carries the Codex review).

## How to use

- **Normal release:** dispatch the workflow **from `main`** with a `version` (`minor`, `patch`, `major`, or an exact `0.6.0` / `0.6.0-rc.1`). It opens a `chore(release): proposal vX.Y.Z` PR.
- **Hotfix:** still dispatch **from `main`**, but set the `base-branch` input to the hotfix line (e.g. `hotfix/0.5.x`). The STS policy requires a protected branch, so the workflow must always be *dispatched* from `main`; `base-branch` controls what gets checked out and where the PR is targeted.

## Testing from a non-protected branch

No STS token can be minted off a protected branch, so the workflow **falls back to a test run**: it pushes the proposal branch **unsigned** and **skips PR creation**, logging a `::warning::`/`::notice::` explaining what was skipped. This lets the full prepare → commit → push flow be exercised without signing/PR permissions.

## Notes

- Does **not** tag or publish — after the proposal PR merges, tag the commit to trigger `publish.yaml`.
- Stacked on the release-automation work merged in #279.
