### PR TITLE
feat(propagation): emit and forward OTel consistent-probability ot tracestate member

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -182,7 +182,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@623d8cee11cfc63d3e5a90c1a70ce8ecf726bd3a  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@53687a2f4eab136c61d2a97474a37846d9ca6959  # main
     permissions:
       contents: read
       id-token: write
@@ -191,5 +191,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 623d8cee11cfc63d3e5a90c1a70ce8ecf726bd3a # main
+      ref: 53687a2f4eab136c61d2a97474a37846d9ca6959 # main
       push_to_test_optimization: true

--- a/datadog-opentelemetry/benches/inject_benchmark.rs
+++ b/datadog-opentelemetry/benches/inject_benchmark.rs
@@ -26,7 +26,7 @@ fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'_> {
         tags: &mut c.tags,
         is_remote: c.is_remote,
         tracestate: None,
-        ot: None,
+        ot_member: None,
     }
 }
 

--- a/datadog-opentelemetry/benches/inject_benchmark.rs
+++ b/datadog-opentelemetry/benches/inject_benchmark.rs
@@ -26,6 +26,7 @@ fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'_> {
         tags: &mut c.tags,
         is_remote: c.is_remote,
         tracestate: None,
+        ot: None,
     }
 }
 

--- a/datadog-opentelemetry/src/propagation/context.rs
+++ b/datadog-opentelemetry/src/propagation/context.rs
@@ -117,7 +117,7 @@ pub struct InjectSpanContext<'a> {
     /// W3C tracestate data to inject.
     pub tracestate: Option<InjectTraceState>,
     /// The OTel consistent-probability `ot` member to emit, if any.
-    pub ot: Option<String>,
+    pub ot_member: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -142,7 +142,7 @@ pub(crate) fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'
                 },
             ))
         }),
-        ot: c.tracestate.as_ref().and_then(|ts| ts.ot.clone()),
+        ot_member: c.tracestate.as_ref().and_then(|ts| ts.ot_member.as_deref()),
     }
 }
 

--- a/datadog-opentelemetry/src/propagation/context.rs
+++ b/datadog-opentelemetry/src/propagation/context.rs
@@ -116,6 +116,8 @@ pub struct InjectSpanContext<'a> {
     pub is_remote: bool,
     /// W3C tracestate data to inject.
     pub tracestate: Option<InjectTraceState>,
+    /// The OTel consistent-probability `ot` member to emit, if any.
+    pub ot: Option<String>,
 }
 
 #[cfg(test)]
@@ -140,6 +142,7 @@ pub(crate) fn span_context_to_inject(c: &mut SpanContext) -> InjectSpanContext<'
                 },
             ))
         }),
+        ot: c.tracestate.as_ref().and_then(|ts| ts.ot.clone()),
     }
 }
 

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -1181,7 +1181,8 @@ pub(crate) mod tests {
                     origin: Some("rum".to_string()),
                     lower_order_trace_id: None,
                     propagation_tags: Some(HashMap::from([("t.usr.id".to_string(), "baz64".to_string()), ("t.dm".to_string(), "-4".to_string())])),
-                    additional_values: Some(vec![("congo".to_string(), "t61rcWkgMz".to_string())])
+                    additional_values: Some(vec![("congo".to_string(), "t61rcWkgMz".to_string())]),
+                    ot: None
                 }),
             }
         ),

--- a/datadog-opentelemetry/src/propagation/mod.rs
+++ b/datadog-opentelemetry/src/propagation/mod.rs
@@ -1182,7 +1182,7 @@ pub(crate) mod tests {
                     lower_order_trace_id: None,
                     propagation_tags: Some(HashMap::from([("t.usr.id".to_string(), "baz64".to_string()), ("t.dm".to_string(), "-4".to_string())])),
                     additional_values: Some(vec![("congo".to_string(), "t61rcWkgMz".to_string())]),
-                    ot: None
+                    ot_member: None
                 }),
             }
         ),

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -62,6 +62,19 @@ pub(crate) fn ot_extract_rv(raw: &str) -> Option<u64> {
     })
 }
 
+/// Removes malformed `rv`/`th` subkeys, preserving valid and unknown subkeys.
+pub(crate) fn ot_sanitize(raw: &str) -> Option<String> {
+    let parts: Vec<_> = raw
+        .split(';')
+        .filter(|item| match item.split_once(':') {
+            Some(("rv", value)) => ot_parse_hex_56(value, Some(14)).is_some(),
+            Some(("th", value)) => ot_parse_hex_56(value, None).is_some(),
+            _ => true,
+        })
+        .collect();
+    join_capped(&parts, TRACESTATE_OT_KEY_MAX_LENGTH)
+}
+
 /// Replaces `rv`/`th` in a raw `ot` member value, dropping the old ones and
 /// appending everything else, in order, after the new pair. `None` when
 /// nothing is left to emit.
@@ -1379,6 +1392,18 @@ mod test {
         for (input, expected) in tests {
             assert_eq!(replace_chars(input, |c| c == b'b', '_'), expected);
         }
+    }
+
+    #[test]
+    fn ot_sanitize_drops_malformed_known_subkeys() {
+        assert_eq!(
+            ot_sanitize("rv:not-hex;th:invalid;future:value"),
+            Some("future:value".to_string())
+        );
+        assert_eq!(
+            ot_sanitize("rv:1234567890abcd;th:e6666666666666;future:value"),
+            Some("rv:1234567890abcd;th:e6666666666666;future:value".to_string())
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -37,6 +37,58 @@ const INVALID_CHAR_REPLACEMENT: char = '_';
 static TRACECONTEXT_HEADER_KEYS: LazyLock<[String; 2]> =
     LazyLock::new(|| [TRACEPARENT_KEY.to_owned(), TRACESTATE_KEY.to_owned()]);
 
+fn ot_parse_hex_56(s: &str, exact_len: Option<usize>) -> Option<u64> {
+    if s.is_empty() || s.len() > 14 {
+        return None;
+    }
+    if exact_len.filter(|n| s.len() != *n).is_some() {
+        return None;
+    }
+    if !s
+        .bytes()
+        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return None;
+    }
+    u64::from_str_radix(s, 16).ok()
+}
+
+/// Extract `rv` from a raw `ot` member value, ignoring everything else.
+pub(crate) fn ot_extract_rv(raw: &str) -> Option<u64> {
+    raw.split(';').find_map(|item| match item.split_once(':') {
+        Some(("rv", v)) => ot_parse_hex_56(v, Some(14)),
+        _ => None,
+    })
+}
+
+/// Replaces `rv`/`th` in a raw `ot` member value, dropping the old ones and
+/// appending everything else, in order, after the new pair. `None` when
+/// nothing is left to emit.
+pub(crate) fn ot_set_rv_th(raw: Option<&str>, rv: Option<u64>, th: Option<u64>) -> Option<String> {
+    let format_th = |v: u64| {
+        if v == 0 {
+            "0".to_string()
+        } else {
+            format!("{v:014x}").trim_end_matches('0').to_string()
+        }
+    };
+    let others = raw
+        .into_iter()
+        .flat_map(|s| s.split(';'))
+        .filter(|item| !matches!(item.split_once(':'), Some(("rv", _)) | Some(("th", _))));
+
+    let rv_part = rv.map(|v| format!("rv:{v:014x}"));
+    let th_part = th.map(|v| format!("th:{}", format_th(v)));
+
+    let parts: Vec<&str> = rv_part
+        .as_deref()
+        .into_iter()
+        .chain(th_part.as_deref())
+        .chain(others)
+        .collect();
+    (!parts.is_empty()).then(|| parts.join(";"))
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Traceparent {
     pub sampling_priority: SamplingPriority,
@@ -55,6 +107,8 @@ pub struct Tracestate {
     pub(crate) lower_order_trace_id: Option<String>,
     pub(crate) propagation_tags: Option<HashMap<String, String>>,
     pub(crate) additional_values: Option<Vec<(String, String)>>,
+    /// Raw inbound OTel field (useful for consistent-probability member value)
+    pub(crate) ot: Option<String>,
 }
 
 /// Code inspired, and copied, by OpenTelemetry Rust project.
@@ -105,6 +159,7 @@ impl FromStr for Tracestate {
 
         let mut dd: Option<HashMap<String, String>> = None;
         let mut additional_values = vec![];
+        let mut ot: Option<String> = None;
 
         for v in ts_v {
             let (key, value) = v.split_once('=').unwrap_or(("", ""));
@@ -132,6 +187,8 @@ impl FromStr for Tracestate {
                         })
                         .collect(),
                 );
+            } else if key == "ot" {
+                ot = Some(value.to_string());
             } else {
                 additional_values.push((key.to_string(), value.to_string()));
             }
@@ -143,6 +200,7 @@ impl FromStr for Tracestate {
             lower_order_trace_id: None,
             propagation_tags: None,
             additional_values: None,
+            ot: None,
         };
 
         // the original order must be maintained
@@ -188,6 +246,7 @@ impl FromStr for Tracestate {
         };
 
         tracestate.propagation_tags = propagation_tags;
+        tracestate.ot = ot;
 
         Ok(tracestate)
     }
@@ -376,6 +435,8 @@ fn append_dd_propagation_tags(context: &InjectSpanContext, tags_buffer: &mut Buf
 
 fn inject_tracestate(context: &InjectSpanContext, carrier: &mut dyn Injector) {
     let mut tracestate = String::with_capacity(256);
+    let mut member_count = 1;
+
     tracestate.push_str("dd=");
 
     // Use a single String buffer to build the entire tracestate, avoiding intermediate allocations
@@ -445,9 +506,19 @@ fn inject_tracestate(context: &InjectSpanContext, carrier: &mut dyn Injector) {
         dd_parts.truncate(index_before_tags);
     }
 
+    if let Some(ot) = context.ot.as_deref() {
+        member_count += 1;
+        let mut ot_part = buf_appender(&mut tracestate);
+        ot_part.push_str(super::const_concat!(TRACESTATE_VALUES_SEPARATOR, "ot=",));
+        ot_part.push_str(ot);
+    }
+
     // Add additional tracestate values if present
     if let Some(ts) = &context.tracestate {
-        for part in ts.additional_values().take(TRACESTATE_MAX_MEMBERS - 1) {
+        for part in ts
+            .additional_values()
+            .take(TRACESTATE_MAX_MEMBERS - member_count)
+        {
             tracestate.push_str(TRACESTATE_VALUES_SEPARATOR);
             tracestate.push_str(part)
         }
@@ -955,6 +1026,7 @@ mod test {
             tracestate: Some(InjectTraceState::from_header(
                 "other=bleh,atel=test,dd=s:2;o:foo_bar_;t.dm:-4".to_owned(),
             )),
+            ot: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -975,6 +1047,112 @@ mod test {
         );
     }
 
+    /// Builds a minimal local-root `InjectSpanContext` carrying `ot`, injects
+    /// it, and returns the emitted `tracestate` string. Used by the OTel
+    /// consistent-probability emission tests (APMAPI-2181, system-tests #7372).
+    fn inject_with_ot(trace_id: u128, ot: Option<&str>) -> String {
+        let mut tags = HashMap::new();
+        let mut context = InjectSpanContext {
+            trace_id,
+            span_id: 0x5555_eeee_6666_ffff,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: Some(mechanism::DEFAULT),
+            },
+            origin: None,
+            tags: &mut tags,
+            is_remote: false,
+            tracestate: None,
+            ot: ot.map(str::to_string),
+        };
+        let mut carrier: HashMap<String, String> = HashMap::new();
+        TracePropagationStyle::TraceContext.inject(
+            &mut context,
+            &mut carrier,
+            &Config::builder().build(),
+        );
+        carrier.get(TRACESTATE_KEY).cloned().unwrap_or_default()
+    }
+
+    // A1: probability decision emits rv;th matching the golden table (rate 0.1,
+    // th = e6666666666666).
+    #[test]
+    fn emits_ot_on_probability_decision_rate_0_1() {
+        let table = [
+            (1u128, "f0948a54d43b8e"),
+            (10, "65cd67504a538e"),
+            (100, "fa060922e7438e"),
+            (18444899399302180863, "ef284ace7a91e1"),
+        ];
+        for (tid, rv) in table {
+            let injected = inject_with_ot(tid, Some(&format!("rv:{rv};th:e6666666666666")));
+            assert!(
+                injected.contains(&format!("ot=rv:{rv};th:e6666666666666")),
+                "tid {tid}: got {injected}"
+            );
+        }
+    }
+
+    // A4: non-probability local decision erases th, forwards inherited rv.
+    #[test]
+    fn force_keep_clears_th_forwards_rv() {
+        let injected = inject_with_ot(10, Some("rv:1234567890abcd"));
+        assert!(injected.contains("ot=rv:1234567890abcd"), "got {injected}");
+        assert!(!injected.contains("th:"), "got {injected}");
+    }
+
+    // A5: no ot to emit -> none fabricated.
+    #[test]
+    fn sampled_without_ot_not_fabricated() {
+        let injected = inject_with_ot(10, None);
+        assert!(!injected.contains("ot="), "got {injected}");
+    }
+
+    // ot is derived from trace id + rate, so it's emitted even on drop
+    // (rate 0.1, trace_id 10 -> DROP: rv 65cd67504a538e < th e6666666666666).
+    #[test]
+    fn probability_drop_still_emits_ot() {
+        let injected = inject_with_ot(10, Some("rv:65cd67504a538e;th:e6666666666666"));
+        assert!(
+            injected.contains("ot=rv:65cd67504a538e;th:e6666666666666"),
+            "got {injected}"
+        );
+    }
+
+    // #7372 ordering: `ot` sits right after `dd=`, before other vendors.
+    #[test]
+    fn ot_is_emitted_after_dd_before_other_vendors() {
+        let mut tags = HashMap::new();
+        let mut context = InjectSpanContext {
+            trace_id: 0x1111aaaa2222bbbb3333cccc4444dddd,
+            span_id: 0x5555_eeee_6666_ffff,
+            sampling: Sampling {
+                priority: Some(priority::AUTO_KEEP),
+                mechanism: Some(mechanism::DEFAULT),
+            },
+            origin: None,
+            tags: &mut tags,
+            is_remote: false,
+            tracestate: Some(InjectTraceState::from_header("congo=xyz".to_owned())),
+            ot: Some("rv:ef284ace7a91e1;th:e6666666666666".to_string()),
+        };
+        let mut carrier: HashMap<String, String> = HashMap::new();
+        TracePropagationStyle::TraceContext.inject(
+            &mut context,
+            &mut carrier,
+            &Config::builder().build(),
+        );
+        let ts = &carrier[TRACESTATE_KEY];
+        assert!(
+            ts.contains("ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz"),
+            "got {ts}"
+        );
+        let dd = ts.find("dd=").unwrap();
+        let ot = ts.find("ot=").unwrap();
+        let congo = ts.find("congo=").unwrap();
+        assert!(dd < ot && ot < congo, "expected dd<ot<congo, got {ts}");
+    }
+
     #[test]
     fn test_inject_traceparent_with_256_max_length() {
         let origin = "abc".repeat(200);
@@ -989,6 +1167,7 @@ mod test {
             tags: &mut HashMap::from([("_dd.p.foo".to_string(), "abc".to_string())]),
             is_remote: false,
             tracestate: None,
+            ot: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1028,6 +1207,7 @@ mod test {
             tags: &mut HashMap::from([("_dd.p.foo".to_string(), "abc".to_string())]),
             is_remote: false,
             tracestate: Some(InjectTraceState::from_header(tracestate)),
+            ot: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1138,6 +1318,37 @@ mod test {
     }
 
     #[test]
+    fn parses_ot_member_and_removes_it_from_additional_values() {
+        let ts: Tracestate = "dd=s:2;t.dm:-3,ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            ts.ot.as_deref(),
+            Some("rv:ef284ace7a91e1;th:e6666666666666")
+        );
+        // ot removed from remainder; congo preserved
+        let additional = ts.additional_values.unwrap();
+        assert!(additional.iter().all(|(k, _)| k != "ot"));
+        assert!(additional.iter().any(|(k, v)| k == "congo" && v == "xyz"));
+    }
+
+    #[test]
+    fn ot_is_kept_raw_at_extraction_even_if_malformed() {
+        let ts: Tracestate = "dd=s:1,ot=rv:not-hex-garbage;th:not-hex-either,congo=xyz123"
+            .parse()
+            .unwrap();
+        // no parsing/validation happens at extraction; forwarded verbatim
+        assert_eq!(
+            ts.ot.as_deref(),
+            Some("rv:not-hex-garbage;th:not-hex-either")
+        );
+        let additional = ts.additional_values.unwrap();
+        assert!(additional
+            .iter()
+            .any(|(k, v)| k == "congo" && v == "xyz123"));
+    }
+
+    #[test]
     fn test_replace_chars() {
         let tests = vec![
             ("ac", "ac"),
@@ -1152,5 +1363,53 @@ mod test {
         for (input, expected) in tests {
             assert_eq!(replace_chars(input, |c| c == b'b', '_'), expected);
         }
+    }
+
+    #[test]
+    fn ot_set_rv_th_formats_rv_padded_and_th_trimmed() {
+        assert_eq!(
+            ot_set_rv_th(None, Some(0x0028d980cf4f1c), None).as_deref(),
+            Some("rv:0028d980cf4f1c")
+        );
+        assert_eq!(
+            ot_set_rv_th(None, None, Some(0x80000000000000)).as_deref(),
+            Some("th:8")
+        );
+        assert_eq!(ot_set_rv_th(None, None, Some(0)).as_deref(), Some("th:0"));
+        assert_eq!(ot_set_rv_th(None, None, None), None);
+    }
+
+    #[test]
+    fn ot_set_rv_th_replaces_old_pair_and_keeps_others() {
+        assert_eq!(
+            ot_set_rv_th(
+                Some("rv:1234567890abcd;th:e6666666666666"),
+                Some(0xf0948a54d43b8e),
+                None
+            )
+            .as_deref(),
+            Some("rv:f0948a54d43b8e")
+        );
+
+        // unrecognized sub-keys are kept, in order, after the new pair
+        assert_eq!(
+            ot_set_rv_th(
+                Some("rv:1234567890abcd;fut:abc;th:e6666666666666"),
+                Some(0xf0948a54d43b8e),
+                Some(0xe6666666666666)
+            )
+            .as_deref(),
+            Some("rv:f0948a54d43b8e;th:e6666666666666;fut:abc")
+        );
+    }
+
+    #[test]
+    fn ot_extract_rv_finds_rv_regardless_of_position() {
+        assert_eq!(
+            ot_extract_rv("th:e6666666666666;rv:f0948a54d43b8e"),
+            Some(0xf0948a54d43b8e)
+        );
+        assert_eq!(ot_extract_rv("th:e6666666666666"), None);
+        assert_eq!(ot_extract_rv("rv:not-hex-garbage"), None);
     }
 }

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -26,6 +26,7 @@ pub const TRACESTATE_KEY: &str = "tracestate";
 const TRACESTATE_MAX_MEMBERS: usize = 32;
 
 const TRACESTATE_DD_KEY_MAX_LENGTH: usize = 256;
+const TRACESTATE_OT_KEY_MAX_LENGTH: usize = 256;
 const TRACESTATE_VALUES_SEPARATOR: &str = ",";
 const TRACESTATE_DD_PAIR_SEPARATOR: &str = ";";
 const TRACESTATE_SAMPLING_PRIORITY_KEY: &str = "s";
@@ -86,7 +87,22 @@ pub(crate) fn ot_set_rv_th(raw: Option<&str>, rv: Option<u64>, th: Option<u64>) 
         .chain(th_part.as_deref())
         .chain(others)
         .collect();
-    (!parts.is_empty()).then(|| parts.join(";"))
+    join_capped(&parts, TRACESTATE_OT_KEY_MAX_LENGTH)
+}
+
+/// Joins leading `parts` with `;` capping length under `max_len`
+fn join_capped(parts: &[&str], max_len: usize) -> Option<String> {
+    let mut len = 0;
+    let mut count = 0;
+    for part in parts {
+        let sep_len = if count == 0 { 0 } else { 1 };
+        if len + sep_len + part.len() > max_len {
+            break;
+        }
+        len += sep_len + part.len();
+        count += 1;
+    }
+    (count > 0).then(|| parts[..count].join(";"))
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1401,6 +1417,29 @@ mod test {
             .as_deref(),
             Some("rv:f0948a54d43b8e;th:e6666666666666;fut:abc")
         );
+    }
+
+    #[test]
+    fn ot_set_rv_th_caps_length_dropping_trailing_subkeys() {
+        let huge = "z".repeat(300);
+        let raw = format!("fut:{huge}");
+        let result =
+            ot_set_rv_th(Some(&raw), Some(0x1234567890abcd), Some(0xe6666666666666)).unwrap();
+        assert!(result.len() <= 256, "got len {}", result.len());
+        assert_eq!(result, "rv:1234567890abcd;th:e6666666666666");
+
+        let raw = (0..40)
+            .map(|i| format!("k{i}:{}", "a".repeat(10)))
+            .collect::<Vec<_>>()
+            .join(";");
+        let result =
+            ot_set_rv_th(Some(&raw), Some(0x1234567890abcd), Some(0xe6666666666666)).unwrap();
+        assert!(result.len() <= 256, "got len {}", result.len());
+        assert!(!result.ends_with(';'));
+        assert!(result.starts_with("rv:1234567890abcd;th:e6666666666666"));
+        for part in result.split(';') {
+            assert!(part.starts_with("rv:") || part.starts_with("th:") || raw.contains(part));
+        }
     }
 
     #[test]

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -136,8 +136,7 @@ pub struct Tracestate {
     pub(crate) lower_order_trace_id: Option<String>,
     pub(crate) propagation_tags: Option<HashMap<String, String>>,
     pub(crate) additional_values: Option<Vec<(String, String)>>,
-    /// Raw inbound OTel field (useful for consistent-probability member value)
-    pub(crate) ot: Option<String>,
+    pub(crate) ot_member: Option<String>,
 }
 
 /// Code inspired, and copied, by OpenTelemetry Rust project.
@@ -229,7 +228,7 @@ impl FromStr for Tracestate {
             lower_order_trace_id: None,
             propagation_tags: None,
             additional_values: None,
-            ot: None,
+            ot_member: None,
         };
 
         // the original order must be maintained
@@ -275,7 +274,7 @@ impl FromStr for Tracestate {
         };
 
         tracestate.propagation_tags = propagation_tags;
-        tracestate.ot = ot;
+        tracestate.ot_member = ot;
 
         Ok(tracestate)
     }
@@ -535,7 +534,7 @@ fn inject_tracestate(context: &InjectSpanContext, carrier: &mut dyn Injector) {
         dd_parts.truncate(index_before_tags);
     }
 
-    if let Some(ot) = context.ot.as_deref() {
+    if let Some(ot) = context.ot_member {
         member_count += 1;
         let mut ot_part = buf_appender(&mut tracestate);
         ot_part.push_str(super::const_concat!(TRACESTATE_VALUES_SEPARATOR, "ot=",));
@@ -1055,7 +1054,7 @@ mod test {
             tracestate: Some(InjectTraceState::from_header(
                 "other=bleh,atel=test,dd=s:2;o:foo_bar_;t.dm:-4".to_owned(),
             )),
-            ot: None,
+            ot_member: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1092,7 +1091,7 @@ mod test {
             tags: &mut tags,
             is_remote: false,
             tracestate: None,
-            ot: ot.map(str::to_string),
+            ot_member: ot,
         };
         let mut carrier: HashMap<String, String> = HashMap::new();
         TracePropagationStyle::TraceContext.inject(
@@ -1163,7 +1162,7 @@ mod test {
             tags: &mut tags,
             is_remote: false,
             tracestate: Some(InjectTraceState::from_header("congo=xyz".to_owned())),
-            ot: Some("rv:ef284ace7a91e1;th:e6666666666666".to_string()),
+            ot_member: Some("rv:ef284ace7a91e1;th:e6666666666666"),
         };
         let mut carrier: HashMap<String, String> = HashMap::new();
         TracePropagationStyle::TraceContext.inject(
@@ -1196,7 +1195,7 @@ mod test {
             tags: &mut HashMap::from([("_dd.p.foo".to_string(), "abc".to_string())]),
             is_remote: false,
             tracestate: None,
-            ot: None,
+            ot_member: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1236,7 +1235,7 @@ mod test {
             tags: &mut HashMap::from([("_dd.p.foo".to_string(), "abc".to_string())]),
             is_remote: false,
             tracestate: Some(InjectTraceState::from_header(tracestate)),
-            ot: None,
+            ot_member: None,
         };
 
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1352,7 +1351,7 @@ mod test {
             .parse()
             .unwrap();
         assert_eq!(
-            ts.ot.as_deref(),
+            ts.ot_member.as_deref(),
             Some("rv:ef284ace7a91e1;th:e6666666666666")
         );
         // ot removed from remainder; congo preserved
@@ -1368,7 +1367,7 @@ mod test {
             .unwrap();
         // no parsing/validation happens at extraction; forwarded verbatim
         assert_eq!(
-            ts.ot.as_deref(),
+            ts.ot_member.as_deref(),
             Some("rv:not-hex-garbage;th:not-hex-either")
         );
         let additional = ts.additional_values.unwrap();

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -301,6 +301,7 @@ impl InjectTraceState {
         self.header.split(',').filter(|part| {
             let (key, value) = part.split_once('=').unwrap_or((part, ""));
             key != "dd"
+                && key != "ot"
                 && !value.is_empty()
                 && Tracestate::valid_key(key)
                 && Tracestate::valid_value(value)
@@ -1164,7 +1165,9 @@ mod test {
             origin: None,
             tags: &mut tags,
             is_remote: false,
-            tracestate: Some(InjectTraceState::from_header("congo=xyz".to_owned())),
+            tracestate: Some(InjectTraceState::from_header(
+                "ot=rv:11111111111111;th:0,congo=xyz".to_owned(),
+            )),
             ot_member: Some("rv:ef284ace7a91e1;th:e6666666666666"),
         };
         let mut carrier: HashMap<String, String> = HashMap::new();
@@ -1178,6 +1181,7 @@ mod test {
             ts.contains("ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz"),
             "got {ts}"
         );
+        assert!(!ts.contains("ot=rv:11111111111111;th:0"), "got {ts}");
         let dd = ts.find("dd=").unwrap();
         let ot = ts.find("ot=").unwrap();
         let congo = ts.find("congo=").unwrap();

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -72,7 +72,7 @@ pub(crate) fn ot_sanitize(raw: &str) -> Option<String> {
             _ => true,
         })
         .collect();
-    join_capped(&parts, TRACESTATE_OT_KEY_MAX_LENGTH)
+    join_capped(parts, TRACESTATE_OT_KEY_MAX_LENGTH)
 }
 
 /// Replaces `rv`/`th` in a raw `ot` member value, dropping the old ones and
@@ -94,28 +94,32 @@ pub(crate) fn ot_set_rv_th(raw: Option<&str>, rv: Option<u64>, th: Option<u64>) 
     let rv_part = rv.map(|v| format!("rv:{v:014x}"));
     let th_part = th.map(|v| format!("th:{}", format_th(v)));
 
-    let parts: Vec<&str> = rv_part
+    let parts = rv_part
         .as_deref()
         .into_iter()
         .chain(th_part.as_deref())
-        .chain(others)
-        .collect();
-    join_capped(&parts, TRACESTATE_OT_KEY_MAX_LENGTH)
+        .chain(others);
+    join_capped(parts, TRACESTATE_OT_KEY_MAX_LENGTH)
 }
 
 /// Joins leading `parts` with `;` capping length under `max_len`
-fn join_capped(parts: &[&str], max_len: usize) -> Option<String> {
+fn join_capped<'a>(parts: impl IntoIterator<Item = &'a str>, max_len: usize) -> Option<String> {
     let mut len = 0;
     let mut count = 0;
+    let mut result = String::new();
     for part in parts {
         let sep_len = if count == 0 { 0 } else { 1 };
         if len + sep_len + part.len() > max_len {
             break;
         }
         len += sep_len + part.len();
+        if count > 0 {
+            result.push(';');
+        }
+        result.push_str(part);
         count += 1;
     }
-    (count > 0).then(|| parts[..count].join(";"))
+    (count > 0).then_some(result)
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -1075,9 +1075,8 @@ mod test {
         );
     }
 
-    /// Builds a minimal local-root `InjectSpanContext` carrying `ot`, injects
-    /// it, and returns the emitted `tracestate` string. Used by the OTel
-    /// consistent-probability emission tests (APMAPI-2181, system-tests #7372).
+    /// Builds a local-root `InjectSpanContext`, injects it, and returns its
+    /// emitted `tracestate` string.
     fn inject_with_ot(trace_id: u128, ot: Option<&str>) -> String {
         let mut tags = HashMap::new();
         let mut context = InjectSpanContext {

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -138,7 +138,7 @@ impl ShouldSample for Sampler {
             result.get_trace_root_sampling_info()
         {
             let inbound_ot = parent_context
-                .and_then(|context| context.get::<DatadogExtractData>())
+                .and_then(|c| c.get::<DatadogExtractData>())
                 .and_then(|data| data.ot.clone());
             // If the parent was deferred, we try to merge propagation tags with what we extracted
             let (mut tags, origin) = if is_parent_deferred {
@@ -146,7 +146,7 @@ impl ShouldSample for Sampler {
                     internal_tags,
                     origin,
                     ..
-                }) = parent_context.and_then(|context| context.get())
+                }) = parent_context.and_then(|c| c.get())
                 {
                     (Some(internal_tags.clone()), origin.clone())
                 } else {

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -7,16 +7,41 @@ use opentelemetry::trace::{TraceContextExt, TraceState};
 use opentelemetry_sdk::{trace::ShouldSample, Resource};
 use std::sync::{Arc, RwLock};
 
+use libdd_sampling::OtelConsistentSampling;
+
 use crate::{
     core::{
         configuration::Config, constants::SAMPLING_DECISION_MAKER_TAG_KEY,
         sampling::SamplingDecision,
     },
+    propagation::tracecontext::{ot_extract_rv, ot_set_rv_th},
     sampling::{DatadogSampler, OtelSamplingData, SamplingRule, SamplingRulesCallback},
     span_processor::{RegisterTracePropagationResult, TracePropagationData},
     text_map_propagator::{self, DatadogExtractData},
     TraceRegistry,
 };
+
+/// Single source of truth for the outbound OTel `ot` member (APMAPI-2181).
+///
+/// * local root + probability decision (`derived` = Some) → emit the derived `rv;th` pair as-is;
+///   any inbound value is ignored (A1).
+/// * local root + non-probability decision (`derived` = None) → erase `th`, keep an inherited `rv`
+///   if present, fabricate nothing otherwise (A4).
+/// * inherited decision (`is_local_root` = false) → forward the inbound value unchanged
+///   (A2/A2b/A3/A5/A6).
+pub(crate) fn resolve_outbound_ot(
+    is_local_root: bool,
+    derived: Option<OtelConsistentSampling>,
+    inbound: Option<String>,
+) -> Option<String> {
+    match (is_local_root, derived) {
+        (true, Some(ocs)) => ot_set_rv_th(inbound.as_deref(), Some(ocs.rv), Some(ocs.th)),
+        (true, None) => inbound
+            .as_deref()
+            .and_then(|raw| ot_set_rv_th(Some(raw), ot_extract_rv(raw), None)),
+        (false, _) => inbound,
+    }
+}
 
 /// OpenTelemetry sampler implementation for Datadog tracing.
 ///
@@ -101,6 +126,8 @@ impl ShouldSample for Sampler {
             .filter(|c| !is_parent_deferred && c.has_active_span())
             .map(|c| c.span().span_context().trace_flags().is_sampled());
 
+        let trace_id_u128 = u128::from_be_bytes(trace_id.to_bytes());
+
         let data = OtelSamplingData::new(
             is_parent_sampled,
             &trace_id,
@@ -114,19 +141,20 @@ impl ShouldSample for Sampler {
             result.get_trace_root_sampling_info()
         {
             // If the parent was deferred, we try to merge propagation tags with what we extracted
-            let (mut tags, origin) = if is_parent_deferred {
+            let (mut tags, origin, inbound_ot) = if is_parent_deferred {
                 if let Some(DatadogExtractData {
                     internal_tags,
                     origin,
+                    ot,
                     ..
                 }) = parent_context.and_then(|c| c.get())
                 {
-                    (Some(internal_tags.clone()), origin.clone())
+                    (Some(internal_tags.clone()), origin.clone(), ot.clone())
                 } else {
-                    (None, None)
+                    (None, None, None)
                 }
             } else {
-                (None, None)
+                (None, None, None)
             };
             let mechanism = trace_root_info.mechanism();
             tags.get_or_insert_default().insert(
@@ -141,6 +169,11 @@ impl ShouldSample for Sampler {
                 },
                 origin,
                 tags,
+                ot: resolve_outbound_ot(
+                    true,
+                    trace_root_info.otel_consistent_sampling(&trace_id_u128),
+                    inbound_ot,
+                ),
             })
         } else if let Some(remote_ctx) =
             parent_context.filter(|c| c.span().span_context().is_remote())
@@ -149,6 +182,7 @@ impl ShouldSample for Sampler {
                 sampling,
                 origin,
                 internal_tags,
+                ot,
                 ..
             }) = remote_ctx.get()
             {
@@ -160,6 +194,7 @@ impl ShouldSample for Sampler {
                     origin: origin.clone(),
                     sampling_decision,
                     tags: Some(internal_tags.clone()),
+                    ot: resolve_outbound_ot(false, None, ot.clone()),
                 })
             } else {
                 None
@@ -213,12 +248,62 @@ impl ShouldSample for Sampler {
 mod tests {
     use super::*;
     use crate::core::configuration::SamplingRuleConfig;
+    use libdd_sampling::OtelConsistentSampling;
     use opentelemetry::{
         trace::{SpanContext, SpanKind, TraceId, TraceState},
         Context, SpanId, TraceFlags,
     };
     use opentelemetry_sdk::trace::{SamplingDecision, ShouldSample};
     use std::collections::HashMap;
+
+    #[test]
+    fn resolve_outbound_ot_covers_a1_a2_a4() {
+        let derived = OtelConsistentSampling {
+            rv: 0xef284ace7a91e1,
+            th: 0xe6666666666666,
+        };
+        let inbound_pair = "rv:1234567890abcd;th:0ccccccccccccd".to_string();
+        let inbound_rv_only = "rv:1234567890abcd".to_string();
+
+        // A1: local root + probability -> emit the derived pair as-is (inbound ignored).
+        assert_eq!(
+            super::resolve_outbound_ot(true, Some(derived), Some(inbound_pair.clone())),
+            Some("rv:ef284ace7a91e1;th:e6666666666666".to_string())
+        );
+        // A4: local root + non-probability (derived None) -> erase th, keep inherited rv
+        assert_eq!(
+            super::resolve_outbound_ot(true, None, Some(inbound_pair)),
+            Some("rv:1234567890abcd".to_string())
+        );
+        // A4 (nothing inherited): local root + non-probability + no inbound -> None
+        assert_eq!(super::resolve_outbound_ot(true, None, None), None);
+        // A2/A2b: inherited decision -> forward inbound unchanged (rv-only kept)
+        assert_eq!(
+            super::resolve_outbound_ot(false, None, Some(inbound_rv_only.clone())),
+            Some(inbound_rv_only)
+        );
+        // A5/A6: inherited with no (or empty) inbound -> None / forwarded as-is
+        assert_eq!(super::resolve_outbound_ot(false, None, None), None);
+        assert_eq!(
+            super::resolve_outbound_ot(false, None, Some(String::new())),
+            Some(String::new())
+        );
+    }
+
+    // restart/ignore: the inbound `ot` is dropped (DatadogExtractData.ot = None)
+    // and the restarted root re-enters the local-root branch, so it emits its
+    // own freshly-derived pair rather than forwarding the previous trace's.
+    #[test]
+    fn resolve_outbound_ot_restart_rederives() {
+        let derived = OtelConsistentSampling {
+            rv: 0xf0948a54d43b8e,
+            th: 0xe6666666666666,
+        };
+        assert_eq!(
+            super::resolve_outbound_ot(true, Some(derived), None),
+            Some("rv:f0948a54d43b8e;th:e6666666666666".to_string())
+        );
+    }
 
     #[test]
     fn test_create_sampler_with_sampling_rules() {

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -14,32 +14,29 @@ use crate::{
         configuration::Config, constants::SAMPLING_DECISION_MAKER_TAG_KEY,
         sampling::SamplingDecision,
     },
-    propagation::tracecontext::{ot_extract_rv, ot_set_rv_th},
+    propagation::tracecontext::{ot_extract_rv, ot_sanitize, ot_set_rv_th},
     sampling::{DatadogSampler, OtelSamplingData, SamplingRule, SamplingRulesCallback},
     span_processor::{RegisterTracePropagationResult, TracePropagationData},
     text_map_propagator::{self, DatadogExtractData},
     TraceRegistry,
 };
 
-/// Single source of truth for the outbound OTel `ot` member (APMAPI-2181).
-///
-/// * local root + probability decision (`derived` = Some) → emit the derived `rv;th` pair as-is;
-///   any inbound value is ignored (A1).
-/// * local root + non-probability decision (`derived` = None) → erase `th`, keep an inherited `rv`
-///   if present, fabricate nothing otherwise (A4).
-/// * inherited decision (`is_local_root` = false) → forward the inbound value unchanged
-///   (A2/A2b/A3/A5/A6).
-pub(crate) fn resolve_outbound_ot(
-    is_local_root: bool,
-    derived: Option<OtelConsistentSampling>,
-    inbound: Option<String>,
-) -> Option<String> {
-    match (is_local_root, derived) {
-        (true, Some(ocs)) => ot_set_rv_th(inbound.as_deref(), Some(ocs.rv), Some(ocs.th)),
-        (true, None) => inbound
+enum OtDecision {
+    Probability(OtelConsistentSampling),
+    NonProbability,
+    Inherited,
+}
+
+/// Resolves the outbound OTel `ot` member from the effective sampling decision.
+fn resolve_outbound_ot(decision: OtDecision, inbound: Option<String>) -> Option<String> {
+    match decision {
+        OtDecision::Probability(ocs) => {
+            ot_set_rv_th(inbound.as_deref(), Some(ocs.rv), Some(ocs.th))
+        }
+        OtDecision::NonProbability => inbound
             .as_deref()
             .and_then(|raw| ot_set_rv_th(Some(raw), ot_extract_rv(raw), None)),
-        (false, _) => inbound,
+        OtDecision::Inherited => inbound.as_deref().and_then(ot_sanitize),
     }
 }
 
@@ -140,23 +137,26 @@ impl ShouldSample for Sampler {
         let trace_propagation_data = if let Some(trace_root_info) =
             result.get_trace_root_sampling_info()
         {
+            let inbound_ot = parent_context
+                .and_then(|context| context.get::<DatadogExtractData>())
+                .and_then(|data| data.ot.clone());
             // If the parent was deferred, we try to merge propagation tags with what we extracted
-            let (mut tags, origin, inbound_ot) = if is_parent_deferred {
+            let (mut tags, origin) = if is_parent_deferred {
                 if let Some(DatadogExtractData {
                     internal_tags,
                     origin,
-                    ot,
                     ..
-                }) = parent_context.and_then(|c| c.get())
+                }) = parent_context.and_then(|context| context.get())
                 {
-                    (Some(internal_tags.clone()), origin.clone(), ot.clone())
+                    (Some(internal_tags.clone()), origin.clone())
                 } else {
-                    (None, None, None)
+                    (None, None)
                 }
             } else {
-                (None, None, None)
+                (None, None)
             };
             let mechanism = trace_root_info.mechanism();
+            let consistent_sampling = trace_root_info.otel_consistent_sampling(&trace_id_u128);
             tags.get_or_insert_default().insert(
                 SAMPLING_DECISION_MAKER_TAG_KEY.to_string(),
                 mechanism.to_cow().into_owned(),
@@ -170,8 +170,7 @@ impl ShouldSample for Sampler {
                 origin,
                 tags,
                 ot: resolve_outbound_ot(
-                    true,
-                    trace_root_info.otel_consistent_sampling(&trace_id_u128),
+                    consistent_sampling.map_or(OtDecision::NonProbability, OtDecision::Probability),
                     inbound_ot,
                 ),
             })
@@ -194,7 +193,7 @@ impl ShouldSample for Sampler {
                     origin: origin.clone(),
                     sampling_decision,
                     tags: Some(internal_tags.clone()),
-                    ot: resolve_outbound_ot(false, None, ot.clone()),
+                    ot: resolve_outbound_ot(OtDecision::Inherited, ot.clone()),
                 })
             } else {
                 None
@@ -257,7 +256,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn resolve_outbound_ot_covers_a1_a2_a4() {
+    fn resolve_outbound_ot_covers_probability_non_probability_and_inherited() {
         let derived = OtelConsistentSampling {
             rv: 0xef284ace7a91e1,
             th: 0xe6666666666666,
@@ -265,28 +264,35 @@ mod tests {
         let inbound_pair = "rv:1234567890abcd;th:0ccccccccccccd".to_string();
         let inbound_rv_only = "rv:1234567890abcd".to_string();
 
-        // A1: local root + probability -> emit the derived pair as-is (inbound ignored).
         assert_eq!(
-            super::resolve_outbound_ot(true, Some(derived), Some(inbound_pair.clone())),
+            super::resolve_outbound_ot(
+                OtDecision::Probability(derived),
+                Some(inbound_pair.clone())
+            ),
             Some("rv:ef284ace7a91e1;th:e6666666666666".to_string())
         );
-        // A4: local root + non-probability (derived None) -> erase th, keep inherited rv
         assert_eq!(
-            super::resolve_outbound_ot(true, None, Some(inbound_pair)),
+            super::resolve_outbound_ot(OtDecision::NonProbability, Some(inbound_pair)),
             Some("rv:1234567890abcd".to_string())
         );
-        // A4 (nothing inherited): local root + non-probability + no inbound -> None
-        assert_eq!(super::resolve_outbound_ot(true, None, None), None);
-        // A2/A2b: inherited decision -> forward inbound unchanged (rv-only kept)
         assert_eq!(
-            super::resolve_outbound_ot(false, None, Some(inbound_rv_only.clone())),
+            super::resolve_outbound_ot(OtDecision::NonProbability, None),
+            None
+        );
+        assert_eq!(
+            super::resolve_outbound_ot(OtDecision::Inherited, Some(inbound_rv_only.clone())),
             Some(inbound_rv_only)
         );
-        // A5/A6: inherited with no (or empty) inbound -> None / forwarded as-is
-        assert_eq!(super::resolve_outbound_ot(false, None, None), None);
         assert_eq!(
-            super::resolve_outbound_ot(false, None, Some(String::new())),
-            Some(String::new())
+            super::resolve_outbound_ot(OtDecision::Inherited, None),
+            None
+        );
+        assert_eq!(
+            super::resolve_outbound_ot(
+                OtDecision::Inherited,
+                Some("rv:not-hex;th:invalid;future:value".to_string())
+            ),
+            Some("future:value".to_string())
         );
     }
 
@@ -300,8 +306,41 @@ mod tests {
             th: 0xe6666666666666,
         };
         assert_eq!(
-            super::resolve_outbound_ot(true, Some(derived), None),
+            super::resolve_outbound_ot(OtDecision::Probability(derived), None),
             Some("rv:f0948a54d43b8e;th:e6666666666666".to_string())
+        );
+    }
+
+    #[test]
+    fn sampled_local_root_registers_ot_probability_decision() {
+        let config = Arc::new(
+            Config::builder()
+                .set_trace_sample_rate(0.1)
+                .set_trace_rate_limit(10_000_000)
+                .build(),
+        );
+        let registry = TraceRegistry::new(config.clone());
+        let sampler = Sampler::new(
+            config,
+            Arc::new(RwLock::new(Resource::builder_empty().build())),
+            Some(registry.clone()),
+        );
+        let trace_id = TraceId::from_bytes(1_u128.to_be_bytes());
+
+        let parent = Context::new()
+            .with_remote_span_context(SpanContext::new(
+                trace_id,
+                SpanId::from_bytes(1_u64.to_be_bytes()),
+                text_map_propagator::TRACE_FLAG_DEFERRED,
+                true,
+                TraceState::NONE,
+            ))
+            .with_value(DatadogExtractData::default());
+        sampler.should_sample(Some(&parent), trace_id, "test", &SpanKind::Server, &[], &[]);
+
+        assert_eq!(
+            registry.get_trace_propagation_data(trace_id.to_bytes()).ot,
+            Some("rv:f0948a54d43b8e;th:e6666666666668".to_string())
         );
     }
 

--- a/datadog-opentelemetry/src/sampler.rs
+++ b/datadog-opentelemetry/src/sampler.rs
@@ -339,7 +339,9 @@ mod tests {
         sampler.should_sample(Some(&parent), trace_id, "test", &SpanKind::Server, &[], &[]);
 
         assert_eq!(
-            registry.get_trace_propagation_data(trace_id.to_bytes()).ot,
+            registry
+                .get_trace_propagation_data(trace_id.to_bytes())
+                .and_then(|data| data.ot),
             Some("rv:f0948a54d43b8e;th:e6666666666668".to_string())
         );
     }

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -61,6 +61,12 @@ const EMPTY_PROPAGATION_DATA: TracePropagationData = TracePropagationData {
     ot: None,
 };
 
+impl Default for TracePropagationData {
+    fn default() -> Self {
+        EMPTY_PROPAGATION_DATA
+    }
+}
+
 #[derive(Debug)]
 struct InnerTraceRegistry {
     registry: BHashMap<[u8; 16], Trace>,
@@ -235,11 +241,10 @@ impl InnerTraceRegistry {
         }
     }
 
-    fn get_trace_propagation_data(&self, trace_id: [u8; 16]) -> &TracePropagationData {
-        match self.registry.get(&trace_id) {
-            Some(trace) => &trace.propagation_data,
-            None => &EMPTY_PROPAGATION_DATA,
-        }
+    fn get_trace_propagation_data(&self, trace_id: [u8; 16]) -> Option<&TracePropagationData> {
+        self.registry
+            .get(&trace_id)
+            .map(|trace| &trace.propagation_data)
     }
 
     fn get_metrics(&mut self) -> TraceRegistryMetrics {
@@ -352,15 +357,15 @@ impl TraceRegistry {
 
     /// Retrieves the trace propagation data for a given trace ID.
     ///
-    /// Returns the sampling decision, origin, and internal tags associated with the trace.
+    /// Returns the sampling decision, origin, and internal tags when the trace is registered.
     #[allow(private_interfaces)]
-    pub fn get_trace_propagation_data(&self, trace_id: [u8; 16]) -> TracePropagationData {
+    pub fn get_trace_propagation_data(&self, trace_id: [u8; 16]) -> Option<TracePropagationData> {
         let inner = self
             .get_shard(trace_id)
             .read()
             .expect("Failed to acquire lock on trace registry");
 
-        inner.get_trace_propagation_data(trace_id).clone()
+        inner.get_trace_propagation_data(trace_id).cloned()
     }
 
     /// Aggregates and returns metrics from all registry shards.

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -48,6 +48,7 @@ pub(crate) struct TracePropagationData {
     pub sampling_decision: SamplingDecision,
     pub origin: Option<String>,
     pub tags: Option<HashMap<String, String>>,
+    pub ot: Option<String>,
 }
 
 const EMPTY_PROPAGATION_DATA: TracePropagationData = TracePropagationData {
@@ -57,6 +58,7 @@ const EMPTY_PROPAGATION_DATA: TracePropagationData = TracePropagationData {
         mechanism: None,
     },
     tags: None,
+    ot: None,
 };
 
 #[derive(Debug)]
@@ -959,6 +961,7 @@ mod tests {
                                                     "dd.p.tid".to_string(),
                                                     "foobar".to_string(),
                                                 )])),
+                                                ot: None,
                                             },
                                         );
                                     }

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -151,7 +151,7 @@ impl DatadogPropagator {
             Some(ot) => Some(ot),
             None if !is_trace_registered => cx
                 .get::<DatadogExtractData>()
-                .and_then(|extract_data| extract_data.ot.clone()),
+                .and_then(|data| data.ot.clone()),
             None => None,
         };
         let ot = ot.as_deref().and_then(ot_sanitize);

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -10,6 +10,7 @@ use crate::{
         baggage::extract_baggage,
         config::{get_extractors, get_injectors},
         context::{InjectSpanContext, InjectTraceState, Sampling, SpanContext, SpanLink},
+        tracecontext::ot_sanitize,
         DatadogCompositePropagator, ExtractResult, TracePropagationStyle,
     },
 };
@@ -148,10 +149,15 @@ impl DatadogPropagator {
             &mut HashMap::new()
         };
 
-        let ot = propagation_data.ot.take().or_else(|| {
-            cx.get::<DatadogExtractData>()
-                .and_then(|extract_data| extract_data.ot.clone())
-        });
+        let ot = propagation_data
+            .ot
+            .take()
+            .or_else(|| {
+                cx.get::<DatadogExtractData>()
+                    .and_then(|extract_data| extract_data.ot.clone())
+            })
+            .as_deref()
+            .and_then(ot_sanitize);
 
         let dd_span_context = &mut InjectSpanContext {
             trace_id: u128::from_be_bytes(trace_id),
@@ -717,6 +723,36 @@ pub mod tests {
         assert!(
             injected_trace_state.contains("ot=rv:ef284ace7a91e1;th:e6666666666666"),
             "expected inbound `ot` to be forwarded unchanged, got {injected_trace_state}"
+        );
+        assert!(
+            injected_trace_state.contains("congo=xyz"),
+            "expected unrelated vendor member to still pass through, got {injected_trace_state}"
+        );
+    }
+
+    #[test]
+    fn extract_inject_w3c_passthrough_drops_malformed_ot_subkeys() {
+        let config = Arc::new(Config::builder().build());
+        let propagator = DatadogPropagator::new(config.clone(), TraceRegistry::new(config));
+        let extractor = HashMap::from([
+            (
+                TRACEPARENT_KEY.to_string(),
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            (
+                TRACESTATE_KEY.to_string(),
+                "dd=s:2,ot=rv:not-hex;th:invalid;future:value,congo=xyz".to_string(),
+            ),
+        ]);
+
+        let extracted_context = propagator.extract(&extractor);
+        let mut injector = HashMap::new();
+        propagator.inject_context(&extracted_context, &mut injector);
+
+        let injected_trace_state = Extractor::get(&injector, TRACESTATE_KEY).unwrap_or("");
+        assert!(
+            injected_trace_state.contains("ot=future:value"),
+            "expected malformed subkeys to be removed, got {injected_trace_state}"
         );
         assert!(
             injected_trace_state.contains("congo=xyz"),

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -148,6 +148,11 @@ impl DatadogPropagator {
             &mut HashMap::new()
         };
 
+        let ot = propagation_data.ot.take().or_else(|| {
+            cx.get::<DatadogExtractData>()
+                .and_then(|extract_data| extract_data.ot.clone())
+        });
+
         let dd_span_context = &mut InjectSpanContext {
             trace_id: u128::from_be_bytes(trace_id),
             span_id: u64::from_be_bytes(otel_span_context.span_id().to_bytes()),
@@ -156,7 +161,7 @@ impl DatadogPropagator {
             origin: propagation_data.origin.as_deref(),
             tags,
             tracestate,
-            ot: propagation_data.ot,
+            ot,
         };
 
         self.inner.inject(dd_span_context, &mut injector)
@@ -684,6 +689,39 @@ pub mod tests {
                 injected_trace_state.get("foo").unwrap_or_default()
             )
         }
+    }
+
+    #[test]
+    fn extract_inject_w3c_passthrough_forwards_ot_without_span_registration() {
+        let builder = Config::builder();
+        let config = Arc::new(builder.build());
+        let registry = TraceRegistry::new(config.clone());
+        let propagator = DatadogPropagator::new(config, registry);
+
+        let mut extractor = HashMap::new();
+        extractor.insert(
+            TRACEPARENT_KEY.to_string(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+        );
+        extractor.insert(
+            TRACESTATE_KEY.to_string(),
+            "dd=s:2,ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz".to_string(),
+        );
+
+        let extracted_context = propagator.extract(&extractor);
+
+        let mut injector = HashMap::new();
+        propagator.inject_context(&extracted_context, &mut injector);
+
+        let injected_trace_state = Extractor::get(&injector, TRACESTATE_KEY).unwrap_or("");
+        assert!(
+            injected_trace_state.contains("ot=rv:ef284ace7a91e1;th:e6666666666666"),
+            "expected inbound `ot` to be forwarded unchanged, got {injected_trace_state}"
+        );
+        assert!(
+            injected_trace_state.contains("congo=xyz"),
+            "expected unrelated vendor member to still pass through, got {injected_trace_state}"
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -114,7 +114,9 @@ impl DatadogPropagator {
         }
 
         let trace_id = otel_span_context.trace_id().to_bytes();
-        let mut propagation_data = self.registry.get_trace_propagation_data(trace_id);
+        let trace_propagation_data = self.registry.get_trace_propagation_data(trace_id);
+        let is_trace_registered = trace_propagation_data.is_some();
+        let mut propagation_data = trace_propagation_data.unwrap_or_default();
 
         // get Trace's sampling decision and if it is not present obtain it from otel's SpanContext
         // flags
@@ -143,21 +145,22 @@ impl DatadogPropagator {
             Some(InjectTraceState::from_header(otel_tracestate.header()))
         };
 
+        // If the trace is not registered yet, fall back to the `ot` value that was
+        // extracted from the incoming context (if any).
+        let ot = match propagation_data.ot.take() {
+            Some(ot) => Some(ot),
+            None if !is_trace_registered => cx
+                .get::<DatadogExtractData>()
+                .and_then(|extract_data| extract_data.ot.clone()),
+            None => None,
+        };
+        let ot = ot.as_deref().and_then(ot_sanitize);
+
         let tags = if let Some(propagation_tags) = &mut propagation_data.tags {
             propagation_tags
         } else {
             &mut HashMap::new()
         };
-
-        let ot = propagation_data
-            .ot
-            .take()
-            .or_else(|| {
-                cx.get::<DatadogExtractData>()
-                    .and_then(|extract_data| extract_data.ot.clone())
-            })
-            .as_deref()
-            .and_then(ot_sanitize);
 
         let dd_span_context = &mut InjectSpanContext {
             trace_id: u128::from_be_bytes(trace_id),
@@ -723,6 +726,53 @@ pub mod tests {
         assert!(
             injected_trace_state.contains("ot=rv:ef284ace7a91e1;th:e6666666666666"),
             "expected inbound `ot` to be forwarded unchanged, got {injected_trace_state}"
+        );
+        assert!(
+            injected_trace_state.contains("congo=xyz"),
+            "expected unrelated vendor member to still pass through, got {injected_trace_state}"
+        );
+    }
+
+    #[test]
+    fn extract_inject_w3c_does_not_restore_erased_ot() {
+        let config = Arc::new(Config::builder().build());
+        let registry = TraceRegistry::new(config.clone());
+        let propagator = DatadogPropagator::new(config, registry.clone());
+        let extractor = HashMap::from([
+            (
+                TRACEPARENT_KEY.to_string(),
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            (
+                TRACESTATE_KEY.to_string(),
+                "dd=s:2,ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz".to_string(),
+            ),
+        ]);
+        let extracted_context = propagator.extract(&extractor);
+        let span = extracted_context.span();
+        let span_context = span.span_context();
+
+        registry.register_span(
+            span_context.trace_id().to_bytes(),
+            span_context.span_id().to_bytes(),
+            TracePropagationData {
+                sampling_decision: SamplingDecision {
+                    priority: None,
+                    mechanism: None,
+                },
+                origin: None,
+                tags: None,
+                ot: None,
+            },
+        );
+
+        let mut injector = HashMap::new();
+        propagator.inject_context(&extracted_context, &mut injector);
+
+        let injected_trace_state = Extractor::get(&injector, TRACESTATE_KEY).unwrap_or("");
+        assert!(
+            !injected_trace_state.contains("ot="),
+            "expected the erased `ot` to remain absent, got {injected_trace_state}"
         );
         assert!(
             injected_trace_state.contains("congo=xyz"),

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -62,7 +62,7 @@ impl DatadogExtractData {
             origin,
             internal_tags,
             sampling,
-            ot: tracestate.and_then(|ts| ts.ot),
+            ot: tracestate.and_then(|ts| ts.ot_member),
         }
     }
 }
@@ -170,7 +170,7 @@ impl DatadogPropagator {
             origin: propagation_data.origin.as_deref(),
             tags,
             tracestate,
-            ot,
+            ot_member: ot.as_deref(),
         };
 
         self.inner.inject(dd_span_context, &mut injector)

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -31,6 +31,7 @@ pub struct DatadogExtractData {
     pub origin: Option<String>,
     pub internal_tags: HashMap<String, String>,
     pub sampling: Sampling,
+    pub ot: Option<String>,
 }
 
 impl DatadogExtractData {
@@ -40,6 +41,7 @@ impl DatadogExtractData {
             tags,
             links,
             sampling,
+            tracestate,
             ..
         }: SpanContext,
     ) -> Self {
@@ -59,6 +61,7 @@ impl DatadogExtractData {
             origin,
             internal_tags,
             sampling,
+            ot: tracestate.and_then(|ts| ts.ot),
         }
     }
 }
@@ -153,6 +156,7 @@ impl DatadogPropagator {
             origin: propagation_data.origin.as_deref(),
             tags,
             tracestate,
+            ot: propagation_data.ot,
         };
 
         self.inner.inject(dd_span_context, &mut injector)
@@ -194,6 +198,7 @@ impl DatadogPropagator {
                 origin: None,
                 internal_tags: HashMap::new(),
                 sampling: Sampling::default(),
+                ot: None,
             }),
             ExtractResult::Passthrough => cx.clone(),
             ExtractResult::Ignore => return cx.clone(),
@@ -650,6 +655,7 @@ pub mod tests {
                         mechanism: None,
                     },
                     tags: Some(tags),
+                    ot: None,
                 },
             );
 

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -169,12 +169,9 @@ async fn test_sampling_extraction() {
                 }
             }
             let tracestate = injected.get("tracestate").unwrap();
-            // The `dd=` member is the first, comma-separated tracestate member.
             let dd_member = tracestate
                 .split(',')
-                .next()
-                .unwrap()
-                .strip_prefix("dd=")
+                .find_map(|member| member.strip_prefix("dd="))
                 .unwrap();
             assert_subset(
                 dd_member.split(';').map(String::from),

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -181,9 +181,8 @@ async fn test_sampling_extraction() {
                     format!("p:{span_id:016x}"),
                 ],
             );
-            // A probability sampling rule (rate 1.0) emits the OTel `ot`
-            // consistent-probability member (APMAPI-2181): rv derived from the
-            // trace id, th:0 for rate 1.0 ("keep all").
+            // A probability sampling rule with rate 1.0 emits an OTel `ot`
+            // member with `rv` from the trace ID and `th:0`.
             assert!(
                 tracestate
                     .split(',')

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -168,19 +168,30 @@ async fn test_sampling_extraction() {
                     propagator.inject(&mut injected);
                 }
             }
+            let tracestate = injected.get("tracestate").unwrap();
+            // The `dd=` member is the first, comma-separated tracestate member.
+            let dd_member = tracestate
+                .split(',')
+                .next()
+                .unwrap()
+                .strip_prefix("dd=")
+                .unwrap();
             assert_subset(
-                injected
-                    .get("tracestate")
-                    .unwrap()
-                    .strip_prefix("dd=")
-                    .unwrap()
-                    .split(';')
-                    .map(String::from),
+                dd_member.split(';').map(String::from),
                 [
                     "s:2".to_string(),
                     "t.dm:-3".to_string(),
                     format!("p:{span_id:016x}"),
                 ],
+            );
+            // A probability sampling rule (rate 1.0) emits the OTel `ot`
+            // consistent-probability member (APMAPI-2181): rv derived from the
+            // trace id, th:0 for rate 1.0 ("keep all").
+            assert!(
+                tracestate
+                    .split(',')
+                    .any(|m| m.starts_with("ot=rv:") && m.ends_with(";th:0")),
+                "expected an ot=rv:…;th:0 member, got {tracestate}"
             );
 
             assert_subset(


### PR DESCRIPTION
## Summary
- Parse the inbound `ot` tracestate member (rv/th) and forward it raw, rewriting only on injection
- Emit `rv`/`th` on inject based on the sampling decision, keeping unrecognized ot sub-keys
- Thread the ot decision from sampler through to the inject context

## Test plan
- [x] cargo test -p datadog-opentelemetry
- [x] cargo clippy --all-targets -- -D warnings
- Tests in https://github.com/DataDog/system-tests/pull/7372 to enable (except the ones involving force keep)