### PR TITLE
feat(log): route the tracer's own diagnostics through tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,5 @@ datadog_opentelemetry::tracing()
 * `logs` enabled the log provider
 * `logs-grpc` enabled the log provider, with GRPC OTLP export
 * `logs-http` enabled the log provider, with HTTP OTLP export
+* `log-compat` routes the tracer's internal diagnostics through the `log` facade when no `tracing`
+  subscriber is available

--- a/datadog-opentelemetry/Cargo.toml
+++ b/datadog-opentelemetry/Cargo.toml
@@ -46,6 +46,8 @@ uuid = { version = "1.11.0", features = ["v4"] }
 arc-swap = "1.7.1"
 ctor = "0.2"
 libc = "0.2"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+log = { version = "0.4.21", optional = true }
 
 # core Test utils
 criterion = { version = "0.5.1", optional = true }
@@ -108,6 +110,7 @@ logs-http = [
     "opentelemetry-otlp/http-proto",
     "opentelemetry-otlp/reqwest-blocking-client",
 ]
+log-compat = ["dep:log"]
 _unstable_propagation = []
 # Emits sampled allocation USDT probes for out-of-process profilers to pick up.
 #

--- a/datadog-opentelemetry/examples/README.md
+++ b/datadog-opentelemetry/examples/README.md
@@ -23,3 +23,10 @@ The server runs on `http://localhost:3000` with endpoints:
 - `/health` - Health check endpoint
 - `/echo` - Echo request body
 - `/jump` - Makes outbound request to port 3001
+
+It also shows where the tracer's own diagnostics go. They are emitted through `tracing` under the
+`datadog_opentelemetry` target, so the subscriber built in `init_logs` decides where they go: the
+console through `fmt`, while the OpenTelemetry bridge excludes the trace transport's own crates so a
+failed export cannot produce further records to export. How verbose they are is a separate setting,
+controlled by `DD_LOG_LEVEL` — this example sets `Debug` in code. The subscriber is installed
+before the tracer, because diagnostics emitted before one exists are printed rather than routed.

--- a/datadog-opentelemetry/examples/propagator/src/server.rs
+++ b/datadog-opentelemetry/examples/propagator/src/server.rs
@@ -27,7 +27,9 @@ use opentelemetry_stdout::{LogExporter, SpanExporter};
 use std::{convert::Infallible, net::SocketAddr, sync::OnceLock};
 use tokio::net::TcpListener;
 use tracing::info;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{
+    layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer as TracingLayer,
+};
 
 fn get_tracer() -> &'static BoxedTracer {
     static TRACER: OnceLock<BoxedTracer> = OnceLock::new();
@@ -242,8 +244,41 @@ fn init_logs() -> SdkLoggerProvider {
         .with_log_processor(EnrichWithBaggageLogProcessor)
         .with_simple_exporter(LogExporter::default())
         .build();
-    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
-    tracing_subscriber::registry().with(otel_layer).init();
+
+    // The tracer emits its own diagnostics through `tracing`, under the `datadog_opentelemetry`
+    // target, so this subscriber decides where they end up. How verbose they are is a separate
+    // question, answered by `DD_LOG_LEVEL` / `set_log_level_filter` — see `init_tracer`.
+    //
+    // This bridge turns events into OpenTelemetry log records, which then have to be exported. The
+    // crates the exporters themselves are built on are excluded for that reason: bridging their
+    // events would make every export produce more records to export.
+    // `libdd` covers every `libdd_*` crate, since directives match targets by prefix. Those crates
+    // are the trace transport, and they log from async tasks where the SDK's context-based
+    // suppression cannot reach them.
+    let otel_filter = EnvFilter::new("info")
+        .add_directive(
+            "datadog_opentelemetry=debug"
+                .parse()
+                .expect("valid filter directive"),
+        )
+        .add_directive("libdd=off".parse().expect("valid filter directive"))
+        .add_directive("hyper=off".parse().expect("valid filter directive"))
+        .add_directive("tonic=off".parse().expect("valid filter directive"))
+        .add_directive("h2=off".parse().expect("valid filter directive"));
+    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider).with_filter(otel_filter);
+
+    // Also print to the console, so the tracer's own debug diagnostics stay readable locally.
+    let fmt_filter = EnvFilter::new("info").add_directive(
+        "datadog_opentelemetry=debug"
+            .parse()
+            .expect("valid filter directive"),
+    );
+    let fmt_layer = tracing_subscriber::fmt::layer().with_filter(fmt_filter);
+
+    tracing_subscriber::registry()
+        .with(otel_layer)
+        .with(fmt_layer)
+        .init();
 
     logger_provider
 }
@@ -252,8 +287,11 @@ fn init_logs() -> SdkLoggerProvider {
 async fn main() {
     use hyper_util::server::conn::auto::Builder;
 
-    let provider = init_tracer();
+    // Install the subscriber before initialising the tracer. Diagnostics emitted before a
+    // subscriber exists are printed to stdout/stderr instead of being routed, so doing this first
+    // is what puts the tracer's start-up messages through the layers configured above.
     let logger_provider = init_logs();
+    let provider = init_tracer();
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = TcpListener::bind(addr).await.unwrap();
 

--- a/datadog-opentelemetry/src/core/log.rs
+++ b/datadog-opentelemetry/src/core/log.rs
@@ -1,7 +1,19 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Logging level
+//! The tracer's own diagnostics: level filtering and routing.
+//!
+//! Call sites use the `dd_debug!` / `dd_info!` / `dd_warn!` / `dd_error!` macros, which gate on
+//! `max_level` — set from `DD_LOG_LEVEL` when configuration is applied — and then hand off
+//! to `print_log`. Two things happen there, independently of each other:
+//!
+//! - Errors are forwarded to instrumentation telemetry, always. Only the uninterpolated format
+//!   template is sent, so interpolated values cannot leak.
+//! - The message is emitted for humans: to a `tracing` subscriber if the application installed one,
+//!   which then owns formatting, destination and filtering
+//!   (`RUST_LOG=datadog_opentelemetry=debug`). If tracing cannot carry the event, the optional
+//!   `log-compat` feature routes it through the `log` facade instead; without that feature it falls
+//!   back to stdout/stderr, so a bare application still sees it.
 
 use std::{
     fmt::{self, Display},
@@ -9,6 +21,7 @@ use std::{
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use tracing::subscriber::NoSubscriber;
 
 static MAX_LOG_LEVEL: AtomicUsize = AtomicUsize::new(LevelFilter::Error as usize);
 
@@ -136,16 +149,16 @@ impl PartialOrd<LevelFilter> for Level {
     }
 }
 
+pub(crate) const LOG_TARGET: &str = env!("CARGO_CRATE_NAME");
+
 pub(crate) fn print_log(
-    lvl: super::log::Level,
+    lvl: Level,
     log: fmt::Arguments,
     file: &str,
     line: u32,
     template: Option<&str>,
 ) {
-    if lvl == super::log::LevelFilter::Error {
-        eprintln!("\x1b[91m{lvl}\x1b[0m {file}:{line} - {log}");
-
+    if lvl == LevelFilter::Error {
         if let Some(template) = template {
             // we should only send the template to telemetry to not leak sensitive information
             super::telemetry::add_log_error(
@@ -153,6 +166,129 @@ pub(crate) fn print_log(
                 Some(format!("Error: {template}\n at {file}:{line}")),
             );
         }
+    }
+
+    emit(lvl, log, file, line);
+}
+
+/// Whether the calling thread would actually dispatch an event to a subscriber.
+///
+/// `tracing::dispatcher::has_been_set` cannot answer this: it reports whether a dispatcher was ever
+/// installed anywhere in the process and is never cleared, so it stays true once a scoped
+/// `with_default` has exited, and on threads — such as the tracer's own workers — that never had
+/// one. Events emitted there reach `tracing`'s no-op dispatcher and are silently lost, exactly the
+/// case the printed fallback exists for. Asking the current dispatcher what it is avoids that.
+///
+/// A subscriber that is installed but filters this target out is deliberately not covered: that is
+/// the application's decision, and printing over it would be worse than staying quiet.
+fn has_current_subscriber() -> bool {
+    tracing::dispatcher::get_default(|dispatch| !dispatch.is::<NoSubscriber>())
+}
+
+/// Where a diagnostic was sent. Returned so tests can assert on the destination without capturing
+/// the process's output streams; production callers ignore it.
+#[derive(Debug, PartialEq, Eq)]
+enum Destination {
+    Subscriber,
+    #[cfg(feature = "log-compat")]
+    Log,
+    #[cfg(not(feature = "log-compat"))]
+    Streams,
+}
+
+/// This crate's level as `tracing` spells it.
+const fn tracing_level(lvl: Level) -> tracing::Level {
+    match lvl {
+        Level::Error => tracing::Level::ERROR,
+        Level::Warn => tracing::Level::WARN,
+        Level::Info => tracing::Level::INFO,
+        Level::Debug => tracing::Level::DEBUG,
+    }
+}
+
+/// Split out from [`tracing_can_deliver`] so the comparison can be tested against ceilings other
+/// than the one this build happens to have.
+fn within_static_ceiling(
+    level: tracing::Level,
+    ceiling: tracing::level_filters::LevelFilter,
+) -> bool {
+    level <= ceiling
+}
+
+/// Whether `tracing` is able to carry a diagnostic at this level at all.
+///
+/// Two ways it cannot, each leaving the printed fallback as the only route:
+///
+/// - No subscriber on this thread, so the event reaches a no-op dispatcher.
+/// - A compile-time ceiling below this level. Applications can enable `tracing`'s `max_level_*` or
+///   `release_max_level_*` features, and because cargo features are additive that compiles our
+///   callsites out. Nothing at runtime, `DD_LOG_LEVEL` included, can bring them back.
+///
+/// OpenTelemetry telemetry suppression does not make `tracing` itself unavailable. A suppressed
+/// event must still be dispatched so non-OpenTelemetry layers can capture, format and redirect it;
+/// `SdkLogger::event_enabled` independently prevents an OpenTelemetry log bridge from exporting it.
+///
+/// Filtering a subscriber *chooses* — by target, or by its own level hint — is deliberately not
+/// covered. That is the application's policy, and printing over it would be worse than staying
+/// quiet. When `log-compat` is disabled, the output streams have no compile-time ceiling and remain
+/// available in both cases above; enabling it gives the `log` facade ownership of the fallback.
+fn tracing_can_deliver(lvl: Level) -> bool {
+    within_static_ceiling(tracing_level(lvl), tracing::level_filters::STATIC_MAX_LEVEL)
+        && has_current_subscriber()
+}
+
+fn emit(lvl: Level, log: fmt::Arguments, file: &str, line: u32) -> Destination {
+    if tracing_can_deliver(lvl) {
+        match lvl {
+            Level::Error => tracing::error!(target: LOG_TARGET, file, line, "{log}"),
+            Level::Warn => tracing::warn!(target: LOG_TARGET, file, line, "{log}"),
+            Level::Info => tracing::info!(target: LOG_TARGET, file, line, "{log}"),
+            Level::Debug => tracing::debug!(target: LOG_TARGET, file, line, "{log}"),
+        }
+        Destination::Subscriber
+    } else {
+        emit_without_tracing(lvl, log, file, line)
+    }
+}
+
+#[cfg(feature = "log-compat")]
+fn emit_without_tracing(lvl: Level, message: fmt::Arguments, file: &str, line: u32) -> Destination {
+    let level = match lvl {
+        Level::Error => log::Level::Error,
+        Level::Warn => log::Level::Warn,
+        Level::Info => log::Level::Info,
+        Level::Debug => log::Level::Debug,
+    };
+    let metadata = log::Metadata::builder()
+        .level(level)
+        .target(LOG_TARGET)
+        .build();
+    let logger = log::logger();
+
+    if level <= log::max_level() && logger.enabled(&metadata) {
+        logger.log(
+            &log::Record::builder()
+                .metadata(metadata)
+                .args(message)
+                .file(Some(file))
+                .line(Some(line))
+                .build(),
+        );
+    }
+
+    Destination::Log
+}
+
+#[cfg(not(feature = "log-compat"))]
+fn emit_without_tracing(lvl: Level, log: fmt::Arguments, file: &str, line: u32) -> Destination {
+    print_to_streams(lvl, log, file, line);
+    Destination::Streams
+}
+
+#[cfg(not(feature = "log-compat"))]
+fn print_to_streams(lvl: Level, log: fmt::Arguments, file: &str, line: u32) {
+    if lvl == LevelFilter::Error {
+        eprintln!("\x1b[91m{lvl}\x1b[0m {file}:{line} - {log}");
     } else {
         println!("\x1b[93m{lvl}\x1b[0m {file}:{line} - {log}");
     }
@@ -205,29 +341,469 @@ macro_rules! dd_log {
       }
     }};
 
-    ($lvl:expr, $first:expr) => {
+    ($lvl:expr, $first:expr) => {{
       let lvl = $lvl;
       if lvl <= $crate::core::log::max_level() {
         let loc = std::panic::Location::caller();
         $crate::core::log::print_log(lvl, format_args!($first), loc.file(), loc.line(), Some($first));
       }
+    }};
+}
+
+/// Serializes tests that touch process-global logging state — `MAX_LOG_LEVEL`, the `tracing`
+/// dispatcher, the `log` logger — since the default `cargo test` harness runs tests as threads
+/// within one process. Not reentrant: hold it at one level only.
+#[cfg(test)]
+pub(crate) fn global_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+/// Captures the events the tracer emits through `tracing`, for tests in this crate that need to
+/// assert on what the host application's subscriber would see.
+#[cfg(test)]
+pub(crate) mod test_capture {
+    use super::{global_test_lock, max_level, set_max_level, LevelFilter, LOG_TARGET};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::filter::FilterFn;
+    use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
+    use tracing_subscriber::Layer;
+
+    /// A single event as the host application's subscriber would see it.
+    #[derive(Debug, Clone)]
+    pub(crate) struct CapturedEvent {
+        pub target: String,
+        pub level: tracing::Level,
+        pub message: String,
+        pub file: Option<String>,
+        pub line: Option<u64>,
+        /// Whether OpenTelemetry telemetry suppression was active when the event was emitted.
+        pub suppressed: bool,
+    }
+
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: LayerContext<'_, S>) {
+            let mut visitor = FieldVisitor::default();
+            event.record(&mut visitor);
+
+            let captured = CapturedEvent {
+                target: event.metadata().target().to_owned(),
+                level: *event.metadata().level(),
+                message: visitor.message,
+                file: visitor.file,
+                line: visitor.line,
+                suppressed: opentelemetry::Context::is_current_telemetry_suppressed(),
+            };
+            self.events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(captured);
+        }
+    }
+
+    #[derive(Default)]
+    struct FieldVisitor {
+        message: String,
+        file: Option<String>,
+        line: Option<u64>,
+    }
+
+    impl Visit for FieldVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.message = format!("{value:?}");
+            }
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == "file" {
+                self.file = Some(value.to_owned());
+            }
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            if field.name() == "line" {
+                self.line = Some(value);
+            }
+        }
+    }
+
+    /// Installs a capturing subscriber on the current thread and returns the events `body` emitted.
+    /// Callers must already hold [`global_test_lock`]: installing even a scoped subscriber flips
+    /// `tracing`'s global "a dispatcher exists" flag, which decides whether `log` records are
+    /// emitted at all.
+    fn capture_locked(body: impl FnOnce()) -> Vec<CapturedEvent> {
+        let layer = CaptureLayer::default();
+        let events = Arc::clone(&layer.events);
+        install_and_run(layer, events, body)
+    }
+
+    fn install_and_run(
+        layer: impl Layer<tracing_subscriber::Registry> + Send + Sync + 'static,
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+        body: impl FnOnce(),
+    ) -> Vec<CapturedEvent> {
+        tracing::subscriber::with_default(tracing_subscriber::registry().with(layer), body);
+        events.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Runs `body` with a capturing subscriber installed on the current thread, and returns the
+    /// events it emitted. Leaves the tracer's max level alone, so callers that do not go through
+    /// the macros cannot be perturbed by a concurrent test.
+    pub(crate) fn capture(body: impl FnOnce()) -> Vec<CapturedEvent> {
+        let _guard = global_test_lock();
+        capture_locked(body)
+    }
+
+    /// [`capture`], but the subscriber filters this crate's target out — present and listening,
+    /// just not interested in us. A `FilterFn` reports no max-level hint, so this cannot perturb
+    /// what a concurrent test sees.
+    pub(crate) fn capture_filtered_out(body: impl FnOnce()) -> Vec<CapturedEvent> {
+        let _guard = global_test_lock();
+        let layer = CaptureLayer::default();
+        let events = Arc::clone(&layer.events);
+        let filter = FilterFn::new(|meta| meta.target() != LOG_TARGET);
+        install_and_run(layer.with_filter(filter), events, body)
+    }
+
+    /// A single `log` record, as a `log`-based application would see it.
+    #[derive(Debug, Clone)]
+    pub(crate) struct CapturedLogRecord {
+        pub target: String,
+        pub level: log::Level,
+        pub message: String,
+        #[cfg(feature = "log-compat")]
+        pub file: Option<String>,
+        #[cfg(feature = "log-compat")]
+        pub line: Option<u32>,
+    }
+
+    static LOG_RECORDS: Mutex<Vec<CapturedLogRecord>> = Mutex::new(Vec::new());
+
+    struct CaptureLogger;
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record) {
+            LOG_RECORDS
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(CapturedLogRecord {
+                    target: record.target().to_owned(),
+                    level: record.level(),
+                    message: record.args().to_string(),
+                    #[cfg(feature = "log-compat")]
+                    file: record.file().map(str::to_owned),
+                    #[cfg(feature = "log-compat")]
+                    line: record.line(),
+                });
+        }
+
+        fn flush(&self) {}
+    }
+
+    /// Runs `body` with a global `log` logger installed and returns the records it produced under
+    /// `LOG_TARGET`. Other targets are dropped, since the logger is process-global and third-party
+    /// crates land in it too.
+    pub(crate) fn capture_log_records(body: impl FnOnce()) -> Vec<CapturedLogRecord> {
+        let _guard = global_test_lock();
+
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            // Only one logger can ever be installed; if something else owns it, the caller sees no
+            // records rather than the wrong ones.
+            let _ = log::set_logger(&CaptureLogger);
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+
+        LOG_RECORDS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        body();
+
+        LOG_RECORDS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .filter(|r| r.target == LOG_TARGET)
+            .cloned()
+            .collect()
+    }
+
+    /// [`capture`], with the tracer's max level set to `level` for the duration — for tests that go
+    /// through the macros and so depend on the level gate.
+    ///
+    /// Note that `ConfigBuilder::build` also writes this global, so tests relying on a level below
+    /// `Error` are only reliable under a process-per-test runner such as nextest.
+    pub(crate) fn capture_at(level: LevelFilter, body: impl FnOnce()) -> Vec<CapturedEvent> {
+        let _guard = global_test_lock();
+        let previous = max_level();
+        set_max_level(level);
+
+        let captured = capture_locked(body);
+
+        set_max_level(previous);
+        captured
+    }
+}
+
+#[cfg(test)]
+mod routing_tests {
+    use opentelemetry::Context;
+
+    use super::test_capture::{capture, capture_at, capture_filtered_out, capture_log_records};
+    use super::{
+        emit, has_current_subscriber, print_log, within_static_ceiling, Destination, Level,
+        LevelFilter, LOG_TARGET,
     };
+
+    #[cfg(feature = "log-compat")]
+    const UNAVAILABLE_DESTINATION: Destination = Destination::Log;
+    #[cfg(not(feature = "log-compat"))]
+    const UNAVAILABLE_DESTINATION: Destination = Destination::Streams;
+
+    #[test]
+    fn emission_after_a_scoped_subscriber_exits_uses_the_fallback() {
+        let mut inside = None;
+        let events = capture(|| {
+            inside = Some(emit(Level::Warn, format_args!("in scope"), "a.rs", 1));
+        });
+        // The same call on the same thread, once the scope has gone away.
+        let outside = emit(Level::Warn, format_args!("after scope"), "a.rs", 2);
+
+        assert_eq!(inside, Some(Destination::Subscriber));
+        assert!(events.iter().any(|e| e.message == "in scope"));
+        assert_eq!(
+            outside, UNAVAILABLE_DESTINATION,
+            "the scope has exited, so nothing would receive this through tracing"
+        );
+    }
+
+    #[test]
+    fn emission_on_another_thread_uses_the_fallback_while_a_subscriber_is_scoped() {
+        // A scoped subscriber belongs to one thread. The tracer's own workers never had one, and
+        // that is where much of its diagnostics come from.
+        let mut worker = None;
+        let events = capture(|| {
+            worker = Some(
+                std::thread::spawn(|| emit(Level::Warn, format_args!("from worker"), "w.rs", 3))
+                    .join()
+                    .expect("worker thread panicked"),
+            );
+        });
+
+        assert_eq!(worker, Some(UNAVAILABLE_DESTINATION));
+        assert!(
+            events.is_empty(),
+            "a diagnostic from another thread cannot reach this thread's subscriber"
+        );
+    }
+
+    #[test]
+    fn a_static_level_ceiling_below_the_event_uses_the_fallback() {
+        use tracing::level_filters::LevelFilter as Ceiling;
+
+        // An application can compile our callsites out with tracing's `max_level_*` /
+        // `release_max_level_*` features, and cargo features are additive. `DD_LOG_LEVEL` would
+        // stop working in those builds if the quieter levels were still routed to `tracing`.
+        assert!(!within_static_ceiling(tracing::Level::DEBUG, Ceiling::WARN));
+        assert!(!within_static_ceiling(tracing::Level::INFO, Ceiling::WARN));
+        assert!(within_static_ceiling(tracing::Level::WARN, Ceiling::WARN));
+        assert!(within_static_ceiling(tracing::Level::ERROR, Ceiling::WARN));
+        assert!(!within_static_ceiling(tracing::Level::ERROR, Ceiling::OFF));
+        assert!(within_static_ceiling(tracing::Level::DEBUG, Ceiling::TRACE));
+    }
+
+    #[test]
+    fn a_suppressed_scope_still_reaches_non_otel_tracing_layers() {
+        // OpenTelemetry suppression makes its log bridge drop the event, but must not prevent other
+        // tracing layers from capturing, formatting or redirecting the diagnostic.
+        let mut destination = None;
+        let events = capture(|| {
+            let _suppress_guard = Context::enter_telemetry_suppressed_scope();
+            destination = Some(emit(Level::Error, format_args!("suppressed"), "a.rs", 5));
+        });
+
+        assert_eq!(destination, Some(Destination::Subscriber));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "suppressed");
+        assert!(events[0].suppressed);
+    }
+
+    #[test]
+    fn a_subscriber_that_filters_the_event_gets_no_fallback() {
+        let mut destination = None;
+        let events = capture_filtered_out(|| {
+            destination = Some(emit(Level::Warn, format_args!("filtered"), "a.rs", 4));
+        });
+
+        assert_eq!(
+            destination,
+            Some(Destination::Subscriber),
+            "a subscriber is installed; whether it keeps the event is its decision, not ours"
+        );
+        assert!(events.is_empty(), "the filter drops it before the layer");
+    }
+
+    #[test]
+    fn an_exited_scoped_subscriber_does_not_count_as_available() {
+        // Once any subscriber is installed — scoped ones included — tracing's global "has been set"
+        // flag stays true for the rest of the process, and it is also true on threads that never
+        // had one, such as the tracer's workers. Diagnostics emitted there must be printed rather
+        // than handed to the no-op dispatcher and lost.
+        let inside = tracing::subscriber::with_default(
+            tracing_subscriber::registry(),
+            has_current_subscriber,
+        );
+        let outside = has_current_subscriber();
+
+        assert!(
+            inside,
+            "a subscriber is in scope, so tracing owns the diagnostic"
+        );
+        assert!(
+            !outside,
+            "the scope has exited, so the printed fallback must be used"
+        );
+        assert!(
+            tracing::dispatcher::has_been_set(),
+            "precondition: the global flag stays set, which is what hid this case"
+        );
+    }
+
+    #[test]
+    fn every_level_reaches_the_host_subscriber_with_target_message_and_location() {
+        let events = capture(|| {
+            print_log(Level::Error, format_args!("boom: {}", 42), "a.rs", 1, None);
+            print_log(Level::Warn, format_args!("warned"), "b.rs", 2, None);
+            print_log(Level::Info, format_args!("informed"), "c.rs", 3, None);
+            print_log(Level::Debug, format_args!("debugged"), "d.rs", 4, None);
+        });
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(LOG_TARGET, "datadog_opentelemetry");
+        assert!(events.iter().all(|e| e.target == LOG_TARGET));
+        assert_eq!(
+            events.iter().map(|e| e.level).collect::<Vec<_>>(),
+            vec![
+                tracing::Level::ERROR,
+                tracing::Level::WARN,
+                tracing::Level::INFO,
+                tracing::Level::DEBUG,
+            ],
+        );
+        assert_eq!(events[0].message, "boom: 42");
+        // The call site's location travels as fields, since the callsite metadata would only ever
+        // point back at this module.
+        assert_eq!(events[0].file.as_deref(), Some("a.rs"));
+        assert_eq!(events[0].line, Some(1));
+        assert_eq!(events[3].message, "debugged");
+    }
+
+    #[test]
+    fn macro_call_sites_supply_their_own_location() {
+        let events = capture_at(LevelFilter::Debug, || crate::dd_error!("from a macro"));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "from a macro");
+        assert!(events[0]
+            .file
+            .as_deref()
+            .is_some_and(|f| f.ends_with("log.rs")));
+        assert!(events[0].line.is_some());
+    }
+
+    #[test]
+    #[cfg(not(feature = "log-compat"))]
+    fn nothing_is_routed_through_the_log_crate() {
+        // Holds either way: with a subscriber installed `tracing` consumes the event, and without
+        // one we print rather than hand it over. A record here would mean the diagnostic went to
+        // `tracing` while nothing was listening, or that tracing's `log` feature came back — this
+        // binary compiles it in via dev-dependencies even though consumers do not get it, which is
+        // what makes the assertion meaningful. The manifest side is checked with
+        // `cargo tree -e features,normal`.
+        let records = capture_log_records(|| {
+            print_log(
+                Level::Warn,
+                format_args!("printed instead"),
+                "a.rs",
+                7,
+                None,
+            )
+        });
+
+        let unexpected: Vec<String> = records
+            .iter()
+            .map(|r| format!("{} {} {}", r.target, r.level, r.message))
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "unexpected log records: {unexpected:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "log-compat")]
+    fn log_compat_routes_to_the_log_facade_when_tracing_is_unavailable() {
+        let mut destination = None;
+        let records = capture_log_records(|| {
+            destination = Some(emit(
+                Level::Warn,
+                format_args!("captured by log"),
+                "caller.rs",
+                17,
+            ));
+        });
+
+        assert_eq!(destination, Some(Destination::Log));
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].target, LOG_TARGET);
+        assert_eq!(records[0].level, log::Level::Warn);
+        assert_eq!(records[0].message, "captured by log");
+        assert_eq!(records[0].file.as_deref(), Some("caller.rs"));
+        assert_eq!(records[0].line, Some(17));
+    }
+
+    #[test]
+    fn events_outside_the_export_path_are_not_suppressed() {
+        let events = capture(|| print_log(Level::Error, format_args!("plain"), "a.rs", 1, None));
+
+        assert_eq!(events.len(), 1);
+        assert!(!events[0].suppressed);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::core::{
         log::LevelFilter,
-        log::{max_level, set_max_level, Level},
+        log::{global_test_lock, max_level, set_max_level, Level},
     };
 
     #[test]
     fn test_default_max_level() {
-        assert!(LevelFilter::Error == max_level());
+        // `MAX_LOG_LEVEL` is initialised from this default. The live value is deliberately not
+        // asserted: it is process-global and `ConfigBuilder::build` writes it, so any other test
+        // building a `Config` can change it while this one runs. `test_max_level` covers the
+        // set/read round-trip under `global_test_lock`.
+        assert_eq!(LevelFilter::default(), LevelFilter::Error);
     }
 
     #[test]
     fn test_max_level() {
+        let _guard = global_test_lock();
         let default_lvl = max_level();
 
         set_max_level(crate::core::log::LevelFilter::Warn);

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -19,6 +19,7 @@ use libdd_data_pipeline::trace_exporter::{
     TraceExporterBuilder, TraceExporterOutputFormat,
 };
 use libdd_shared_runtime::{BasicRuntime, BlockingRuntime, SharedRuntime, SharedRuntimeError};
+use opentelemetry::Context;
 use opentelemetry_sdk::{trace::SpanData, Resource};
 
 use crate::{
@@ -567,6 +568,15 @@ fn log_trace_exporter_error(e: &TraceExporterError) {
 
     use crate::{dd_debug, dd_error};
 
+    // Suppress OpenTelemetry log records for the duration of this call. These diagnostics reach the
+    // application's `tracing` subscriber, which may bridge them into an OpenTelemetry log pipeline;
+    // if that pipeline exports through this same trace
+    // exporter, a failed export would log, produce a record, and fail again. The OpenTelemetry
+    // SDK enters this scope around its own exporters, but Datadog span export runs on
+    // libdatadog's worker instead, so we enter it ourselves. The guard is `!Send`, hence it is
+    // taken here rather than around the `async` export itself.
+    let _suppress_guard = Context::enter_telemetry_suppressed_scope();
+
     match e {
         // Exceptional errors
         TraceExporterError::Builder(e) => {
@@ -621,7 +631,10 @@ fn log_trace_exporter_error(e: &TraceExporterError) {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
+    use crate::core::log::{test_capture::capture_at, LevelFilter};
+    use libdd_data_pipeline::trace_exporter::error::InternalErrorKind;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -671,5 +684,20 @@ mod tests {
         let pending = make_pending();
         let res = wait_for_barrier(&pending, Duration::from_secs(5));
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn export_errors_reach_non_otel_tracing_layers_while_suppressed() {
+        let error = TraceExporterError::Internal(InternalErrorKind::InvalidWorkerState(
+            "stopped".to_owned(),
+        ));
+
+        let events = capture_at(LevelFilter::Debug, || log_trace_exporter_error(&error));
+
+        // The event is dispatched so non-OpenTelemetry layers can capture it. The active
+        // suppression flag makes an OpenTelemetry log bridge reject the event independently.
+        assert_eq!(events.len(), 1);
+        assert!(events[0].suppressed);
+        assert!(events[0].message.contains("Invalid worker state: stopped"));
     }
 }

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "uuid",
 ]
 


### PR DESCRIPTION
## What

`dd_debug!` / `dd_info!` / `dd_warn!` / `dd_error!` wrote directly to stdout and stderr, which applications could not capture, format, filter, or redirect. They now emit through `tracing` under the `datadog_opentelemetry` target when a subscriber is available.

`DD_LOG_LEVEL` still decides which diagnostics are created. Once created, the application's subscriber controls their formatting, destination, and filtering. For example, debug diagnostics require both `DD_LOG_LEVEL=debug` and a subscriber filter that admits `datadog_opentelemetry=debug`.

Applications built around the `log` facade can enable the new opt-in `log-compat` feature. When `tracing` cannot carry a diagnostic, the feature routes it through `log`; without the feature, the existing stdout/stderr behavior remains as the fallback.

## Routing

For each diagnostic enabled by `DD_LOG_LEVEL`:

1. Error templates are forwarded to instrumentation telemetry as before. This is independent of human-readable log routing, and only the uninterpolated template is sent.
2. If the calling thread has a `tracing` subscriber and the event is within `tracing`'s compile-time level ceiling, emit it through `tracing`.
3. Otherwise, emit through the `log` facade when `log-compat` is enabled, or fall back to stdout/stderr when it is not.

The fallback is used only when `tracing` is incapable of carrying the event:

- **No subscriber on the calling thread.** `dispatcher::has_been_set()` cannot answer this because it remains true after a scoped `with_default` exits and on threads that never had that subscriber, including the tracer's workers.
- **A compile-time ceiling below the event's level.** Additive features such as `tracing/release_max_level_warn` can compile callsites out; no runtime filter can restore them.

If an installed subscriber filters this target or level out, that decision is respected and no fallback is emitted.

OpenTelemetry suppression does **not** prevent dispatch to `tracing`. Non-OpenTelemetry layers can still capture the diagnostic, while `SdkLogger::event_enabled` independently prevents an OpenTelemetry log bridge from exporting it and creating a telemetry loop.

## Decisions

- **`log-compat` is opt-in.** It gives applications using the `log` facade ownership of the fallback without changing default behavior for applications that have no logger installed.
- **`tracing`'s `log` feature is not enabled.** Cargo feature unification could otherwise enable `log` emission for every tracing-instrumented crate in the application's graph and cause duplicate records.
- **`LOG_TARGET = env!("CARGO_CRATE_NAME")`.** This uses the underscored crate name without a duplicated literal. `module_path!()` would identify `core::log`, rather than the code that produced the diagnostic, so the original file and line are attached as event fields.
- **Telemetry forwarding remains unconditional** and happens independently of the human-readable destination.
- **Trace-export errors log inside an OpenTelemetry-suppressed scope.** The SDK does this around its own exporters, but Datadog span export runs on libdatadog's worker. The guard is `!Send`, so it wraps synchronous logging rather than the asynchronous export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
