### PR TITLE
ci(licenses): validate license CSVs across workspaces

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -123,7 +123,7 @@ jobs:
 
   license-3rdparty:
     runs-on: ubuntu-latest
-    name: "Valid LICENSE-3rdparty.csv"
+    name: "Valid license CSV files"
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -139,23 +139,26 @@ jobs:
             ~/.cargo/.crates2.json
           key: dd-rust-license-tool-1.0.6-v2
       - run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.6" || cargo install dd-rust-license-tool --version "1.0.6" --locked
-      - name: Generate new LICENSE-3rdparty.csv and check against the previous
+      - name: Generate license CSV files and check against committed copies
         run: |
-          if ! dd-rust-license-tool dump > /tmp/CI.csv 2> /tmp/CI.error; then
-            echo "ERROR: dd-rust-license-tool dump failed! See error output below:"
-            cat /tmp/CI.error
+          if ! ./scripts/update_license_3rdparty.sh . instrumentation; then
+            echo "ERROR: license CSV generation failed."
             exit 1
           fi
-          if ! diff /tmp/CI.csv LICENSE-3rdparty.csv; then
-            echo "Differences detected in LICENSE-3rdparty.csv."
-            echo "Please run './scripts/update_license_3rdparty.sh' to update the file and commit the changes."
+          if [ -n "$(git status --porcelain -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv)" ]; then
+            git diff -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv
+            git status --short -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv
+            echo "Differences detected in license CSV files."
+            echo "Please run './scripts/update_license_3rdparty.sh . instrumentation' to update the files and commit the changes."
             exit 1
           fi
           echo "No differences found."
-      - name: Export generated license file on failure
+      - name: Export generated license files on failure
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: LICENSE-3rdparty.csv
-          path: /tmp/CI.csv
+          name: license-3rdparty-csv
+          path: |
+            LICENSE-3rdparty.csv
+            instrumentation/LICENSE-3rdparty.csv
           overwrite: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -123,7 +123,7 @@ jobs:
 
   license-3rdparty:
     runs-on: ubuntu-latest
-    name: "Valid license CSV files"
+    name: "Valid LICENSE-3rdparty.csv files"
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -139,19 +139,32 @@ jobs:
             ~/.cargo/.crates2.json
           key: dd-rust-license-tool-1.0.6-v2
       - run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.6" || cargo install dd-rust-license-tool --version "1.0.6" --locked
-      - name: Generate license CSV files and check against committed copies
+      - name: Generate new license CSV files and check against the previous
         run: |
-          if ! ./scripts/update_license_3rdparty.sh . instrumentation; then
-            echo "ERROR: license CSV generation failed."
+          if ! dd-rust-license-tool dump > /tmp/CI.csv 2> /tmp/CI.error; then
+            echo "ERROR: dd-rust-license-tool dump failed! See error output below:"
+            cat /tmp/CI.error
             exit 1
           fi
-          if [ -n "$(git status --porcelain -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv)" ]; then
-            git diff -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv
-            git status --short -- LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv
-            echo "Differences detected in license CSV files."
-            echo "Please run './scripts/update_license_3rdparty.sh . instrumentation' to update the files and commit the changes."
+
+          if ! dd-rust-license-tool --manifest-path instrumentation/Cargo.toml dump > /tmp/CI-instrumentation.csv 2> /tmp/CI.error; then
+            echo "ERROR: dd-rust-license-tool dump failed for instrumentation! See error output below:"
+            cat /tmp/CI.error
             exit 1
           fi
+
+          if ! diff /tmp/CI.csv LICENSE-3rdparty.csv; then
+            echo "Differences detected in LICENSE-3rdparty.csv."
+            echo "Please run './scripts/update_license_3rdparty.sh' to update the file and commit the changes."
+            exit 1
+          fi
+
+          if ! diff /tmp/CI-instrumentation.csv instrumentation/LICENSE-3rdparty.csv; then
+            echo "Differences detected in instrumentation/LICENSE-3rdparty.csv."
+            echo "Please run './scripts/update_license_3rdparty.sh' to update the file and commit the changes."
+            exit 1
+          fi
+
           echo "No differences found."
       - name: Export generated license files on failure
         if: failure()
@@ -159,6 +172,6 @@ jobs:
         with:
           name: license-3rdparty-csv
           path: |
-            LICENSE-3rdparty.csv
-            instrumentation/LICENSE-3rdparty.csv
+            /tmp/CI.csv
+            /tmp/CI-instrumentation.csv
           overwrite: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ find . -name '*.sh' -print0 | xargs -0 shellcheck
 rumdl check .
 
 # Update licence files if dependencies changed
-./scripts/update_license_3rdparty.sh . instrumentation
+./scripts/update_license_3rdparty.sh
 ```
 
 ## Code Style
@@ -194,8 +194,7 @@ dependencies are properly documented.
 
 To update the license files:
 
-1. Run `./scripts/update_license_3rdparty.sh . instrumentation` (requires Docker or local tool
-   install)
+1. Run `./scripts/update_license_3rdparty.sh` (requires Docker or local tool install)
 2. Review the changes to `LICENSE-3rdparty.csv` and `instrumentation/LICENSE-3rdparty.csv`
 3. Commit the updated file(s)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ cargo test --workspace --doc --locked
 find . -name '*.sh' -print0 | xargs -0 shellcheck
 rumdl check .
 
-# Update licence file if dependencies changed
-./scripts/update_license_3rdparty.sh
+# Update licence files if dependencies changed
+./scripts/update_license_3rdparty.sh . instrumentation
 ```
 
 ## Code Style
@@ -188,19 +188,20 @@ If any code in the PR was contributed by an AI agent, apply the `ai generated` l
 
 ## Third-party Licenses
 
-When adding or updating dependencies, you must update the `LICENSE-3rdparty.csv` file to reflect
-these changes. This file is checked by our CI pipeline to ensure all dependencies are properly
-documented.
+When adding or updating dependencies, you must update the applicable `LICENSE-3rdparty.csv`
+file(s) to reflect these changes. These files are checked by our CI pipeline to ensure all
+dependencies are properly documented.
 
-To update the license file:
+To update the license files:
 
-1. Run `./scripts/update_license_3rdparty.sh` (requires Docker or local tool install)
-2. Review the changes to `LICENSE-3rdparty.csv`
-3. Commit the updated file
+1. Run `./scripts/update_license_3rdparty.sh . instrumentation` (requires Docker or local tool
+   install)
+2. Review the changes to `LICENSE-3rdparty.csv` and `instrumentation/LICENSE-3rdparty.csv`
+3. Commit the updated file(s)
 
-The script uses Docker to ensure the generated file matches our CI environment, avoiding
-platform-specific differences. Otherwise the GH action will generate a correct
-`LICENSE-3rdparty.csv` file artifact on failure, which you can download and add to your branch.
+The script uses the pinned local license tool when it is available, or can run through Docker when
+needed. Otherwise the GH action will generate correct license CSV file artifacts on failure, which
+you can download and add to your branch.
 
 ## Rust Code Review
 

--- a/instrumentation/LICENSE-3rdparty.csv
+++ b/instrumentation/LICENSE-3rdparty.csv
@@ -1,0 +1,286 @@
+Component,Origin,License,Copyright
+aho-corasick,https://github.com/BurntSushi/aho-corasick,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+allocator-api2,https://github.com/zakarumych/allocator-api2,MIT OR Apache-2.0,Zakarum <zaq.dev@icloud.com>
+android_system_properties,https://github.com/nical/android_system_properties,MIT OR Apache-2.0,Nicolas Silva <nical@fastmail.com>
+anes,https://github.com/zrzka/anes-rs,MIT OR Apache-2.0,Robert Vojta <rvojta@me.com>
+anstyle,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The anstyle Authors
+anyhow,https://github.com/dtolnay/anyhow,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+arc-swap,https://github.com/vorner/arc-swap,MIT OR Apache-2.0,Michal 'vorner' Vaner <vorner@vorner.cz>
+async-stream,https://github.com/tokio-rs/async-stream,MIT,Carl Lerche <me@carllerche.com>
+async-stream-impl,https://github.com/tokio-rs/async-stream,MIT,Carl Lerche <me@carllerche.com>
+async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
+base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
+bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
+block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+borrow-or-share,https://github.com/yescallop/borrow-or-share,MIT-0,Scallop Ye <yescallop@gmail.com>
+bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
+bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
+cadence,https://github.com/56quarters/cadence,Apache-2.0 OR MIT,Nick Pillitteri
+cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
+cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
+ciborium,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-io,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-ll,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+clap,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap Authors
+clap_builder,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_builder Authors
+clap_lex,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_lex Authors
+const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
+const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
+core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
+cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+criterion,https://github.com/bheisler/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
+criterion-plot,https://github.com/bheisler/criterion.rs,MIT OR Apache-2.0,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
+crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
+crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
+crossbeam-epoch,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-epoch Authors
+crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-utils Authors
+crunchy,https://github.com/AtheMathmo/crunchy,MIT,Eira Fransham <jackefransham@gmail.com>
+crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
+ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
+darling,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+darling_core,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+darling_macro,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
+digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
+displaydoc,https://github.com/yaahc/displaydoc,MIT OR Apache-2.0,Jane Lusby <jlusby@yaah.dev>
+dyn-clone,https://github.com/dtolnay/dyn-clone,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,The either Authors
+equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
+errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
+find-msvc-tools,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,The find-msvc-tools Authors
+fluent-uri,https://github.com/yescallop/fluent-uri-rs,MIT,Scallop Ye <yescallop@gmail.com>
+fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
+foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
+form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
+futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors
+futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
+futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors
+futures-executor,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-executor Authors
+futures-io,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-io Authors
+futures-macro,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-macro Authors
+futures-sink,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-sink Authors
+futures-task,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-task Authors
+futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-util Authors
+generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
+getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
+h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
+half,https://github.com/VoidStarKat/half-rs,MIT OR Apache-2.0,Kathryn Long <squeeself@gmail.com>
+hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,The hashbrown Authors
+heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
+hermit-abi,https://github.com/hermit-os/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
+hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
+http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
+http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
+http-body-util,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
+http-serde,https://gitlab.com/kornelski/http-serde,Apache-2.0 OR MIT,Kornel <kornel@geekhood.net>
+httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
+hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
+hyper-timeout,https://github.com/hjr3/hyper-timeout,MIT OR Apache-2.0,Herman J. Radtke III <herman@hermanradtke.com>
+hyper-util,https://github.com/hyperium/hyper-util,MIT,Sean McArthur <sean@seanmonstar.com>
+iana-time-zone,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,"Andrew Straw <strawman@astraw.com>, René Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>"
+iana-time-zone-haiku,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,René Kijewski <crates.io@k6i.de>
+icu_collections,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_locale_core,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_normalizer,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_normalizer_data,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_properties,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_properties_data,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+icu_provider,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
+idna,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
+idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
+indexmap,https://github.com/bluss/indexmap,Apache-2.0 OR MIT,The indexmap Authors
+indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
+ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
+is-terminal,https://github.com/sunfishcode/is-terminal,MIT,"softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
+itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
+itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
+konst,https://github.com/rodrimati1992/konst,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
+konst_macro_rules,https://github.com/rodrimati1992/konst,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
+lambda_runtime,https://github.com/awslabs/aws-lambda-rust-runtime,Apache-2.0,"David Calavera <dcalaver@amazon.com>, Harold Sun <sunhua@amazon.com>"
+lambda_runtime_api_client,https://github.com/awslabs/aws-lambda-rust-runtime,Apache-2.0,"David Calavera <dcalaver@amazon.com>, Harold Sun <sunhua@amazon.com>"
+lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
+libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-capabilities,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities,Apache-2.0,The libdd-capabilities Authors
+libdd-capabilities-impl,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl,Apache-2.0,The libdd-capabilities-impl Authors
+libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apache-2.0,The libdd-common Authors
+libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
+libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
+libdd-dogstatsd-client,https://github.com/DataDog/libdatadog/tree/main/libdd-dogstatsd-client,Apache-2.0,The libdd-dogstatsd-client Authors
+libdd-library-config,https://github.com/DataDog/libdatadog/tree/main/libdd-library-config,Apache-2.0,The libdd-library-config Authors
+libdd-remote-config,https://github.com/DataDog/libdatadog/tree/main/libdd-remote-config,Apache-2.0,Datadog Inc. <info@datadoghq.com>
+libdd-sampling,https://github.com/DataDog/libdatadog/tree/main/libdd-sampling,Apache-2.0,Datadog Inc. <info@datadoghq.com>
+libdd-shared-runtime,https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime,Apache-2.0,The libdd-shared-runtime Authors
+libdd-telemetry,https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry,Apache-2.0,The libdd-telemetry Authors
+libdd-tinybytes,https://github.com/DataDog/libdatadog/tree/main/libdd-tinybytes,Apache-2.0,The libdd-tinybytes Authors
+libdd-trace-normalization,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-normalization,Apache-2.0,David Lee <david.lee@datadoghq.com>
+libdd-trace-obfuscation,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-obfuscation,Apache-2.0,Datadog Inc. <info@datadoghq.com>
+libdd-trace-protobuf,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-protobuf,Apache-2.0,The libdd-trace-protobuf Authors
+libdd-trace-stats,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-stats,Apache-2.0,The libdd-trace-stats Authors
+libdd-trace-utils,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-utils,Apache-2.0,The libdd-trace-utils Authors
+linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
+litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
+lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
+manual_future,https://github.com/dmarcuse/manual_future,MIT,Dana Marcuse <dana@marcuse.us>
+matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
+memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+memfd,https://github.com/lucab/memfd-rs,MIT OR Apache-2.0,"Luca Bruno <lucab@lucabruno.net>, Simonas Kazlauskas <memfd@kazlauskas.me>"
+mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
+nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
+num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
+num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
+once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
+oorandom,https://hg.sr.ht/~icefox/oorandom,MIT,Simon Heath <icefox@dreamquest.io>
+opentelemetry,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry,Apache-2.0,The opentelemetry Authors
+opentelemetry-http,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http,Apache-2.0,The opentelemetry-http Authors
+opentelemetry-otlp,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp,Apache-2.0,The opentelemetry-otlp Authors
+opentelemetry-proto,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto,Apache-2.0,The opentelemetry-proto Authors
+opentelemetry-semantic-conventions,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions,Apache-2.0,The opentelemetry-semantic-conventions Authors
+opentelemetry_sdk,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk,Apache-2.0,The opentelemetry_sdk Authors
+percent-encoding,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
+pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project Authors
+pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project-internal Authors
+pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
+plotters,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-backend,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-svg,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
+potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
+ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
+proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
+prost,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-derive,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-types,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
+rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
+rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
+rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ref-cast-impl,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
+rmp,https://github.com/3Hren/msgpack-rust,MIT,"Evgeny Safronov <division494@gmail.com>, Kornel <kornel@geekhood.net>"
+rmp-serde,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
+rmpv,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
+rustc-hash,https://github.com/rust-lang/rustc-hash,Apache-2.0 OR MIT,The Rust Project Developers
+rustc_version,https://github.com/djc/rustc-version-rs,MIT OR Apache-2.0,The rustc_version Authors
+rustc_version_runtime,https://github.com/seppo0010/rustc-version-runtime-rs,MIT,Sebastian Waisbrot <seppo0010@gmail.com>
+rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
+rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
+same-file,https://github.com/BurntSushi/same-file,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+schemars,https://github.com/GREsau/schemars,MIT,Graham Esau <gesau@hotmail.co.uk>
+semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde-transcode,https://github.com/sfackler/serde-transcode,MIT OR Apache-2.0,Steven Fackler <sfackler@palantir.com>
+serde_bytes,https://github.com/serde-rs/bytes,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde_path_to_error,https://github.com/dtolnay/path-to-error,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+serde_with,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,"Jonas Bushart, Marcin Kaźmierczak"
+serde_with_macros,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,Jonas Bushart
+serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
+sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
+shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
+slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
+smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
+socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
+stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
+static_assertions,https://github.com/nvzqz/static-assertions-rs,MIT OR Apache-2.0,Nikolai Vazquez
+strsim,https://github.com/rapidfuzz/strsim-rs,MIT,"Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>"
+strum,https://github.com/Peternator7/strum,MIT,Peter Glotfelty <peter.glotfelty@microsoft.com>
+strum_macros,https://github.com/Peternator7/strum,MIT,Peter Glotfelty <peter.glotfelty@microsoft.com>
+syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <developer@actyx.io>
+synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
+sys-info,https://github.com/FillZpp/sys-info-rs,MIT,Siyu Wang <FillZpp.pub@gmail.com>
+thin-vec,https://github.com/mozilla/thin-vec,MIT OR Apache-2.0,Aria Beingessner <a.beingessner@gmail.com>
+thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+thiserror-impl,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+time,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
+time-core,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
+time-macros,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
+tinystr,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+tinytemplate,https://github.com/bheisler/TinyTemplate,Apache-2.0 OR MIT,Brook Heisler <brookheisler@gmail.com>
+tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tokio-macros,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tokio-util,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tonic,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
+tonic-prost,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
+tonic-types,https://github.com/hyperium/tonic,MIT,"Lucio Franco <luciofranco14@gmail.com>, Rafael Lemos <flemos.rafael.dev@gmail.com>"
+tower,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
+tower-http,https://github.com/tower-rs/tower-http,MIT,Tower Maintainers <team@tower-rs.com>
+tower-layer,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
+tower-service,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
+tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>"
+tracing-attributes,https://github.com/tokio-rs/tracing,MIT,"Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>"
+tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
+tracing-serde,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
+tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
+try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
+typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,The typenum Authors
+unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
+unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
+unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
+url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
+utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
+uuid,https://github.com/uuid-rs/uuid,Apache-2.0 OR MIT,"Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>"
+valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
+walkdir,https://github.com/BurntSushi/walkdir,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+want,https://github.com/seanmonstar/want,MIT,Sean McArthur <sean@seanmonstar.com>
+wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The Cranelift Project Developers
+wasip2,https://github.com/bytecodealliance/wasi-rs,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wasip2 Authors
+wasm-bindgen,https://github.com/wasm-bindgen/wasm-bindgen,MIT OR Apache-2.0,The wasm-bindgen Developers
+wasm-bindgen-futures,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures,MIT OR Apache-2.0,The wasm-bindgen Developers
+wasm-bindgen-macro,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro,MIT OR Apache-2.0,The wasm-bindgen Developers
+wasm-bindgen-macro-support,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support,MIT OR Apache-2.0,The wasm-bindgen Developers
+wasm-bindgen-shared,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared,MIT OR Apache-2.0,The wasm-bindgen Developers
+web-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
+winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+windows,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows-core,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-core Authors
+windows-implement,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-implement Authors
+windows-interface,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-interface Authors
+windows-link,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-link Authors
+windows-result,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-result Authors
+windows-strings,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-strings Authors
+windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-sys Authors
+windows-targets,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_aarch64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_aarch64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+winver,https://github.com/rhysd/winver,MIT,rhysd <lin90162@yahoo.co.jp>
+wit-bindgen,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
+writeable,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+yoke,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
+yoke-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
+zerocopy,https://github.com/google/zerocopy,BSD-2-Clause OR Apache-2.0 OR MIT,"Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>"
+zerocopy-derive,https://github.com/google/zerocopy,BSD-2-Clause OR Apache-2.0 OR MIT,"Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>"
+zerofrom,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+zerofrom-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
+zerotrie,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+zerovec,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+zerovec-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
+zmij,https://github.com/dtolnay/zmij,MIT,David Tolnay <dtolnay@gmail.com>

--- a/instrumentation/LICENSE-3rdparty.csv
+++ b/instrumentation/LICENSE-3rdparty.csv
@@ -252,6 +252,7 @@ wasm-bindgen-macro,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crat
 wasm-bindgen-macro-support,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support,MIT OR Apache-2.0,The wasm-bindgen Developers
 wasm-bindgen-shared,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared,MIT OR Apache-2.0,The wasm-bindgen Developers
 web-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
+web-time,https://github.com/daxpedda/web-time,MIT OR Apache-2.0,The web-time Authors
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 windows,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows-core,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-core Authors

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -14,5 +14,10 @@ WORKDIR /build
 
 COPY . .
 
-ENTRYPOINT ["dd-rust-license-tool"]
-CMD ["--manifest-path", "Cargo.toml", "dump"]
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    mkdir -p /licenses/instrumentation && \
+    dd-rust-license-tool dump > /licenses/LICENSE-3rdparty.csv && \
+    dd-rust-license-tool --manifest-path instrumentation/Cargo.toml dump > /licenses/instrumentation/LICENSE-3rdparty.csv
+
+ENTRYPOINT ["/bin/sh", "-ec", "test \"$#\" -eq 1; exec cat \"$1\"", "--"]

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -14,8 +14,5 @@ WORKDIR /build
 
 COPY . .
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    dd-rust-license-tool dump > /licenses.csv
-
-ENTRYPOINT ["cat", "/licenses.csv"]
+ENTRYPOINT ["dd-rust-license-tool"]
+CMD ["--manifest-path", "Cargo.toml", "dump"]

--- a/scripts/update_license_3rdparty.sh
+++ b/scripts/update_license_3rdparty.sh
@@ -12,17 +12,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
 usage() {
     cat <<EOF
-Usage: $0 WORKSPACE_PATH [WORKSPACE_PATH...]
+Usage: $0
 
-Generate third-party license CSV files.
-
-Each WORKSPACE_PATH must point to a Cargo workspace directory. The generated file is written next
-to that workspace's Cargo.toml as LICENSE-3rdparty.csv.
-
-Examples:
-  $0 .
-  $0 instrumentation
-  $0 . instrumentation
+Generate third-party license CSV files for the root and instrumentation Cargo workspaces.
 EOF
 }
 
@@ -33,56 +25,22 @@ case "${1:-}" in
         ;;
 esac
 
-if [ "$#" -eq 0 ]; then
-    echo "ERROR: at least one workspace path is required."
+if [ "$#" -ne 0 ]; then
+    echo "ERROR: this script does not accept arguments."
     echo ""
     usage
     exit 1
 fi
 
-WORKSPACE_PATHS=("$@")
-
-normalize_workspace_path() {
-    local workspace_path="$1"
-
-    workspace_path="${workspace_path#./}"
-    workspace_path="${workspace_path%/}"
-    if [ -z "${workspace_path}" ]; then
-        workspace_path="."
-    fi
-    echo "${workspace_path}"
-}
-
-run_tool() {
-    local workspace_path
-    local manifest
-    local output
-
-    workspace_path="$(normalize_workspace_path "$1")"
-    manifest="${workspace_path}/Cargo.toml"
-    output="${workspace_path}/LICENSE-3rdparty.csv"
-
-    if [ ! -f "${manifest}" ]; then
-        echo "ERROR: ${workspace_path} is not a Cargo workspace directory."
-        echo "Expected manifest at: ${manifest}"
-        exit 1
-    fi
-
-    echo "Generating ${output}..."
-    dd-rust-license-tool --manifest-path "${manifest}" dump > "${output}"
-}
-
 run_native() {
     cd "${ROOT_DIR}"
-    for workspace_path in "${WORKSPACE_PATHS[@]}"; do
-        run_tool "${workspace_path}"
-    done
+    echo "Generating LICENSE-3rdparty.csv..."
+    dd-rust-license-tool dump > "${GENERATED_DIR}/LICENSE-3rdparty.csv"
+    echo "Generating instrumentation/LICENSE-3rdparty.csv..."
+    dd-rust-license-tool --manifest-path instrumentation/Cargo.toml dump > "${GENERATED_DIR}/instrumentation/LICENSE-3rdparty.csv"
 }
 
 run_docker() {
-    local manifest
-    local output
-
     if ! command -v docker &> /dev/null || ! docker info &> /dev/null; then
         echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
         exit 1
@@ -94,42 +52,45 @@ run_docker() {
         -t dd-trace-rs-dd-license-tool \
         -f "${ROOT_DIR}/scripts/Dockerfile.license" \
         "${ROOT_DIR}"
-    for workspace_path in "${WORKSPACE_PATHS[@]}"; do
-        workspace_path="$(normalize_workspace_path "${workspace_path}")"
-        manifest="${workspace_path}/Cargo.toml"
-        output="${workspace_path}/LICENSE-3rdparty.csv"
+    echo "Reading generated LICENSE-3rdparty.csv..."
+    docker run --rm dd-trace-rs-dd-license-tool /licenses/LICENSE-3rdparty.csv > "${GENERATED_DIR}/LICENSE-3rdparty.csv"
+    echo "Reading generated instrumentation/LICENSE-3rdparty.csv..."
+    docker run --rm dd-trace-rs-dd-license-tool /licenses/instrumentation/LICENSE-3rdparty.csv > "${GENERATED_DIR}/instrumentation/LICENSE-3rdparty.csv"
+}
 
-        if [ ! -f "${ROOT_DIR}/${manifest}" ]; then
-            echo "ERROR: ${workspace_path} is not a Cargo workspace directory."
-            echo "Expected manifest at: ${manifest}"
-            exit 1
+promote_if_changed() {
+    local changed=0
+    local file
+
+    for file in LICENSE-3rdparty.csv instrumentation/LICENSE-3rdparty.csv; do
+        if ! cmp -s "${file}" "${GENERATED_DIR}/${file}"; then
+            echo ""
+            echo "Differences for ${file}:"
+            diff -u "${file}" "${GENERATED_DIR}/${file}" || true
+            cp "${GENERATED_DIR}/${file}" "${file}"
+            changed=1
         fi
-
-        echo "Generating ${output}..."
-        docker run --rm dd-trace-rs-dd-license-tool --manifest-path "${manifest}" dump > "${ROOT_DIR}/${output}"
     done
-}
 
-has_matching_license_tool() {
-    cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}:" \
-        || { command -v dd-rust-license-tool > /dev/null && [ "$(dd-rust-license-tool --version | awk '{print $2}')" = "${TOOL_VERSION}" ]; }
-}
-
-installed_license_tool_version() {
-    local version
-
-    version="$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)"
-    if [ -n "${version}" ]; then
-        echo "${version}"
-    elif command -v dd-rust-license-tool > /dev/null; then
-        dd-rust-license-tool --version | awk '{print $2}'
+    if [ "${changed}" -eq 0 ]; then
+        echo ""
+        echo "Generated license CSV files match committed copies."
+    else
+        echo ""
+        echo "Updated license CSV file(s)."
+        echo "Please review and commit the changes."
     fi
 }
 
-if has_matching_license_tool; then
+GENERATED_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dd-trace-rs-license.XXXXXX")"
+trap 'rm -rf "${GENERATED_DIR}"' EXIT
+mkdir -p "${GENERATED_DIR}/instrumentation"
+cd "${ROOT_DIR}"
+
+if cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
     run_native
 else
-    INSTALLED_VERSION="$(installed_license_tool_version)"
+    INSTALLED_VERSION="$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)"
 
     echo "dd-rust-license-tool v${TOOL_VERSION} is not installed."
     if [ -n "${INSTALLED_VERSION}" ]; then
@@ -173,6 +134,4 @@ else
     esac
 fi
 
-echo ""
-echo "Successfully generated license CSV file(s)."
-echo "Please review and commit the changes."
+promote_if_changed

--- a/scripts/update_license_3rdparty.sh
+++ b/scripts/update_license_3rdparty.sh
@@ -10,13 +10,79 @@ TOOL_VERSION="1.0.6"
 INSTALL_CMD="cargo install dd-rust-license-tool --version \"${TOOL_VERSION}\" --locked"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
+usage() {
+    cat <<EOF
+Usage: $0 WORKSPACE_PATH [WORKSPACE_PATH...]
+
+Generate third-party license CSV files.
+
+Each WORKSPACE_PATH must point to a Cargo workspace directory. The generated file is written next
+to that workspace's Cargo.toml as LICENSE-3rdparty.csv.
+
+Examples:
+  $0 .
+  $0 instrumentation
+  $0 . instrumentation
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+if [ "$#" -eq 0 ]; then
+    echo "ERROR: at least one workspace path is required."
+    echo ""
+    usage
+    exit 1
+fi
+
+WORKSPACE_PATHS=("$@")
+
+normalize_workspace_path() {
+    local workspace_path="$1"
+
+    workspace_path="${workspace_path#./}"
+    workspace_path="${workspace_path%/}"
+    if [ -z "${workspace_path}" ]; then
+        workspace_path="."
+    fi
+    echo "${workspace_path}"
+}
+
+run_tool() {
+    local workspace_path
+    local manifest
+    local output
+
+    workspace_path="$(normalize_workspace_path "$1")"
+    manifest="${workspace_path}/Cargo.toml"
+    output="${workspace_path}/LICENSE-3rdparty.csv"
+
+    if [ ! -f "${manifest}" ]; then
+        echo "ERROR: ${workspace_path} is not a Cargo workspace directory."
+        echo "Expected manifest at: ${manifest}"
+        exit 1
+    fi
+
+    echo "Generating ${output}..."
+    dd-rust-license-tool --manifest-path "${manifest}" dump > "${output}"
+}
+
 run_native() {
     cd "${ROOT_DIR}"
-    echo "Running dd-rust-license-tool dump..."
-    dd-rust-license-tool dump > LICENSE-3rdparty.csv
+    for workspace_path in "${WORKSPACE_PATHS[@]}"; do
+        run_tool "${workspace_path}"
+    done
 }
 
 run_docker() {
+    local manifest
+    local output
+
     if ! command -v docker &> /dev/null || ! docker info &> /dev/null; then
         echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
         exit 1
@@ -28,14 +94,42 @@ run_docker() {
         -t dd-trace-rs-dd-license-tool \
         -f "${ROOT_DIR}/scripts/Dockerfile.license" \
         "${ROOT_DIR}"
-    echo "Generating LICENSE-3rdparty.csv..."
-    docker run --rm dd-trace-rs-dd-license-tool > "${ROOT_DIR}/LICENSE-3rdparty.csv"
+    for workspace_path in "${WORKSPACE_PATHS[@]}"; do
+        workspace_path="$(normalize_workspace_path "${workspace_path}")"
+        manifest="${workspace_path}/Cargo.toml"
+        output="${workspace_path}/LICENSE-3rdparty.csv"
+
+        if [ ! -f "${ROOT_DIR}/${manifest}" ]; then
+            echo "ERROR: ${workspace_path} is not a Cargo workspace directory."
+            echo "Expected manifest at: ${manifest}"
+            exit 1
+        fi
+
+        echo "Generating ${output}..."
+        docker run --rm dd-trace-rs-dd-license-tool --manifest-path "${manifest}" dump > "${ROOT_DIR}/${output}"
+    done
 }
 
-if cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
+has_matching_license_tool() {
+    cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}:" \
+        || { command -v dd-rust-license-tool > /dev/null && [ "$(dd-rust-license-tool --version | awk '{print $2}')" = "${TOOL_VERSION}" ]; }
+}
+
+installed_license_tool_version() {
+    local version
+
+    version="$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)"
+    if [ -n "${version}" ]; then
+        echo "${version}"
+    elif command -v dd-rust-license-tool > /dev/null; then
+        dd-rust-license-tool --version | awk '{print $2}'
+    fi
+}
+
+if has_matching_license_tool; then
     run_native
 else
-    INSTALLED_VERSION=$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)
+    INSTALLED_VERSION="$(installed_license_tool_version)"
 
     echo "dd-rust-license-tool v${TOOL_VERSION} is not installed."
     if [ -n "${INSTALLED_VERSION}" ]; then
@@ -80,5 +174,5 @@ else
 fi
 
 echo ""
-echo "Successfully generated LICENSE-3rdparty.csv."
+echo "Successfully generated license CSV file(s)."
 echo "Please review and commit the changes."


### PR DESCRIPTION
## What does this PR do?

Updates third-party license CSV generation and validation to cover both the root Cargo workspace and the `instrumentation` workspace.

- Adds `instrumentation/LICENSE-3rdparty.csv`
- Updates the license CI job to generate and diff both CSV files from temporary outputs
- Keeps CI close to the previous flow by calling `dd-rust-license-tool` directly
- Updates `scripts/update_license_3rdparty.sh` to regenerate both workspace CSVs together
- Generates local script outputs in a temporary directory before copying them into tracked files
- Updates the license Docker image to generate both CSVs at build time with cache mounts
- Documents the simplified `./scripts/update_license_3rdparty.sh` workflow

## Motivation

The repository now has multiple Cargo workspaces with separate dependency graphs. CI previously validated only the root `LICENSE-3rdparty.csv`, so dependencies under `instrumentation` were not covered by the license CSV check.

## Additional Notes

No Rust runtime code is changed. The CI failure artifact now includes both generated license CSV files to make remediation easier.