### PR TITLE
chore(docs): mark memory profiling as experimental

### DIFF
--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -236,9 +236,10 @@
 //! * `logs` enabled the log provider
 //! * `logs-grpc` enabled the log provider, with GRPC OTLP export
 //! * `logs-http` enabled the log provider, with HTTP OTLP export
-//! * `memory-profiling` enables sampled allocation events for out-of-process profilers to collect,
+//! * Experimental features
+//!     * `memory-profiling` enables sampled allocation events for out-of-process profilers to collect,
 //!   including live-heap (retained) tracking
-//! * `memory-profiling-alloc-only` is the same but with live-heap tracking compiled out (allocation
+//!     * `memory-profiling-alloc-only` is the same but with live-heap tracking compiled out (allocation
 //!   profiling only, lower overhead); enable this *or* `memory-profiling`, not both
 
 #![deny(missing_docs)]

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -237,10 +237,11 @@
 //! * `logs-grpc` enabled the log provider, with GRPC OTLP export
 //! * `logs-http` enabled the log provider, with HTTP OTLP export
 //! * Experimental features
-//!     * `memory-profiling` enables sampled allocation events for out-of-process profilers to collect,
-//!   including live-heap (retained) tracking
-//!     * `memory-profiling-alloc-only` is the same but with live-heap tracking compiled out (allocation
-//!   profiling only, lower overhead); enable this *or* `memory-profiling`, not both
+//!     * `memory-profiling` enables sampled allocation events for out-of-process profilers to
+//!       collect, including live-heap (retained) tracking
+//!     * `memory-profiling-alloc-only` is the same but with live-heap tracking compiled out
+//!       (allocation profiling only, lower overhead).  `memory-profiling` is a superset of this
+//!       feature flag so you don't need to enable both
 
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
# What does this PR do?

Update documentation to mark memory prof features as experimental, as they are otherwise removed from the documentation.
