### PR TITLE
chore(deps): bump libdd-data-pipeline to 8.0.0 and aligned libdatadog deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,15 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,22 +1599,25 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdd-capabilities"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
+checksum = "e67c40cbfd0a7bbc2944237cd9ed481cbe803b1835679527d9898272758f5a7b"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e948ad5c65d8598fd3889762ea4767b9a521ebfb2f7b72f6e52162aa4d7f353"
+checksum = "1fc1d0afa0f84914ec64f5d206c37a2f4ff625109e6c081f7a82adb849e69e2b"
 dependencies = [
+ "anyhow",
  "bytes",
  "http",
  "http-body-util",
@@ -1670,15 +1664,16 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433f9bfe60850c0638a273dfb2bd873f5abc12c9983ce74ebffe055a7a3c21c9"
+checksum = "ecfc85fff58f2589e473af6a81e9ff4c19fe5386aad4c72ab787a7bb889b60d9"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
  "bytes",
  "either",
+ "futures",
  "getrandom 0.2.17",
  "http",
  "http-body-util",
@@ -1703,28 +1698,32 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
+checksum = "827db9addada0e19a8371241e54fe4f27e9101c5a1dc30a13cf42dea5220e3f0"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c7bd569824c4d8ffe7171bb77e6b69c2161517ed75436ff458b40d41a663d"
+checksum = "74c277a83676a4897e5fc3331758d34adda6db6ac5b9e51c1918eba067b2c127"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cadence",
  "http",
  "libdd-common",
+ "libdd-shared-runtime",
  "serde",
+ "tokio",
  "tracing",
 ]
 
@@ -1808,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
+checksum = "55749d4e255a4fd6544036338f895235418e530198e2ecb2e4b493267d0c6397"
 dependencies = [
  "async-trait",
  "futures",
@@ -1826,46 +1825,50 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c791d810acbe99b0c7fc4285824f4e27a4b2b9137d4aec8a5df220ca55b34942"
+checksum = "004aebda20a6ca15304c3129f997bce6756bfa5b4980163716761d72ef3630f2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "hashbrown 0.15.5",
  "http",
- "http-body-util",
  "libc",
+ "libdd-capabilities",
  "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sys-info",
  "tokio",
  "tokio-util",
  "tracing",
  "uuid",
+ "web-time",
  "winver",
 ]
 
 [[package]]
 name = "libdd-tinybytes"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97db80e3f3f9d19643ac444d6267951a5dab622ad9828c51149d49150625cfe8"
+checksum = "1d3e6ade71c21b86ab81fa8d905f9f26733336f1a904bb826b9ac1972b3c8289"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4184666070c137e058b2c16acd147c3f045b51de3efe81e0bec62044f29fc6c6"
+checksum = "a643220a54228ef837631b5036f34fc13fc8ee2e307a74ac011232c062393fc5"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1873,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d313153f515b9dd31a483bc7e4d432ecb76e53dd33f67f4eeaa415319372b68d"
+checksum = "8b5709cd8d3e058e5d9056affbf6aae7464b49eb461afc49945576285d1f457b"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1890,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210492f004b4c343cca736aab2a8c93109034e0c00111bc7376661370439a11c"
+checksum = "3b1bc3bd67115bec00669d84a29b7b52ef1d61f36dfb49b273b2fee3346bf18f"
 dependencies = [
  "prost",
  "serde",
@@ -1901,13 +1904,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a575e3ecccfbbbd1612ddb1cb8b08e0c12ae0a62052ef995f05d93976a55b"
+checksum = "23d3cc84f8d144752fa51abe59d3a7a3a956b9a479897fb9689a2e1bac458ac2"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "futures",
  "hashbrown 0.15.5",
  "http",
  "libdd-capabilities",
@@ -1925,13 +1929,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
-version = "9.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2529075e0b7494767011c027750951f302b3ee8a5f5d15ab7a6e95e88a755182"
+checksum = "3f5dcd936e7be2edbde4e9cd11af0f1a227e5af239205e56ee8f137e8bb2869f"
 dependencies = [
  "anyhow",
  "base64",
@@ -1947,6 +1952,7 @@ dependencies = [
  "httpmock",
  "hyper",
  "indexmap 2.14.0",
+ "itoa",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -2475,7 +2481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 
 [workspace.dependencies]
 # Libdatadog dependencies
-libdd-data-pipeline = { version = "7.0.0", features = [
+libdd-data-pipeline = { version = "8.0.0", features = [
     "stats-obfuscation",
     "telemetry",
 ], default-features = false }
-libdd-trace-utils = { version = "9.0.0", default-features = false }
-libdd-capabilities-impl = { version = "3.0.0", default-features = false }
-libdd-telemetry = { version = "6.0.0", default-features = false }
-libdd-common = { version = "5.1.0", default-features = false }
-libdd-tinybytes = { version = "1.1.1", default-features = false }
+libdd-trace-utils = { version = "10.1.0", default-features = false }
+libdd-capabilities-impl = { version = "4.0.0", default-features = false }
+libdd-telemetry = { version = "7.0.0", default-features = false }
+libdd-common = { version = "5.2.0", default-features = false }
+libdd-tinybytes = { version = "1.1.2", default-features = false }
 libdd-library-config = { version = "3.0.0", default-features = false }
 libdd-sampling = { version = "6.0.0", default-features = false }
-libdd-shared-runtime = { version = "2.0.0", default-features = false }
+libdd-shared-runtime = { version = "3.0.0", default-features = false }
 libdd-remote-config = { version = "2.0.0", default-features = false, features = [
     "client",
 ] }

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -319,7 +319,7 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
         // Always include the default value
         configurations.push(Configuration {
             name: self.name.as_str().to_string(),
-            value: self.default_value.get_configuration_value(),
+            value: Some(self.default_value.get_configuration_value()),
             origin: ConfigSourceOrigin::Default.into(),
             config_id: self.config_id.clone(),
             seq_id: Some(ConfigSourceOrigin::Default as u64),
@@ -327,7 +327,7 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
         if let Some(calculated_value) = calculated_value {
             configurations.push(Configuration {
                 name: self.name.as_str().to_string(),
-                value: calculated_value,
+                value: Some(calculated_value),
                 origin: ConfigSourceOrigin::Calculated.into(),
                 config_id: self.config_id.clone(),
                 seq_id: Some(ConfigSourceOrigin::Calculated as u64),
@@ -336,7 +336,7 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
         if let Some(ref env_value) = self.env_value {
             configurations.push(Configuration {
                 name: self.name.as_str().to_string(),
-                value: env_value.get_configuration_value(),
+                value: Some(env_value.get_configuration_value()),
                 origin: ConfigSourceOrigin::EnvVar.into(),
                 config_id: self.config_id.clone(),
                 seq_id: Some(ConfigSourceOrigin::EnvVar as u64),
@@ -345,7 +345,7 @@ impl<T: Clone + ConfigurationValueProvider> ConfigItem<T> {
         if let Some(ref code_value) = self.code_value {
             configurations.push(Configuration {
                 name: self.name.as_str().to_string(),
-                value: code_value.get_configuration_value(),
+                value: Some(code_value.get_configuration_value()),
                 origin: ConfigSourceOrigin::Code.into(),
                 config_id: self.config_id.clone(),
                 seq_id: Some(ConfigSourceOrigin::Code as u64),
@@ -520,7 +520,7 @@ impl<T: Clone + ConfigurationValueProvider + Deref> ConfigurationProvider
             let config_id = self.config_id.load().as_ref().map(|id| (**id).clone());
             configurations.push(Configuration {
                 name: self.config_item.name.as_str().to_string(),
-                value: self.value().get_configuration_value(),
+                value: Some(self.value().get_configuration_value()),
                 origin: self.source().into(),
                 config_id,
                 seq_id: Some(self.source() as u64),
@@ -4147,7 +4147,7 @@ mod tests {
         // Converting configuration value to json helps with comparison as serialized properties may
         // differ from their original order
         assert_eq!(
-            ParsedSamplingRules::from_str(&active_configuration.value).unwrap(),
+            ParsedSamplingRules::from_str(active_configuration.value.as_deref().unwrap()).unwrap(),
             expected.clone()
         );
 
@@ -4170,7 +4170,7 @@ mod tests {
             ConfigurationOrigin::RemoteConfig
         );
         assert_eq!(
-            ParsedSamplingRules::from_str(&active_configuration_after_rc.value).unwrap(),
+            ParsedSamplingRules::from_str(active_configuration_after_rc.value.as_deref().unwrap()).unwrap(),
             expected_rc
         );
 
@@ -4181,7 +4181,7 @@ mod tests {
         let active_configuration = configurations.iter().max_by_key(|c| c.seq_id).unwrap();
         assert_eq!(active_configuration.origin, ConfigurationOrigin::EnvVar);
         assert_eq!(
-            ParsedSamplingRules::from_str(&active_configuration.value).unwrap(),
+            ParsedSamplingRules::from_str(active_configuration.value.as_deref().unwrap()).unwrap(),
             expected
         );
     }
@@ -4362,7 +4362,7 @@ mod tests {
             SENTINEL_OTLP_LOGS,
         ] {
             assert!(
-                !configurations.iter().any(|c| c.value.contains(sentinel)),
+                !configurations.iter().any(|c| c.value.as_deref().is_some_and(|v| v.contains(sentinel))),
                 "sentinel value {sentinel:?} must not appear in telemetry configuration"
             );
         }
@@ -4386,7 +4386,7 @@ mod tests {
                 .iter()
                 .filter(|c| c.name == name)
                 .max_by_key(|c| c.seq_id)
-                .map(|c| c.value.clone())
+                .and_then(|c| c.value.clone())
         };
         assert_eq!(
             value_for("OTEL_EXPORTER_OTLP_ENDPOINT").as_deref(),

--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -4170,7 +4170,8 @@ mod tests {
             ConfigurationOrigin::RemoteConfig
         );
         assert_eq!(
-            ParsedSamplingRules::from_str(active_configuration_after_rc.value.as_deref().unwrap()).unwrap(),
+            ParsedSamplingRules::from_str(active_configuration_after_rc.value.as_deref().unwrap())
+                .unwrap(),
             expected_rc
         );
 
@@ -4362,7 +4363,9 @@ mod tests {
             SENTINEL_OTLP_LOGS,
         ] {
             assert!(
-                !configurations.iter().any(|c| c.value.as_deref().is_some_and(|v| v.contains(sentinel))),
+                !configurations
+                    .iter()
+                    .any(|c| c.value.as_deref().is_some_and(|v| v.contains(sentinel))),
                 "sentinel value {sentinel:?} must not appear in telemetry configuration"
             );
         }

--- a/datadog-opentelemetry/src/core/telemetry.rs
+++ b/datadog-opentelemetry/src/core/telemetry.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use anyhow::Error;
+use libdd_capabilities_impl::NativeCapabilities;
 use libdd_telemetry::{
     data::{self, Configuration},
     metrics::ContextKey,
@@ -190,7 +191,7 @@ trait TelemetryHandle: Sync + Send + 'static + Any {
 }
 
 struct TelemetryHandleWrapper {
-    handle: TelemetryWorkerHandle,
+    handle: TelemetryWorkerHandle<NativeCapabilities>,
     metrics_context: [OnceLock<ContextKey>; TELEMETRY_METRICS_COUNT],
 }
 
@@ -318,7 +319,7 @@ fn make_telemetry_worker(
         builder.config.parent_session_id = inst.parent_session_id;
         // builder.config.debug_enabled = true;
 
-        builder.run().map(|handle| {
+        builder.run::<NativeCapabilities>().map(|handle| {
             Box::new(TelemetryHandleWrapper {
                 handle,
                 metrics_context: [const { OnceLock::new() }; TELEMETRY_METRICS_COUNT],
@@ -533,8 +534,8 @@ mod tests {
         fn get_all_configurations(&self) -> Vec<data::Configuration> {
             vec![data::Configuration {
                 name: self.name.clone(),
-                value: self.value.clone(),
-                origin: self.origin.clone(),
+                value: Some(self.value.clone()),
+                origin: self.origin,
                 config_id: self.config_id.clone(),
                 seq_id: None,
             }]
@@ -837,7 +838,7 @@ mod tests {
 
         let sent_config = &handle.configurations[0];
         assert_eq!(sent_config.name, "DD_SERVICE");
-        assert_eq!(sent_config.value, "test");
+        assert_eq!(sent_config.value.as_deref(), Some("test"));
         assert_eq!(sent_config.origin, data::ConfigurationOrigin::EnvVar);
         assert_eq!(sent_config.config_id, config_id);
     }

--- a/datadog-opentelemetry/src/span_exporter.rs
+++ b/datadog-opentelemetry/src/span_exporter.rs
@@ -223,12 +223,12 @@ impl DatadogExporter {
         match self.trace_buffer().send_chunk(buffered) {
             Ok(()) => Ok(()),
             Err(e) => {
-                // `BatchFull` and `AlreadyShutdown` are outright rejections, so the export side
+                // `BatchFull` and `AlreadyClosed` are outright rejections, so the export side
                 // will never decrement. Late errors from `wait_flush_done` (sync
                 // mode) mean the chunk is still queued.
                 if matches!(
                     e,
-                    TraceBufferError::BatchFull(_) | TraceBufferError::AlreadyShutdown
+                    TraceBufferError::BatchFull(_) | TraceBufferError::AlreadyClosed
                 ) {
                     cancel_pending(&self.pending_spans, n);
                 }
@@ -281,7 +281,7 @@ impl DatadogExporter {
             .lock()
             .map_err(|_| TraceBufferError::MutexPoisoned)?
             .take()
-            .ok_or(TraceBufferError::AlreadyShutdown)?;
+            .ok_or(TraceBufferError::AlreadyClosed)?;
         let runtime_result = match rx.recv_timeout(timeout) {
             Ok(res) => res,
             Err(mpsc::RecvTimeoutError::Timeout) => return Err(TraceBufferError::TimedOut(timeout)),
@@ -298,7 +298,7 @@ impl DatadogExporter {
             Ok(()) => Ok(()),
             Err(SharedRuntimeError::ShutdownTimedOut(d)) => Err(TraceBufferError::TimedOut(d)),
             Err(SharedRuntimeError::LockFailed(_)) => Err(TraceBufferError::MutexPoisoned),
-            Err(SharedRuntimeError::RuntimeUnavailable) => Err(TraceBufferError::AlreadyShutdown),
+            Err(SharedRuntimeError::RuntimeUnavailable) => Err(TraceBufferError::AlreadyClosed),
             Err(e) => Err(TraceBufferError::TraceExporter(TraceExporterError::Internal(
                 libdd_data_pipeline::trace_exporter::error::InternalErrorKind::InvalidWorkerState(
                     e.to_string(),
@@ -406,7 +406,7 @@ fn decrement_pending(pending: &PendingSpans, n: usize) {
 }
 
 /// Like `decrement_pending` but does NOT count the spans as exported. Used when chunks are
-/// rejected outright (BatchFull / AlreadyShutdown) — the spans were never handed to the
+/// rejected outright (BatchFull / AlreadyClosed) — the spans were never handed to the
 /// background worker, so they should not advance the flush barrier.
 fn cancel_pending(pending: &PendingSpans, n: usize) {
     let (lock, _) = &**pending;

--- a/datadog-opentelemetry/src/span_processor.rs
+++ b/datadog-opentelemetry/src/span_processor.rs
@@ -731,7 +731,7 @@ impl opentelemetry_sdk::trace::SpanProcessor for DatadogSpanProcessor {
 
 fn exporter_error_to_otel(e: &DatadogExporterError, operation: &str) -> OTelSdkError {
     match e {
-        DatadogExporterError::AlreadyShutdown => OTelSdkError::AlreadyShutdown,
+        DatadogExporterError::AlreadyClosed => OTelSdkError::AlreadyShutdown,
         DatadogExporterError::TimedOut(duration) => OTelSdkError::Timeout(*duration),
         DatadogExporterError::MutexPoisoned => OTelSdkError::InternalFailure(format!(
             "DatadogExporter.{operation}: the sender mutex was poisonned"

--- a/instrumentation/Cargo.lock
+++ b/instrumentation/Cargo.lock
@@ -1167,22 +1167,25 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdd-capabilities"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
+checksum = "e67c40cbfd0a7bbc2944237cd9ed481cbe803b1835679527d9898272758f5a7b"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e948ad5c65d8598fd3889762ea4767b9a521ebfb2f7b72f6e52162aa4d7f353"
+checksum = "1fc1d0afa0f84914ec64f5d206c37a2f4ff625109e6c081f7a82adb849e69e2b"
 dependencies = [
+ "anyhow",
  "bytes",
  "http",
  "http-body-util",
@@ -1224,15 +1227,16 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433f9bfe60850c0638a273dfb2bd873f5abc12c9983ce74ebffe055a7a3c21c9"
+checksum = "ecfc85fff58f2589e473af6a81e9ff4c19fe5386aad4c72ab787a7bb889b60d9"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
  "bytes",
  "either",
+ "futures",
  "getrandom 0.2.17",
  "http",
  "http-body-util",
@@ -1257,28 +1261,32 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
+checksum = "827db9addada0e19a8371241e54fe4f27e9101c5a1dc30a13cf42dea5220e3f0"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c7bd569824c4d8ffe7171bb77e6b69c2161517ed75436ff458b40d41a663d"
+checksum = "74c277a83676a4897e5fc3331758d34adda6db6ac5b9e51c1918eba067b2c127"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cadence",
  "http",
  "libdd-common",
+ "libdd-shared-runtime",
  "serde",
+ "tokio",
  "tracing",
 ]
 
@@ -1343,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
+checksum = "55749d4e255a4fd6544036338f895235418e530198e2ecb2e4b493267d0c6397"
 dependencies = [
  "async-trait",
  "futures",
@@ -1361,46 +1369,50 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c791d810acbe99b0c7fc4285824f4e27a4b2b9137d4aec8a5df220ca55b34942"
+checksum = "004aebda20a6ca15304c3129f997bce6756bfa5b4980163716761d72ef3630f2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "hashbrown 0.15.5",
  "http",
- "http-body-util",
  "libc",
+ "libdd-capabilities",
  "libdd-common",
  "libdd-ddsketch",
  "libdd-shared-runtime",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sys-info",
  "tokio",
  "tokio-util",
  "tracing",
  "uuid",
+ "web-time",
  "winver",
 ]
 
 [[package]]
 name = "libdd-tinybytes"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97db80e3f3f9d19643ac444d6267951a5dab622ad9828c51149d49150625cfe8"
+checksum = "1d3e6ade71c21b86ab81fa8d905f9f26733336f1a904bb826b9ac1972b3c8289"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4184666070c137e058b2c16acd147c3f045b51de3efe81e0bec62044f29fc6c6"
+checksum = "a643220a54228ef837631b5036f34fc13fc8ee2e307a74ac011232c062393fc5"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1408,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d313153f515b9dd31a483bc7e4d432ecb76e53dd33f67f4eeaa415319372b68d"
+checksum = "8b5709cd8d3e058e5d9056affbf6aae7464b49eb461afc49945576285d1f457b"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1425,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210492f004b4c343cca736aab2a8c93109034e0c00111bc7376661370439a11c"
+checksum = "3b1bc3bd67115bec00669d84a29b7b52ef1d61f36dfb49b273b2fee3346bf18f"
 dependencies = [
  "prost",
  "serde",
@@ -1436,13 +1448,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a575e3ecccfbbbd1612ddb1cb8b08e0c12ae0a62052ef995f05d93976a55b"
+checksum = "23d3cc84f8d144752fa51abe59d3a7a3a956b9a479897fb9689a2e1bac458ac2"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "futures",
  "hashbrown 0.15.5",
  "http",
  "libdd-capabilities",
@@ -1460,13 +1473,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
-version = "9.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2529075e0b7494767011c027750951f302b3ee8a5f5d15ab7a6e95e88a755182"
+checksum = "3f5dcd936e7be2edbde4e9cd11af0f1a227e5af239205e56ee8f137e8bb2869f"
 dependencies = [
  "anyhow",
  "base64",
@@ -1478,6 +1492,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "indexmap 2.14.0",
+ "itoa",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -2855,6 +2870,16 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
# What does this PR do?

Upgrade `libdd-data-pipeline` from `7.0.0` to `8.0.0` and bump the `libdatadog` workspace dependencies to the minimum versions that satisfy its transitive requirements.

# Motivation

Fixes in #287 should really use updated `flush_and_wait` functionality in `libdd-data-pipeline`.

# Additional Notes

| Crate | From | To |
|-------|------|-----|
| libdd-data-pipeline | 7.0.0 | 8.0.0 |
| libdd-trace-utils | 9.0.0 | 10.1.0 |
| libdd-capabilities-impl | 3.0.0 | 4.0.0 |
| libdd-telemetry | 6.0.0 | 7.0.0 |
| libdd-common | 5.1.0 | 5.2.0 |
| libdd-tinybytes | 1.1.1 | 1.1.2 |
| libdd-shared-runtime | 2.0.0 | 3.0.0 |