### PR TITLE
chore: add serverless teams as codeowners for instrumentation/datadog-aws-lambda

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 *   @DataDog/apm-rust
+
+instrumentation/datadog-aws-lambda/   @DataDog/apm-serverless @DataDog/serverless-aws


### PR DESCRIPTION
# What does this PR do?

Add `apm-serverless` and `serverless-aws` as codeowners for `instrumentation/datadog-aws-lambda` folder.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
