### PR TITLE
fix(ci): validate base-branch is a protected branch before running its code

### DIFF
--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -32,7 +32,7 @@ jobs:
       # Deliberately above the crate's `rust-version` (1.87.0): cargo-release 1.1.2 needs >= 1.91
       RUST_VERSION: 1.92.0
     steps:
-      - name: "Validate base-branch is a trusted protected branch"
+      - name: "Validate base-branch requires reviewed pull requests"
         env:
           GH_TOKEN: ${{ github.token }}
           BASE_BRANCH: ${{ inputs.base-branch }}
@@ -41,14 +41,13 @@ jobs:
             echo "::error::base-branch '${BASE_BRANCH}' is not a valid ref."
             exit 1
           fi
-          
           encoded="$(jq -rn --arg b "$BASE_BRANCH" '$b | @uri')"
-          protected="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${encoded}" --jq '.protected' 2>/dev/null || echo error)"
-          if [ "$protected" != "true" ]; then
-            echo "::error::base-branch '${BASE_BRANCH}' is not an existing protected branch (got '${protected}'); refusing to run its code with a privileged token."
+          has_pr_rule="$(gh api "repos/${GITHUB_REPOSITORY}/rules/branches/${encoded}" --jq 'any(.[]?; .type == "pull_request")' 2>/dev/null || echo error)"
+          if [ "$has_pr_rule" != "true" ]; then
+            echo "::error::base-branch '${BASE_BRANCH}' does not require pull requests (no active 'pull_request' rule); refusing to run its code with a privileged token."
             exit 1
           fi
-          echo "base-branch '${BASE_BRANCH}' is a protected branch."
+          echo "base-branch '${BASE_BRANCH}' requires pull requests; treating it as trusted."
 
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts

--- a/.github/workflows/release-proposal-dispatch.yaml
+++ b/.github/workflows/release-proposal-dispatch.yaml
@@ -32,6 +32,24 @@ jobs:
       # Deliberately above the crate's `rust-version` (1.87.0): cargo-release 1.1.2 needs >= 1.91
       RUST_VERSION: 1.92.0
     steps:
+      - name: "Validate base-branch is a trusted protected branch"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: |
+          if ! git check-ref-format "refs/heads/${BASE_BRANCH}"; then
+            echo "::error::base-branch '${BASE_BRANCH}' is not a valid ref."
+            exit 1
+          fi
+          
+          encoded="$(jq -rn --arg b "$BASE_BRANCH" '$b | @uri')"
+          protected="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${encoded}" --jq '.protected' 2>/dev/null || echo error)"
+          if [ "$protected" != "true" ]; then
+            echo "::error::base-branch '${BASE_BRANCH}' is not an existing protected branch (got '${protected}'); refusing to run its code with a privileged token."
+            exit 1
+          fi
+          echo "base-branch '${BASE_BRANCH}' is a protected branch."
+
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:


### PR DESCRIPTION
## Problem

The **Release proposal** workflow (`release-proposal-dispatch.yaml`) is dispatched from `main`, so
its OIDC claims satisfy the Octo STS policy and the job mints a token with `contents: write` /
`pull_requests: write` (and has `id-token: write`). It then checks out the **unrestricted,
dispatcher-chosen `base-branch`** and runs *that ref's* `scripts/prepare-release.sh`.

A dispatcher (anyone with write access) could point `base-branch` at a branch carrying a malicious
`prepare-release.sh`, executing arbitrary code in the privileged context — exfiltrating the token
(e.g. via `GITHUB_ENV`/`BASH_ENV` persistence into later steps that set `GH_TOKEN`), minting the
workflow's OIDC identity, and reaching the release/publish supply chain.

## Fix

Add a first step that validates `base-branch` **before** the token is minted or anything is checked
out, so only a review-gated (protected) branch's code can ever run:

- `git check-ref-format` rejects malformed refs early with a clear error.
- The branch is **URL-encoded** (`@uri`) for the protected-branch API lookup, so the check resolves
  the *exact literal ref* that `actions/checkout` will use. Without this, a name like
  `main#attacker` is truncated at `#` by the URL and would validate `main` while checkout ran the
  attacker's unprotected ref.
- The job proceeds only if that ref is an **existing protected branch**.

## Verification

- `main` → `true`; `hotfix/0.5.x`-style refs resolve via `%2F`.
- `main#attacker` → `main%23attacker` → 404 → refused (same ref checkout would use).
- `../evil` → rejected by `check-ref-format` and 404.
