### PR TITLE
fix(config): map OTel deployment environment

### DIFF
--- a/datadog-opentelemetry/src/core/configuration/configuration.rs
+++ b/datadog-opentelemetry/src/core/configuration/configuration.rs
@@ -1079,6 +1079,7 @@ pub struct Config {
     // # Service tagging
     service: ConfigItemWithOverride<ServiceName>,
     env: ConfigItem<Option<String>>,
+    otel_resource_environment: Option<String>,
     version: ConfigItem<Option<String>>,
 
     // # Agent
@@ -1296,6 +1297,31 @@ impl Config {
         }
 
         let cisu = ConfigItemSourceUpdater { sources };
+        let env = cisu.update_string(default.env, Some);
+        let mut parsed_otel_resource_attributes = sources
+            .get_parse::<OtelResourceAttributes>(SupportedConfigurations::OTEL_RESOURCE_ATTRIBUTES);
+        let mut otel_resource_environment = None;
+
+        if let Some(config_key) = parsed_otel_resource_attributes.value.as_mut() {
+            let OtelResourceAttributes(attributes) = &mut config_key.value;
+            otel_resource_environment = attributes
+                .iter()
+                .find(|(key, value)| key == "deployment.environment.name" && !value.is_empty())
+                .or_else(|| {
+                    attributes
+                        .iter()
+                        .find(|(key, value)| key == "deployment.environment" && !value.is_empty())
+                })
+                .map(|(_, value)| value.clone());
+            attributes.retain(|(key, _)| {
+                key != "deployment.environment.name" && key != "deployment.environment"
+            });
+        }
+        let otel_resource_attributes = cisu.apply_result(
+            default.otel_resource_attributes,
+            parsed_otel_resource_attributes,
+            |OtelResourceAttributes(attributes)| attributes,
+        );
 
         Self {
             runtime_id: default.runtime_id,
@@ -1307,15 +1333,13 @@ impl Config {
                 SupportedConfigurations::OTEL_SERVICE_NAME,
                 ServiceName::Configured,
             ),
-            env: cisu.update_string(default.env, Some),
+            env,
+            otel_resource_environment,
             version: cisu.update_string(default.version, Some),
             // TODO(paullgdc): tags should be merged, not replaced
             global_tags: cisu
                 .update_parsed_with_transform(default.global_tags, |DdKeyValueTags(tags)| tags),
-            otel_resource_attributes: cisu.update_parsed_with_transform(
-                default.otel_resource_attributes,
-                |OtelResourceAttributes(attrs)| attrs,
-            ),
+            otel_resource_attributes,
             otel_metrics_exporter: cisu.update_string(default.otel_metrics_exporter, Cow::Owned),
             otel_metrics_temporality_preference: cisu.update_string(
                 default.otel_metrics_temporality_preference,
@@ -1522,7 +1546,15 @@ impl Config {
 
     /// Returns the configured environment name (e.g., "production", "staging").
     pub fn env(&self) -> Option<&str> {
+        self.explicit_env().or(self.otel_resource_environment())
+    }
+
+    pub(crate) fn explicit_env(&self) -> Option<&str> {
         self.env.value().as_deref()
+    }
+
+    pub(crate) fn otel_resource_environment(&self) -> Option<&str> {
+        self.otel_resource_environment.as_deref()
     }
 
     /// Returns the configured application version.
@@ -2012,6 +2044,7 @@ impl std::fmt::Debug for Config {
             .field("language_version", &self.language_version)
             .field("service", &self.service)
             .field("env", &self.env)
+            .field("otel_resource_environment", &self.otel_resource_environment)
             .field("version", &self.version)
             .field("global_tags", &self.global_tags)
             .field("trace_agent_url", &self.trace_agent_url)
@@ -2058,6 +2091,7 @@ fn default_config() -> Config {
     Config {
         runtime_id: Config::process_runtime_id(),
         env: ConfigItem::new(SupportedConfigurations::DD_ENV, None),
+        otel_resource_environment: None,
         // TODO(paullgdc): Default service naming detection, probably from arg0
         service: ConfigItemWithOverride::new_calculated(
             SupportedConfigurations::DD_SERVICE,
@@ -2907,12 +2941,40 @@ impl ConfigBuilder {
 #[cfg(test)]
 mod tests {
     use libdd_telemetry::data::ConfigurationOrigin;
+    use opentelemetry::KeyValue;
+    use opentelemetry_sdk::Resource;
     use std::collections::HashMap;
 
     use super::Config;
     use super::*;
     use crate::core::configuration::sources::{CompositeSource, ConfigSourceOrigin, HashMapSource};
+    use crate::mappings::transform_tests::{test_cases, test_span_to_sdk_span};
+    use crate::mappings::{otel_span_to_dd_span, SpanStr};
     use crate::propagation::config::{get_extractors, get_injectors};
+
+    fn assert_resource_environment_on_span(config: Config, resource: Resource, expected_env: &str) {
+        let resource = crate::create_dd_resource(resource, &config);
+        let input_span = test_cases().remove(0).input_span;
+        let output = otel_span_to_dd_span(&test_span_to_sdk_span(&input_span), &resource);
+
+        assert_eq!(
+            output
+                .meta
+                .get(&SpanStr::from_str("env"))
+                .map(SpanStr::as_str),
+            Some(expected_env)
+        );
+        assert_eq!(
+            output
+                .meta
+                .get(&SpanStr::from_str("unrelated"))
+                .map(SpanStr::as_str),
+            Some("value")
+        );
+        for source_key in ["deployment.environment.name", "deployment.environment"] {
+            assert!(!output.meta.contains_key(&SpanStr::from_str(source_key)));
+        }
+    }
 
     #[test]
     fn test_config_from_source() {
@@ -3015,6 +3077,168 @@ mod tests {
         let config = Config::builder_with_sources(&sources).build();
         assert_eq!(&*config.service(), "unnamed-rust-service");
         assert!(config.service_is_default());
+    }
+
+    #[test]
+    fn test_otel_resource_deployment_environment_mapping() {
+        struct TestCase {
+            name: &'static str,
+            dd_env: Option<&'static str>,
+            resource_attributes: &'static str,
+            expected_env: &'static str,
+        }
+
+        for case in [
+            TestCase {
+                name: "stable only",
+                dd_env: None,
+                resource_attributes:
+                    "first=one,deployment.environment.name=stable,second=two",
+                expected_env: "stable",
+            },
+            TestCase {
+                name: "legacy only",
+                dd_env: None,
+                resource_attributes: "first=one,deployment.environment=legacy,second=two",
+                expected_env: "legacy",
+            },
+            TestCase {
+                name: "stable before legacy",
+                dd_env: None,
+                resource_attributes: "first=one,deployment.environment.name=stable,deployment.environment=legacy,second=two",
+                expected_env: "stable",
+            },
+            TestCase {
+                name: "legacy before stable",
+                dd_env: None,
+                resource_attributes: "first=one,deployment.environment=legacy,deployment.environment.name=stable,second=two",
+                expected_env: "stable",
+            },
+            TestCase {
+                name: "DD_ENV takes precedence",
+                dd_env: Some("datadog"),
+                resource_attributes: "first=one,deployment.environment=legacy,deployment.environment.name=stable,second=two",
+                expected_env: "datadog",
+            },
+        ] {
+            let mut values = vec![("OTEL_RESOURCE_ATTRIBUTES", case.resource_attributes)];
+            if let Some(dd_env) = case.dd_env {
+                values.push(("DD_ENV", dd_env));
+            }
+
+            let mut sources = CompositeSource::new();
+            sources.add_source(HashMapSource::from_iter(
+                values,
+                ConfigSourceOrigin::EnvVar,
+            ));
+            let config = Config::builder_with_sources(&sources).build();
+
+            assert_eq!(config.env(), Some(case.expected_env), "{} env", case.name);
+            assert_eq!(
+                config.otel_resource_attributes().collect::<Vec<_>>(),
+                vec![("first", "one"), ("second", "two")],
+                "{} resource attributes",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_dd_env_overrides_otel_resource_environment_on_span() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [("DD_ENV", "datadog")],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        let resource = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new("deployment.environment", "legacy"),
+                KeyValue::new("deployment.environment.name", "stable"),
+                KeyValue::new("unrelated", "value"),
+            ])
+            .build();
+        assert_resource_environment_on_span(config, resource, "datadog");
+    }
+
+    #[test]
+    fn test_resource_environment_overrides_otel_resource_attributes_on_span() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [(
+                "OTEL_RESOURCE_ATTRIBUTES",
+                "deployment.environment.name=fallback",
+            )],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        let resource = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new("deployment.environment", "provided"),
+                KeyValue::new("unrelated", "value"),
+            ])
+            .build();
+        assert_resource_environment_on_span(config, resource, "provided");
+    }
+
+    #[test]
+    fn test_datadog_tags_environment_overrides_otel_resource_attributes() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [
+                ("DD_TAGS", "env:datadog"),
+                (
+                    "OTEL_RESOURCE_ATTRIBUTES",
+                    "deployment.environment.name=fallback",
+                ),
+            ],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        let resource = crate::otlp_utils::build_otel_resource(&config, None);
+
+        assert_eq!(
+            resource.get(&opentelemetry::Key::from_static_str(
+                "deployment.environment.name"
+            )),
+            Some(opentelemetry::Value::from("datadog"))
+        );
+        assert_eq!(
+            resource.get(&opentelemetry::Key::from_static_str(
+                "deployment.environment"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resource_environment_overrides_otel_resource_attributes_for_otlp() {
+        let mut sources = CompositeSource::new();
+        sources.add_source(HashMapSource::from_iter(
+            [(
+                "OTEL_RESOURCE_ATTRIBUTES",
+                "deployment.environment.name=fallback",
+            )],
+            ConfigSourceOrigin::EnvVar,
+        ));
+        let config = Config::builder_with_sources(&sources).build();
+        let resource = Resource::builder_empty()
+            .with_attribute(KeyValue::new("deployment.environment", "provided"))
+            .build();
+        let resource = crate::otlp_utils::build_otel_resource(&config, Some(resource));
+
+        assert_eq!(
+            resource.get(&opentelemetry::Key::from_static_str(
+                "deployment.environment.name"
+            )),
+            Some(opentelemetry::Value::from("provided"))
+        );
+        assert_eq!(
+            resource.get(&opentelemetry::Key::from_static_str(
+                "deployment.environment"
+            )),
+            None
+        );
     }
 
     #[test]

--- a/datadog-opentelemetry/src/lib.rs
+++ b/datadog-opentelemetry/src/lib.rs
@@ -324,11 +324,34 @@ mod telemetry_metrics_exporter;
 mod text_map_propagator;
 mod trace_id;
 
-use std::sync::{Arc, RwLock};
+use std::{
+    borrow::Cow,
+    sync::{Arc, RwLock},
+};
 
 use opentelemetry::{Key, KeyValue, Value};
 use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
-use opentelemetry_semantic_conventions::resource::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+
+pub(crate) const DEPLOYMENT_ENVIRONMENT_NAME: &str =
+    opentelemetry_semantic_conventions::resource::DEPLOYMENT_ENVIRONMENT_NAME;
+pub(crate) const LEGACY_DEPLOYMENT_ENVIRONMENT: &str = "deployment.environment";
+
+pub(crate) fn is_environment_attribute(key: &str) -> bool {
+    key == DEPLOYMENT_ENVIRONMENT_NAME || key == LEGACY_DEPLOYMENT_ENVIRONMENT
+}
+
+pub(crate) fn resource_environment(resource: &Resource) -> Option<Cow<'_, str>> {
+    [DEPLOYMENT_ENVIRONMENT_NAME, LEGACY_DEPLOYMENT_ENVIRONMENT]
+        .into_iter()
+        .find_map(|key| {
+            resource
+                .iter()
+                .find(|(resource_key, _)| resource_key.as_str() == key)
+                .map(|(_, value)| value.as_str())
+                .filter(|value| !value.is_empty())
+        })
+}
 
 use crate::{
     core::configuration::{Config, RemoteConfigUpdate},
@@ -629,7 +652,21 @@ fn merge_resource<I: IntoIterator<Item = (Key, Value)>>(
     builder.build()
 }
 
-fn create_dd_resource(resource: Resource, cfg: &Config) -> Resource {
+fn without_environment_attributes(resource: &Resource) -> Resource {
+    let attributes = resource
+        .iter()
+        .filter(|(key, _)| !is_environment_attribute(key.as_str()))
+        .map(|(key, value)| KeyValue::new(key.clone(), value.clone()));
+    let mut builder = Resource::builder_empty();
+    if let Some(schema_url) = resource.schema_url() {
+        builder = builder.with_schema_url(attributes, schema_url.to_string());
+    } else {
+        builder = builder.with_attributes(attributes);
+    }
+    builder.build()
+}
+
+fn create_dd_resource(mut resource: Resource, cfg: &Config) -> Resource {
     let otel_service_name: Option<Value> = resource.get(&Key::from_static_str(SERVICE_NAME));
 
     // Collect attributes to add
@@ -662,11 +699,14 @@ fn create_dd_resource(resource: Resource, cfg: &Config) -> Resource {
         ));
     }
 
-    // Handle environment - add it if configured and not already present
-    if let Some(env) = cfg.env() {
-        let otel_env: Option<Value> =
-            resource.get(&Key::from_static_str(DEPLOYMENT_ENVIRONMENT_NAME));
-        if otel_env.is_none() {
+    if let Some(env) = cfg.explicit_env() {
+        resource = without_environment_attributes(&resource);
+        attributes.push((
+            Key::from_static_str(DEPLOYMENT_ENVIRONMENT_NAME),
+            Value::from(env.to_string()),
+        ));
+    } else if resource_environment(&resource).is_none() {
+        if let Some(env) = cfg.otel_resource_environment() {
             attributes.push((
                 Key::from_static_str(DEPLOYMENT_ENVIRONMENT_NAME),
                 Value::from(env.to_string()),

--- a/datadog-opentelemetry/src/mappings/transform/mod.rs
+++ b/datadog-opentelemetry/src/mappings/transform/mod.rs
@@ -572,6 +572,11 @@ pub fn otel_span_to_dd_span<'a>(
     }
 
     for (key, value) in otel_resource.iter() {
+        if key.as_str() == DEPLOYMENT_ENVIRONMENT_NAME.key()
+            || key.as_str() == DEPLOYMENT_ENVIRONMENT.key()
+        {
+            continue;
+        }
         set_meta_otlp_with_semconv_mappings(key.as_str(), value, &mut dd_span);
     }
 

--- a/datadog-opentelemetry/src/mappings/transform/transform_tests.rs
+++ b/datadog-opentelemetry/src/mappings/transform/transform_tests.rs
@@ -769,6 +769,72 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_otel_span_to_dd_span_consumes_environment_resource_attributes() {
+        for (name, resource_attributes, expected_env) in [
+            (
+                "stable only",
+                vec![("deployment.environment.name", "stable")],
+                "stable",
+            ),
+            (
+                "legacy only",
+                vec![("deployment.environment", "legacy")],
+                "legacy",
+            ),
+            (
+                "stable before legacy",
+                vec![
+                    ("deployment.environment.name", "stable"),
+                    ("deployment.environment", "legacy"),
+                ],
+                "stable",
+            ),
+            (
+                "legacy before stable",
+                vec![
+                    ("deployment.environment", "legacy"),
+                    ("deployment.environment.name", "stable"),
+                ],
+                "stable",
+            ),
+        ] {
+            let resource = Resource::builder_empty()
+                .with_attributes(
+                    resource_attributes
+                        .into_iter()
+                        .chain([("unrelated", "value")])
+                        .map(|(key, value)| KeyValue::new(key, value)),
+                )
+                .build();
+            let input_span = test_cases().remove(0).input_span;
+            let output = otel_span_to_dd_span(&test_span_to_sdk_span(&input_span), &resource);
+
+            assert_eq!(
+                output
+                    .meta
+                    .get(&CowStr::from_str("env"))
+                    .map(CowStr::as_str),
+                Some(expected_env),
+                "{name} environment"
+            );
+            assert_eq!(
+                output
+                    .meta
+                    .get(&CowStr::from_str("unrelated"))
+                    .map(CowStr::as_str),
+                Some("value"),
+                "{name} unrelated resource attribute"
+            );
+            for source_key in ["deployment.environment.name", "deployment.environment"] {
+                assert!(
+                    !output.meta.contains_key(&CowStr::from_str(source_key)),
+                    "{name} retained {source_key}"
+                );
+            }
+        }
+    }
+
     #[track_caller]
     fn hashmap_diff<'a, V: PartialEq + Debug>(
         output: &VecMap<CowStr<'a>, V>,

--- a/datadog-opentelemetry/src/otlp_utils.rs
+++ b/datadog-opentelemetry/src/otlp_utils.rs
@@ -8,6 +8,13 @@
     feature = "logs-http"
 ))]
 use opentelemetry_sdk::Resource;
+#[cfg(any(
+    feature = "metrics-grpc",
+    feature = "metrics-http",
+    feature = "logs-grpc",
+    feature = "logs-http"
+))]
+use std::borrow::Cow;
 
 #[cfg(any(
     feature = "metrics-grpc",
@@ -15,7 +22,10 @@ use opentelemetry_sdk::Resource;
     feature = "logs-grpc",
     feature = "logs-http"
 ))]
-use crate::{configuration::OtlpProtocol, core::configuration::Config};
+use crate::{
+    configuration::OtlpProtocol, core::configuration::Config, is_environment_attribute,
+    resource_environment, DEPLOYMENT_ENVIRONMENT_NAME,
+};
 
 #[cfg(any(
     feature = "metrics-grpc",
@@ -47,6 +57,16 @@ pub(crate) const DEFAULT_OTLP_HTTP_PORT: u16 = 4318;
 ))]
 pub(crate) fn build_otel_resource(config: &Config, resource: Option<Resource>) -> Resource {
     let mut resource_attrs: Vec<opentelemetry::KeyValue> = Vec::new();
+    let environment = config
+        .explicit_env()
+        .map(Cow::Borrowed)
+        .or_else(|| resource.as_ref().and_then(resource_environment))
+        .or_else(|| {
+            config
+                .global_tags()
+                .find_map(|(key, value)| (key == "env").then(|| Cow::Owned(value.to_string())))
+        })
+        .or_else(|| config.otel_resource_environment().map(Cow::Borrowed));
 
     for (key, value) in config.otel_resource_attributes() {
         resource_attrs.push(opentelemetry::KeyValue::new(
@@ -58,7 +78,7 @@ pub(crate) fn build_otel_resource(config: &Config, resource: Option<Resource>) -
     for (key, value) in config.global_tags() {
         let otel_key = match key {
             "service" => "service.name",
-            "env" => "deployment.environment",
+            "env" => DEPLOYMENT_ENVIRONMENT_NAME,
             "version" => "service.version",
             _ => key,
         };
@@ -70,7 +90,7 @@ pub(crate) fn build_otel_resource(config: &Config, resource: Option<Resource>) -
         ));
     }
 
-    if let Some(resource) = resource {
+    if let Some(resource) = resource.as_ref() {
         for (k, v) in resource.iter() {
             resource_attrs.push(opentelemetry::KeyValue::new(k.clone(), v.clone()));
         }
@@ -92,11 +112,11 @@ pub(crate) fn build_otel_resource(config: &Config, resource: Option<Resource>) -
         ));
     }
 
-    if let Some(env) = config.env() {
-        resource_attrs.retain(|kv| kv.key.as_str() != "deployment.environment");
+    resource_attrs.retain(|kv| !is_environment_attribute(kv.key.as_str()));
+    if let Some(env) = environment {
         resource_attrs.push(opentelemetry::KeyValue::new(
-            "deployment.environment",
-            env.to_string(),
+            DEPLOYMENT_ENVIRONMENT_NAME,
+            env.into_owned(),
         ));
     }
 
@@ -218,4 +238,47 @@ pub(crate) fn get_otlp_logs_timeout(config: &Config) -> u32 {
         return timeout;
     }
     config.otlp_timeout()
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "metrics-grpc",
+        feature = "metrics-http",
+        feature = "logs-grpc",
+        feature = "logs-http"
+    )
+))]
+mod tests {
+    use opentelemetry::{Key, KeyValue, Value};
+
+    use super::*;
+    use crate::LEGACY_DEPLOYMENT_ENVIRONMENT;
+
+    #[test]
+    fn configured_environment_replaces_resource_aliases() {
+        let config = Config::builder().set_env("datadog".to_string()).build();
+        let resource = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "stable"),
+                KeyValue::new(LEGACY_DEPLOYMENT_ENVIRONMENT, "legacy"),
+                KeyValue::new("unrelated", "value"),
+            ])
+            .build();
+
+        let resource = build_otel_resource(&config, Some(resource));
+
+        assert_eq!(
+            resource.get(&Key::from_static_str(DEPLOYMENT_ENVIRONMENT_NAME)),
+            Some(Value::from("datadog"))
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str(LEGACY_DEPLOYMENT_ENVIRONMENT)),
+            None
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str("unrelated")),
+            Some(Value::from("value"))
+        );
+    }
 }


### PR DESCRIPTION
# What does this PR do?

Maps `deployment.environment.name` to the Datadog environment, with `deployment.environment` as a fallback and an explicit `DD_ENV` override. The mapping applies to tracer configuration, emitted spans, and OpenTelemetry metrics and logs resources.

# Motivation

OpenTelemetry stabilized the deployment environment semantic convention under `deployment.environment.name`.

Related PRs:

- DataDog/system-tests#7613
- DataDog/dd-trace-go#5285
- DataDog/dd-trace-dotnet#9150
- DataDog/dd-trace-rb#6261
- DataDog/dd-trace-php#4148
- DataDog/dd-trace-js#10050
- DataDog/dd-trace-rs#300
- DataDog/dd-trace-java#12324
- DataDog/dd-trace-py#19901

# Additional Notes

The OTel value remains a fallback instead of being promoted to explicit Datadog configuration, so caller-provided resources and `DD_TAGS` keep their existing priority. Both aliases are consumed after mapping, while unrelated attributes remain. The full non-integration suite, doc tests, formatting, and all feature combinations in Clippy pass. The system-test config assertion remains excluded because the Rust test app does not implement `/trace/config`; the emitted-span assertion runs normally.