### PR TITLE
chore(ci): add cargo deny ban check and gate PRs on it

### DIFF
--- a/.github/workflows/cargo-deny-bans.yaml
+++ b/.github/workflows/cargo-deny-bans.yaml
@@ -25,5 +25,9 @@ jobs:
       uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # v2.49.15
       with:
         tool: cargo-deny
-    - name: Block PRs that introduce banned or compromised crates
+    - name: Block PRs that introduce banned or compromised crates (root workspace)
       run: cargo deny --log-level error check bans
+    - name: Block PRs that introduce banned or compromised crates (instrumentation workspace)
+      # instrumentation/ is a separate Cargo workspace with its own Cargo.lock;
+      # check it too so a dependency-only change there cannot bypass the gate.
+      run: cargo deny --log-level error --manifest-path instrumentation/Cargo.toml check bans

--- a/.github/workflows/cargo-deny-bans.yaml
+++ b/.github/workflows/cargo-deny-bans.yaml
@@ -1,0 +1,29 @@
+name: cargo-deny bans
+# Dedicated, always-on security gate: banned/compromised crates must never enter
+# the dependency graph. Runs on every PR (NOT scoped to changed crates) so a
+# dependency-only change - e.g. a Cargo.lock bump pulling a compromised
+# transitive crate - cannot bypass it. Blocks on cargo-deny's exit code.
+permissions:
+  contents: read
+on:
+  pull_request:
+  push:
+    branches:
+      - 'mq-working-branch-*'
+jobs:
+  cargo-deny-bans:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/cache
+      with:
+        rust_version: stable
+    - name: Install stable toolchain
+      run: rustup install stable && rustup default stable
+    - name: Install cargo-deny
+      uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3 # v2.49.15
+      with:
+        tool: cargo-deny
+    - name: Block PRs that introduce banned or compromised crates
+      run: cargo deny --log-level error check bans

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,14 @@
+[bans]
+multiple-versions = "warn"
+
+deny = [
+    { name = "arrayref", version = "=0.3.10" },
+    { name = "append-only-vec", version = "=0.1.9" },
+    { name = "internment", version = "=0.8.7" },
+    { name = "proc-macro1" },
+    { name = "proc-macro-en" },
+    { name = "aovine" },
+    { name = "arone" },
+    { name = "aronenao" },
+    { name = "tinymember" },
+]


### PR DESCRIPTION
# What does this PR do?

Introduce cargo deny to dd-trace-rs. Gate PRs when banned dependencies are present. 

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?
