### PR TITLE
fix(sampling): emit expected rate-limiter metric `_dd.limit_psr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59de587e652491cb19fd8b7d8e59901794ca56e3961c8c1b97707479d7fe7ec8"
+checksum = "350fb68fd76193dceecbadd8add17732f5f2ca0b0c7806d62da0bd110af53410"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-sampling"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6c34dd818feb6a2c1de996017d2f8e3190615c62fa5513f3b9559bce727dfb"
+checksum = "e709eca79e8f161d915947dc5d83b23081f28ca7f6f1bb0abdb4d646a4e016da"
 dependencies = [
  "libdd-common",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ libdd-telemetry = { version = "6.0.0", default-features = false }
 libdd-common = { version = "5.1.0", default-features = false }
 libdd-tinybytes = { version = "1.1.1", default-features = false }
 libdd-library-config = { version = "3.0.0", default-features = false }
-libdd-sampling = { version = "5.0.0", default-features = false }
+libdd-sampling = { version = "6.0.0", default-features = false }
 libdd-shared-runtime = { version = "2.0.0", default-features = false }
 libdd-remote-config = { version = "2.0.0", default-features = false, features = [
     "client",

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_received_traces.json
@@ -19,6 +19,7 @@
     },
     "metrics": {
       "_dd.measured": 1.0,
+      "_dd.limit_psr": 1.0,
       "_dd.rule_psr": 1.0,
       "_sampling_priority_v1": 2.0,
       "_top_level": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_remote_config_sampling_rates.json
@@ -20,6 +20,7 @@
       "telemetry.sdk.name": "datadog"
     },
     "metrics": {
+      "_dd.limit_psr": 1.0,
       "_dd.rule_psr": 1.0,
       "_sampling_priority_v1": 2.0,
       "_top_level": 1.0

--- a/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
+++ b/datadog-opentelemetry/tests/snapshots/opentelemetry_api/test_sampling_extraction.json
@@ -20,6 +20,7 @@
       "telemetry.sdk.name": "datadog"
     },
     "metrics": {
+      "_dd.limit_psr": 1.0,
       "_dd.rule_psr": 1.0,
       "_sampling_priority_v1": 2.0,
       "_top_level": 1.0

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59de587e652491cb19fd8b7d8e59901794ca56e3961c8c1b97707479d7fe7ec8"
+checksum = "350fb68fd76193dceecbadd8add17732f5f2ca0b0c7806d62da0bd110af53410"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-sampling"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6c34dd818feb6a2c1de996017d2f8e3190615c62fa5513f3b9559bce727dfb"
+checksum = "e709eca79e8f161d915947dc5d83b23081f28ca7f6f1bb0abdb4d646a4e016da"
 dependencies = [
  "libdd-common",
  "lru",


### PR DESCRIPTION
# What does this PR do?

Bumps `libdd-sampling` version to 6.0.0 and adds the expected rate-limiter metric `_dd.limit_psr` to the affected integration snapshots.

# Motivation

`libdd-sampling` 6.0.0 now records the rate limiter’s effective sampling rate when it allows a trace.

# Additional Notes
