### PR TITLE
chore(release): bump dd-trace-rs to 0.5.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Tracer Version(s)
       description: "Version(s) of the tracer affected by this bug"
-      placeholder: "0.5.0"
+      placeholder: "0.5.1"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "propagator"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "datadog-opentelemetry",
  "http-body-util",
@@ -3251,7 +3251,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_tracing"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "datadog-opentelemetry",
  "opentelemetry",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "0.5.0"
+version = "0.5.1"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/dd-trace-rs"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ opentelemetry-sdk.
 Add to you Cargo.toml
 
 ```toml
-datadog-opentelemetry = { version = "0.5.0" }
+datadog-opentelemetry = { version = "0.5.1" }
 ```
 
 ### Creating traces, metrics and logs
@@ -203,7 +203,7 @@ let logging_provider = datadog_opentelemetry::logs()
 
 For advanced usage and configuration information, check out [`DatadogTracingBuilder`],
 [`configuration::ConfigBuilder`] and the
-[library documentation](https://docs.rs/datadog-opentelemetry/0.5.0/datadog_opentelemetry/).
+[library documentation](https://docs.rs/datadog-opentelemetry/0.5.1/datadog_opentelemetry/).
 
 * Through env variables
 

--- a/datadog-opentelemetry/CHANGELOG.md
+++ b/datadog-opentelemetry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 (Aug 13, 2026)
+
+- Only error when no extractor recovers a real trace [SVLS-9550] in https://github.com/DataDog/dd-trace-rs/pull/284
+
 ## 0.5.0 (Jul 10, 2026)
 
 - Upgrade opentelemetry to 0.32 in https://github.com/DataDog/dd-trace-rs/pull/270

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -16,7 +16,7 @@
 //! Add to you Cargo.toml
 //!
 //! ```toml
-//! datadog-opentelemetry = { version = "0.5.0" }
+//! datadog-opentelemetry = { version = "0.5.1" }
 //! ```
 //!
 //! ### Creating traces, metrics and logs

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",


### PR DESCRIPTION
# What does this PR do?

Bump libdatadog to 0.5.1

