### PR TITLE
fix(otel): drain pending spans in force_flush [APMSP-3915]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -171,7 +171,7 @@ jobs:
   parametric:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@271863c89eb498754525cc8a7f59f46868a729e4  # main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@623d8cee11cfc63d3e5a90c1a70ce8ecf726bd3a  # main
     permissions:
       contents: read
       id-token: write
@@ -180,5 +180,5 @@ jobs:
       binaries_artifact: system_tests_binaries
       job_count: 2
       job_matrix: '[1,2]'
-      ref: 271863c89eb498754525cc8a7f59f46868a729e4 # main
+      ref: 623d8cee11cfc63d3e5a90c1a70ce8ecf726bd3a # main
       push_to_test_optimization: true

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1138,6 +1138,10 @@ pub struct Config {
     trace_writer_synchronous_timeout: Duration,
     /// The max amount of time a span stays in the writer buffer before we trigger a flush
     trace_writer_max_flush_interval: Duration,
+    /// How long `force_flush` waits for pending spans to be exported before returning. Unlike
+    /// `trace_writer_synchronous_timeout` this applies to explicit flushes regardless of whether
+    /// synchronous writes are enabled.
+    trace_writer_force_flush_timeout: Duration,
 
     /// Configurations for testing. Not exposed to customer
     #[cfg(feature = "test-utils")]
@@ -1385,6 +1389,7 @@ impl Config {
             trace_writer_synchronous_write: default.trace_writer_synchronous_write,
             trace_writer_synchronous_timeout: default.trace_writer_synchronous_timeout,
             trace_writer_max_flush_interval: default.trace_writer_max_flush_interval,
+            trace_writer_force_flush_timeout: default.trace_writer_force_flush_timeout,
             #[cfg(feature = "test-utils")]
             wait_agent_info_ready: default.wait_agent_info_ready,
             extra_services_tracker: ExtraServicesTracker::new(),
@@ -1631,6 +1636,10 @@ impl Config {
 
     pub(crate) fn trace_writer_max_flush_interval(&self) -> Duration {
         self.trace_writer_max_flush_interval
+    }
+
+    pub(crate) fn trace_writer_force_flush_timeout(&self) -> Duration {
+        self.trace_writer_force_flush_timeout
     }
 
     #[cfg(feature = "test-utils")]
@@ -2112,6 +2121,7 @@ fn default_config() -> Config {
         trace_writer_synchronous_write: false,
         trace_writer_synchronous_timeout: Duration::from_secs(2),
         trace_writer_max_flush_interval: Duration::from_secs(1),
+        trace_writer_force_flush_timeout: Duration::from_secs(5),
         #[cfg(feature = "test-utils")]
         wait_agent_info_ready: false,
 
@@ -2867,6 +2877,20 @@ impl ConfigBuilder {
         trace_writer_max_flush_interval: Duration,
     ) -> &mut Self {
         self.config.trace_writer_max_flush_interval = trace_writer_max_flush_interval;
+        self
+    }
+
+    /// Set the maximum time `force_flush` waits for pending spans to be exported before
+    /// returning. Unlike [`ConfigBuilder::set_trace_writer_synchronous_timeout`] this applies
+    /// to explicit flushes regardless of whether synchronous writes are enabled. If the timeout
+    /// is reached, the flush continues in the background.
+    ///
+    /// **Default**: `5s`
+    pub fn set_trace_writer_force_flush_timeout(
+        &mut self,
+        trace_writer_force_flush_timeout: Duration,
+    ) -> &mut Self {
+        self.config.trace_writer_force_flush_timeout = trace_writer_force_flush_timeout;
         self
     }
 

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -102,8 +102,20 @@ impl BufferSize for BufferedSpan {
     }
 }
 
-/// Counter + cvar tracking spans accepted by `send_chunk` but not yet exported.
-type PendingSpans = Arc<(Mutex<usize>, Condvar)>;
+/// Pending-span accounting for `flush_and_drain`.
+///
+/// `pending` counts spans accepted by `send_chunk` but not yet exported. `total_exported` is a
+/// monotonically increasing count of spans that have been exported, used to build a flush
+/// barrier: `flush_and_drain` snapshots `total_exported + pending` and waits until
+/// `total_exported` reaches it, so spans accepted concurrently after the flush notification do
+/// not delay the wait.
+#[derive(Debug, Default)]
+struct PendingState {
+    pending: usize,
+    total_exported: u64,
+}
+
+type PendingSpans = Arc<(Mutex<PendingState>, Condvar)>;
 
 pub struct DatadogExporter {
     // Wrapped in `Option` so `Drop` can move them onto a dedicated std thread —
@@ -213,41 +225,24 @@ impl DatadogExporter {
                     e,
                     TraceBufferError::BatchFull(_) | TraceBufferError::AlreadyShutdown
                 ) {
-                    decrement_pending(&self.pending_spans, n);
+                    cancel_pending(&self.pending_spans, n);
                 }
                 Err(e)
             }
         }
     }
 
-    pub fn force_flush(&self) -> Result<(), TraceBufferError> {
-        self.trace_buffer().force_flush()
-    }
-
-    /// Triggers a flush and blocks until every span accepted by `send_chunk` has been exported
-    /// (or the timeout elapses). Use this before [`trigger_shutdown`] so the runtime cancellation
-    /// doesn't drop a queued batch.
+    /// Triggers a flush and blocks until every span accepted by `send_chunk` *before this call*
+    /// has been exported (or the timeout elapses). Spans accepted concurrently after the flush
+    /// notification do not delay the wait. Use this before [`trigger_shutdown`] so the runtime
+    /// cancellation doesn't drop a queued batch.
     pub fn flush_and_drain(&self, timeout: Duration) -> Result<(), TraceBufferError> {
         self.trace_buffer().force_flush()?;
         self.wait_for_drain(timeout)
     }
 
     fn wait_for_drain(&self, timeout: Duration) -> Result<(), TraceBufferError> {
-        let (lock, cvar) = &*self.pending_spans;
-        let guard = lock.lock().map_err(|_| TraceBufferError::MutexPoisoned)?;
-        if *guard == 0 {
-            return Ok(());
-        }
-        if timeout.is_zero() {
-            return Err(TraceBufferError::TimedOut(Duration::ZERO));
-        }
-        let (_guard, res) = cvar
-            .wait_timeout_while(guard, timeout, |count| *count > 0)
-            .map_err(|_| TraceBufferError::MutexPoisoned)?;
-        if res.timed_out() {
-            return Err(TraceBufferError::TimedOut(timeout));
-        }
-        Ok(())
+        wait_for_barrier(&self.pending_spans, timeout)
     }
 
     pub fn trigger_shutdown(&self) {
@@ -354,7 +349,8 @@ fn build_on_dedicated_thread(
         .max_flush_interval(config.trace_writer_max_flush_interval());
 
     let otel_resource = Arc::new(ArcSwap::new(Arc::new(Resource::builder_empty().build())));
-    let pending_spans: PendingSpans = Arc::new((Mutex::new(0_usize), Condvar::new()));
+    let pending_spans: PendingSpans =
+        Arc::new((Mutex::new(PendingState::default()), Condvar::new()));
 
     let export = SpanDataExport {
         trace_exporter,
@@ -384,19 +380,52 @@ fn build_on_dedicated_thread(
 
 fn increment_pending(pending: &PendingSpans, n: usize) {
     let (lock, _) = &**pending;
-    if let Ok(mut count) = lock.lock() {
-        *count = count.saturating_add(n);
+    if let Ok(mut state) = lock.lock() {
+        state.pending = state.pending.saturating_add(n);
     }
 }
 
 fn decrement_pending(pending: &PendingSpans, n: usize) {
     let (lock, cvar) = &**pending;
-    if let Ok(mut count) = lock.lock() {
-        *count = count.saturating_sub(n);
-        if *count == 0 {
-            cvar.notify_all();
-        }
+    if let Ok(mut state) = lock.lock() {
+        state.pending = state.pending.saturating_sub(n);
+        state.total_exported = state.total_exported.saturating_add(n as u64);
+        // Notify on every decrement so barrier waiters waiting on `total_exported` (not just
+        // `pending == 0`) wake up. Flushes are rare, so the extra wakeups are negligible.
+        cvar.notify_all();
     }
+}
+
+/// Like `decrement_pending` but does NOT count the spans as exported. Used when chunks are
+/// rejected outright (BatchFull / AlreadyShutdown) — the spans were never handed to the
+/// background worker, so they should not advance the flush barrier.
+fn cancel_pending(pending: &PendingSpans, n: usize) {
+    let (lock, _) = &**pending;
+    if let Ok(mut state) = lock.lock() {
+        state.pending = state.pending.saturating_sub(n);
+    }
+}
+
+/// Blocks until every span pending at call time has been exported, i.e. until the cumulative
+/// exported count reaches `total_exported + pending` captured here. Spans accepted concurrently
+/// after this snapshot raise `pending` but not the barrier, so they cannot stall the wait.
+fn wait_for_barrier(pending: &PendingSpans, timeout: Duration) -> Result<(), TraceBufferError> {
+    let (lock, cvar) = &**pending;
+    let guard = lock.lock().map_err(|_| TraceBufferError::MutexPoisoned)?;
+    let barrier = guard.total_exported.saturating_add(guard.pending as u64);
+    if guard.total_exported >= barrier {
+        return Ok(());
+    }
+    if timeout.is_zero() {
+        return Err(TraceBufferError::TimedOut(Duration::ZERO));
+    }
+    let (_guard, res) = cvar
+        .wait_timeout_while(guard, timeout, |state| state.total_exported < barrier)
+        .map_err(|_| TraceBufferError::MutexPoisoned)?;
+    if res.timed_out() {
+        return Err(TraceBufferError::TimedOut(timeout));
+    }
+    Ok(())
 }
 
 fn build_trace_exporter(
@@ -579,4 +608,59 @@ fn log_trace_exporter_error(e: &TraceExporterError) {
             );
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    fn make_pending() -> PendingSpans {
+        Arc::new((Mutex::new(PendingState::default()), Condvar::new()))
+    }
+
+    #[test]
+    fn barrier_wait_returns_when_pre_flush_spans_exported() {
+        let pending = make_pending();
+        increment_pending(&pending, 5);
+        // Snapshot the barrier on a waiter thread before exporting.
+        let pending2 = Arc::clone(&pending);
+        let waiter =
+            std::thread::spawn(move || wait_for_barrier(&pending2, Duration::from_secs(5)));
+
+        // Give the waiter a moment to snapshot the barrier (total_exported=0, pending=5 -> 5).
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Accept spans concurrently *after* the barrier snapshot: these must not stall the wait.
+        increment_pending(&pending, 100);
+        // Export the 5 pre-flush spans: total_exported reaches the barrier.
+        decrement_pending(&pending, 5);
+
+        let res = waiter.join().unwrap();
+        assert!(
+            res.is_ok(),
+            "barrier wait should return once pre-flush spans are exported: {res:?}"
+        );
+        // The 100 concurrently-accepted spans are still pending, yet the wait returned.
+        let (lock, _) = &*pending;
+        let state = lock.lock().unwrap();
+        assert_eq!(state.pending, 100);
+        assert_eq!(state.total_exported, 5);
+    }
+
+    #[test]
+    fn barrier_wait_times_out_when_spans_never_exported() {
+        let pending = make_pending();
+        increment_pending(&pending, 3);
+        let res = wait_for_barrier(&pending, Duration::from_millis(100));
+        assert!(matches!(res, Err(TraceBufferError::TimedOut(_))), "{res:?}");
+    }
+
+    #[test]
+    fn barrier_wait_no_op_when_nothing_pending() {
+        let pending = make_pending();
+        let res = wait_for_barrier(&pending, Duration::from_secs(5));
+        assert!(res.is_ok());
+    }
 }

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -643,8 +643,13 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
     }
 
     fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        // Previously this called `DatadogExporter::force_flush`, which only notified the
+        // background worker and could return while a chunk was still queued. Drain pending
+        // spans (bounded by the force-flush timeout) so the export completes before returning.
+        // See APMSP-3915.
+        let timeout = self.config.trace_writer_force_flush_timeout();
         self.span_exporter
-            .force_flush()
+            .flush_and_drain(timeout)
             .map_err(|e| exporter_error_to_otel(&e, "force_flush"))
     }
 

--- a/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
+++ b/datadog-opentelemetry/tests/integration_tests/opentelemetry_api.rs
@@ -345,6 +345,44 @@ async fn test_trace_writer_synchronous_mode() {
 }
 
 #[tokio::test]
+/// Regression test for APMSP-3915: `force_flush` must block until pending spans are
+/// exported to the agent, not merely notify the background worker.
+async fn test_force_flush_drains_pending_spans() {
+    const SESSION_NAME: &str = "opentelemetry_api/test_force_flush_drains_pending_spans";
+    let test_agent = make_test_agent(SESSION_NAME).await;
+
+    let mut cfg = Config::builder();
+    cfg.set_trace_agent_url(test_agent.get_base_uri().await.to_string())
+        // Disable the periodic flush so only `force_flush` can deliver the queued trace.
+        .set_trace_writer_max_flush_interval(Duration::from_secs(1000000000))
+        .set_log_level_filter(LevelFilter::Debug);
+    let config = Arc::new(cfg.build());
+
+    let (tracer_provider, _propagator) = make_test_tracer(config.clone());
+
+    drop(
+        SpanBuilder::from_name("force-flush-span")
+            .with_kind(opentelemetry::trace::SpanKind::Server)
+            .start_with_context(&tracer_provider.tracer("test"), &Context::new()),
+    );
+
+    assert!(
+        test_agent.get_sent_traces().await.is_empty(),
+        "trace should still be queued"
+    );
+
+    tracer_provider.force_flush().expect("force_flush failed");
+
+    let traces = test_agent.get_sent_traces().await;
+    assert!(
+        !traces.is_empty(),
+        "force_flush should have delivered the trace before returning, got: {traces:?}"
+    );
+
+    tracer_provider.shutdown().expect("failed to shutdown");
+}
+
+#[tokio::test]
 /// Datadog and TraceContext headers carry the same 128-bit trace ID
 /// (0x1111111111111111_0000000000000001). With Restart behavior a new trace is started and
 /// the incoming context is referenced via a span link with


### PR DESCRIPTION
# What does this PR do?

Changes `force_flush` in the span processor API to also drain all pending spans and wait for the flush to finish.

# Motivation

System tests and the OTel APIs expect `force_flush` to drain all pending spans.

# Additional Notes

Anything else we should know when reviewing?
