### PR TITLE
fix(propagation): preserve unchanged `ot` member order in W3C tracestate

### DIFF
--- a/datadog-opentelemetry/src/propagation/tracecontext.rs
+++ b/datadog-opentelemetry/src/propagation/tracecontext.rs
@@ -219,9 +219,10 @@ impl FromStr for Tracestate {
                         })
                         .collect(),
                 );
-            } else if key == "ot" {
-                ot = Some(value.to_string());
             } else {
+                if key == "ot" {
+                    ot = Some(value.to_string());
+                }
                 additional_values.push((key.to_string(), value.to_string()));
             }
         }
@@ -297,11 +298,20 @@ impl InjectTraceState {
         Self { header }
     }
 
-    pub(crate) fn additional_values(&self) -> impl Iterator<Item = &str> {
-        self.header.split(',').filter(|part| {
+    fn contains_ot(&self, ot: &str) -> bool {
+        self.header
+            .split(',')
+            .any(|part| part.split_once('=') == Some(("ot", ot)))
+    }
+
+    pub(crate) fn additional_values<'a>(
+        &'a self,
+        ot: Option<&'a str>,
+    ) -> impl Iterator<Item = &'a str> {
+        self.header.split(',').filter(move |part| {
             let (key, value) = part.split_once('=').unwrap_or((part, ""));
             key != "dd"
-                && key != "ot"
+                && (key != "ot" || ot == Some(value))
                 && !value.is_empty()
                 && Tracestate::valid_key(key)
                 && Tracestate::valid_value(value)
@@ -539,7 +549,14 @@ fn inject_tracestate(context: &InjectSpanContext, carrier: &mut dyn Injector) {
         dd_parts.truncate(index_before_tags);
     }
 
-    if let Some(ot) = context.ot_member {
+    let retained_ot = context.ot_member.filter(|ot| {
+        context
+            .tracestate
+            .as_ref()
+            .is_some_and(|tracestate| tracestate.contains_ot(ot))
+    });
+
+    if let Some(ot) = context.ot_member.filter(|_| retained_ot.is_none()) {
         member_count += 1;
         let mut ot_part = buf_appender(&mut tracestate);
         ot_part.push_str(super::const_concat!(TRACESTATE_VALUES_SEPARATOR, "ot=",));
@@ -549,7 +566,7 @@ fn inject_tracestate(context: &InjectSpanContext, carrier: &mut dyn Injector) {
     // Add additional tracestate values if present
     if let Some(ts) = &context.tracestate {
         for part in ts
-            .additional_values()
+            .additional_values(retained_ot)
             .take(TRACESTATE_MAX_MEMBERS - member_count)
         {
             tracestate.push_str(TRACESTATE_VALUES_SEPARATOR);
@@ -1353,7 +1370,7 @@ mod test {
     }
 
     #[test]
-    fn parses_ot_member_and_removes_it_from_additional_values() {
+    fn parses_ot_member_and_preserves_it_in_additional_values() {
         let ts: Tracestate = "dd=s:2;t.dm:-3,ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz"
             .parse()
             .unwrap();
@@ -1361,10 +1378,16 @@ mod test {
             ts.ot_member.as_deref(),
             Some("rv:ef284ace7a91e1;th:e6666666666666")
         );
-        // ot removed from remainder; congo preserved
-        let additional = ts.additional_values.unwrap();
-        assert!(additional.iter().all(|(k, _)| k != "ot"));
-        assert!(additional.iter().any(|(k, v)| k == "congo" && v == "xyz"));
+        assert_eq!(
+            ts.additional_values,
+            Some(vec![
+                (
+                    "ot".to_string(),
+                    "rv:ef284ace7a91e1;th:e6666666666666".to_string()
+                ),
+                ("congo".to_string(), "xyz".to_string())
+            ])
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/text_map_propagator.rs
+++ b/datadog-opentelemetry/src/text_map_propagator.rs
@@ -701,7 +701,7 @@ pub mod tests {
     }
 
     #[test]
-    fn extract_inject_w3c_passthrough_forwards_ot_without_span_registration() {
+    fn extract_inject_w3c_passthrough_preserves_unchanged_ot_member_order() {
         let builder = Config::builder();
         let config = Arc::new(builder.build());
         let registry = TraceRegistry::new(config.clone());
@@ -714,7 +714,7 @@ pub mod tests {
         );
         extractor.insert(
             TRACESTATE_KEY.to_string(),
-            "dd=s:2,ot=rv:ef284ace7a91e1;th:e6666666666666,congo=xyz".to_string(),
+            "dd=s:1,foo=bar,ot=rv:6e6d1a75832a2f,something=else".to_string(),
         );
 
         let extracted_context = propagator.extract(&extractor);
@@ -722,14 +722,10 @@ pub mod tests {
         let mut injector = HashMap::new();
         propagator.inject_context(&extracted_context, &mut injector);
 
-        let injected_trace_state = Extractor::get(&injector, TRACESTATE_KEY).unwrap_or("");
-        assert!(
-            injected_trace_state.contains("ot=rv:ef284ace7a91e1;th:e6666666666666"),
-            "expected inbound `ot` to be forwarded unchanged, got {injected_trace_state}"
-        );
-        assert!(
-            injected_trace_state.contains("congo=xyz"),
-            "expected unrelated vendor member to still pass through, got {injected_trace_state}"
+        assert_eq!(
+            Extractor::get(&injector, TRACESTATE_KEY).unwrap_or(""),
+            "dd=s:1;p:00f067aa0ba902b7;t.tid:4bf92f3577b34da6,foo=bar,\
+             ot=rv:6e6d1a75832a2f,something=else"
         );
     }
 


### PR DESCRIPTION
# What does this PR do?

Preserves the position of an unchanged `ot` tracestate member while retaining existing behavior for changed or removed values.

# Motivation

Unmodified tracestate members must retain their order (W3C spec). This fixes the Rust
failure covered by [system-tests#7579](https://github.com/DataDog/system-tests/pull/7579).

# Additional Notes

None.